### PR TITLE
Add space in help text

### DIFF
--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -42,7 +42,7 @@ public class Main {
         options.addOption("u", "url", true, "URL to GTFS zipped archive");
         options.addOption("z", "zip", true, "if --url is used, where to place the " +
                 "downloaded archive." +
-                "Otherwise, relative path pointing to a valid GTFS zipped archive on disk");
+                " Otherwise, relative path pointing to a valid GTFS zipped archive on disk");
         options.addOption("i", "input", true, "Relative path where to extract the zip" +
                 " content");
         options.addOption("o", "output", true, "Relative path where to place output" +


### PR DESCRIPTION
**Summary:**

Currently the help text looks like:

> -z,--zip <arg>      if --url is used, where to place the downloaded
                     archive.Otherwise, relative path pointing to a valid
                     GTFS zipped archive on disk

There should be a space after the `.` and before `Otherwise`

**Expected behavior:** 

After this change, a space is added:

> -z,--zip <arg>      if --url is used, where to place the downloaded
                     archive. Otherwise, relative path pointing to a valid
                     GTFS zipped archive on disk


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)

![image](https://user-images.githubusercontent.com/928045/78402298-51880880-75c8-11ea-9dc8-3401a67783c1.png)
