### PR TITLE
Add CI badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gtfs-validator
+# gtfs-validator [![Java CI](https://github.com/MobilityData/gtfs-validator/workflows/Java%20CI/badge.svg)](https://github.com/MobilityData/gtfs-validator/actions?query=workflow%3A%22Java+CI%22)
 
 A GTFS static feed validator
 


### PR DESCRIPTION
**Summary:**

Allows you to easily see the latest build status of the master branch of the project (and others), and links to the CI results

**Expected behavior:** 

When going to the README, I should be able to see a badge for the CI that shows current status and links to the CI results:

![image](https://user-images.githubusercontent.com/928045/76430657-f119f880-6386-11ea-9af3-2c29538ea831.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)