### PR TITLE
Fix #106 - Fix javadocs so they compile

### DIFF
--- a/adapter/parser/src/main/java/org/mobilitydata/gtfsvalidator/parser/GtfsEntityParser.java
+++ b/adapter/parser/src/main/java/org/mobilitydata/gtfsvalidator/parser/GtfsEntityParser.java
@@ -135,7 +135,7 @@ public class GtfsEntityParser implements GtfsSpecRepository.RawEntityParser {
     /**
      * Returns a parsed entity where fields' type have been determined. The {@link ParsedEntity} is formatted as follows:
      * - the entityId is the header name
-     * - the contentByHeaderMap is a Map<String, Object> matching columns' header names with the type validated values
+     * - the contentByHeaderMap is a Map(String, Object) matching columns' header names with the type validated values
      * associated to the {@link RawEntity} to parse
      * - the {@link RawFileInfo} associated to the file being processed
      *

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsSpecRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsSpecRepository.java
@@ -50,7 +50,7 @@ public class InMemoryGtfsSpecRepository implements GtfsSpecRepository {
 
     /**
      * @param specResourceName the path to the GTFS schema resource
-     * @throws IOException in case {@param specResourceName} was not find
+     * @throws IOException in case {@code specResourceName} was not find
      */
     public InMemoryGtfsSpecRepository(final String specResourceName) throws IOException {
         //noinspection UnstableApiUsage
@@ -109,7 +109,7 @@ public class InMemoryGtfsSpecRepository implements GtfsSpecRepository {
      * Returns the list of the headers marked as optional for a given GTFS CSV file
      *
      * @param fileInfo information about the file to process: location and expected content
-     * @return the list of the headers marked as optional for file associated to {@param fileInfo}
+     * @return the list of the headers marked as optional for file associated to {@code fileInfo}
      */
     @Override
     public List<String> getOptionalHeadersForFile(RawFileInfo fileInfo) {
@@ -142,7 +142,7 @@ public class InMemoryGtfsSpecRepository implements GtfsSpecRepository {
      * Returns the parser for raw data associated to a given GTFS CSV file
      *
      * @param file information about the file to process: location and expected content
-     * @return the parser for raw data associated to the file associated to {@param file}
+     * @return the parser for raw data associated to the file associated to {@code file}
      */
     @Override
     public RawEntityParser getParserForFile(RawFileInfo file) {
@@ -161,7 +161,7 @@ public class InMemoryGtfsSpecRepository implements GtfsSpecRepository {
      * Returns the type validator associated to a given GTFS CSV file
      *
      * @param file information about the file to process: location and expected content
-     * @return the type validator associated to file associated to {@param file}
+     * @return the type validator associated to file associated to {@code file}
      */
     @Override
     public ParsedEntityTypeValidator getValidatorForFile(RawFileInfo file) {

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/ParsedEntity.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/ParsedEntity.java
@@ -54,6 +54,7 @@ public class ParsedEntity {
     /**
      * Returns the value contained in a parsed row for a given header (column)
      *
+     * @param header a GTFS file column header
      * @return the value contained in a parsed row for a given header (column)
      */
     public Object get(final String header) {

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/RawEntity.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/RawEntity.java
@@ -45,6 +45,7 @@ public class RawEntity {
     /**
      * Returns the value contained in a row for a given header (column)
      *
+     * @param header a GTFS file column header
      * @return the value contained in a row for a given header (column)
      */
     public String get(final String header) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRequiredFilePresence.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRequiredFilePresence.java
@@ -50,6 +50,7 @@ public class ValidateAllRequiredFilePresence {
      * Use case execution method: checks the presence of all required files in a {@link RawFileRepository} instance
      * A new notice is generated each time a file marked as "required" is missing from a {@link RawFileRepository}
      * instance. This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
+     * @return a list of notices generated each time a file marked as "required" is missing from a {@link RawFileRepository} instance.
      */
     public List<String> execute() {
         if (!rawFileRepo.getFilenameAll().containsAll(specRepo.getRequiredFilenameList())) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRowLengthForFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRowLengthForFile.java
@@ -51,7 +51,7 @@ public class ValidateAllRowLengthForFile {
      * Use case execution method: validates the length of all rows of the file linked to the {@link RawFileInfo}.
      * For each row of a GTFS CSV file, a {@link RawEntity} is created with a 1 based index identifying the row location
      * within a GTFS CSV file and its content as a map of strings.
-     * If the process to retrieve data from a file fail, a {@link CannotConstructDataProviderNotice is generated
+     * If the process to retrieve data from a file fail, a {@link CannotConstructDataProviderNotice} is generated
      * and added to the {@link ValidationResultRepository} provided in the constructor.
      */
     public void execute() {


### PR DESCRIPTION
**Summary:**

This change re-formats a few Javadocs so they compile using `./gradlew javadoc`. Fixes #106.

**Expected behavior:** 

`./gradlew javadoc` now successfully completes:

![image](https://user-images.githubusercontent.com/928045/78405588-ccecb880-75ce-11ea-9e91-8a859976adbc.png)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)