### PR TITLE
Implement #80 - Separate CSV from GTFS validation

### DIFF
--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -116,28 +116,8 @@ public class Main {
             logger.info("Unzipping archive");
             config.unzipInputArchive(zipInputPath, config.cleanOrCreatePath(zipExtractTargetPath).execute()).execute();
 
-            List<String> filenameList = config.validateAllRequiredFilePresence().execute();
-
-            filenameList.addAll(config.validateAllOptionalFileName().execute());
-
-            // FIXME: removing files with unsupported field types
-            filenameList.remove("calendar.txt");
-            filenameList.remove("calendar_dates.txt");
-            filenameList.remove("stop_times.txt");
-            filenameList.remove("frequencies.txt");
-
-            // base validation
-            filenameList.forEach(filename -> {
-                logger.info("Validating: " + filename);
-
-                config.validateHeadersForFile(filename).execute();
-                config.validateAllRowLengthForFile(filename).execute();
-
-                ParseSingleRowForFile parseSingleRowForFile = config.parseSingleRowForFile(filename);
-                while (parseSingleRowForFile.hasNext()) {
-                    config.validateGtfsTypes().execute(parseSingleRowForFile.execute());
-                }
-            });
+            executeCsvValidation(logger, config);
+//            todo: executeGtfsValidation(parameterListToBeDefined);
 
             logger.info("validation repo content:" + config.getValidationResult());
 
@@ -152,6 +132,31 @@ public class Main {
         }
 
         logger.info("Took " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");
+    }
+
+    private static void executeCsvValidation(Logger logger, DefaultConfig config) {
+        List<String> filenameList = config.validateAllRequiredFilePresence().execute();
+
+        filenameList.addAll(config.validateAllOptionalFileName().execute());
+
+        // FIXME: removing files with unsupported field types
+        filenameList.remove("calendar.txt");
+        filenameList.remove("calendar_dates.txt");
+        filenameList.remove("stop_times.txt");
+        filenameList.remove("frequencies.txt");
+
+        // base validation
+        filenameList.forEach(filename -> {
+            logger.info("Validating: " + filename);
+
+            config.validateHeadersForFile(filename).execute();
+            config.validateAllRowLengthForFile(filename).execute();
+
+            ParseSingleRowForFile parseSingleRowForFile = config.parseSingleRowForFile(filename);
+            while (parseSingleRowForFile.hasNext()) {
+                config.validateGtfsTypes().execute(parseSingleRowForFile.execute());
+            }
+        });
     }
 
     //TODO: make a use case out of this

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -27,6 +27,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
@@ -48,6 +50,7 @@ public class Main {
         options.addOption("o", "output", true, "Relative path where to place output" +
                 " files");
         options.addOption("h", "help", false, "Print this message");
+        options.addOption("e", "exclude", true, "exclude files in GTFS validation");
 
         //TODO: add configurable warning threshold for GTFS time type validation - when we support time type again
 
@@ -58,6 +61,8 @@ public class Main {
             final DefaultConfig config = new DefaultConfig();
 
             final CommandLine cmd = parser.parse(options, args);
+
+            final List<String> filenameListToExclude = new ArrayList<>();
 
             if (args.length == 0) {
                 printHelp(options);
@@ -113,11 +118,16 @@ public class Main {
                 config.downloadArchiveFromNetwork(cmd.getOptionValue("u"), zipInputPath).execute();
             }
 
+            if (cmd.hasOption("e")) {
+                filenameListToExclude.addAll(Arrays.asList(cmd.getOptionValues("e")));
+                logger.info("Excluding files: " + filenameListToExclude + " from GTFS validation");
+            }
+
             logger.info("Unzipping archive");
             config.unzipInputArchive(zipInputPath, config.cleanOrCreatePath(zipExtractTargetPath).execute()).execute();
 
             executeCsvValidation(logger, config);
-//            todo: executeGtfsValidation(parameterListToBeDefined);
+            executeGtfsValidation(logger, config, filenameListToExclude);
 
             logger.info("validation repo content:" + config.getValidationResult());
 
@@ -134,7 +144,13 @@ public class Main {
         logger.info("Took " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");
     }
 
-    private static void executeCsvValidation(Logger logger, DefaultConfig config) {
+    private static void executeGtfsValidation(final Logger logger,
+                                              final DefaultConfig config,
+                                              final List<String> filenameListToExclude) {
+        // todo: implement with relevant usecases
+    }
+
+    private static void executeCsvValidation(final Logger logger, final DefaultConfig config) {
         List<String> filenameList = config.validateAllRequiredFilePresence().execute();
 
         filenameList.addAll(config.validateAllOptionalFileName().execute());


### PR DESCRIPTION
**Summary:**

This PR comes provides implementation of tests to separate CSV from GTFS validation with command line options.


**Expected behavior:** 

CSV and GTFS validation should be separate, with the possibility to specify which files to exclude from the command line. Files excluded from the CSV validation should also be excluded from the GTFS validation process.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)