### PR TITLE
Fix #103 - Bump Gradle to 6.3

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Thu Nov 21 11:46:52 EST 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists


### PR DESCRIPTION
**Summary:**
Enables the project to build on JDK 14

**Expected behavior:** 

Previously (as discussed in #103), on JDK 14 building the project fails. This PR enables the project to build using JDK 14.

![image](https://user-images.githubusercontent.com/928045/78398356-f43c8900-75c0-11ea-83f5-daa5ee2bea77.png)

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)