### PR TITLE
Add Slack badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gtfs-validator [![Java CI](https://github.com/MobilityData/gtfs-validator/workflows/Java%20CI/badge.svg)](https://github.com/MobilityData/gtfs-validator/actions?query=workflow%3A%22Java+CI%22)
+# gtfs-validator [![Java CI](https://github.com/MobilityData/gtfs-validator/workflows/Java%20CI/badge.svg)](https://github.com/MobilityData/gtfs-validator/actions?query=workflow%3A%22Java+CI%22) [![Join the gtfs-validator chat](https://mobilitydata-io.herokuapp.com/badge.svg)](https://mobilitydata-io.herokuapp.com/)
 
 A GTFS static feed validator
 


### PR DESCRIPTION
**Summary:**

This PR adds a badge to the README that points to the MobilityData Slack.

![image](https://user-images.githubusercontent.com/928045/76999166-99eac980-692c-11ea-89bc-476d25433c1d.png)

We have a similar badge on the GTFS-RT Validator:
https://github.com/CUTR-at-USF/gtfs-realtime-validator

**Expected behavior:** 

Make it easier for developers to find the MobilityData Slack group