### PR TITLE
Add GitHub Actions Maven CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up JDK 1.11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.11
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
Add continuous integration via GitHub's integrated actions.

It's currently configured using JDK 11. I believe we can add a matrix with other Java versions too.

We would have to pay for Travis CI because gtfs-validator is a private repo, so we'll see if this works as a free version :slightly_smiling_face:.