### PR TITLE
feat(Release): Enable command-line releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,7 +5,7 @@ We create releases from the command-line using the [shadow Gradle plugin](https:
 Usage:
 
 ```
-/.gradlew shadowJar
+./gradlew shadowJar
 ```
 
 ...which will output a file to `\cli-app\build\libs` such as `gtfs-validator-1.1.0-SNAPSHOT-all.jar`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,6 @@
 # Release instructions
 
-We create releases from the command-line using the [shadow Gradle plugin](https://github.com/johnrengelman/shadow), which creates a JAR file with all necessary dependencies.
+We create releases from the command-line using the [shadow Gradle plugin](https://github.com/johnrengelman/shadow), which creates a JAR file including all necessary dependencies.
 
 ### 1. Prepare for release
 Change `version` in the various `build.gradle` files to remove the `-SNAPSHOT` qualifier. 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,19 +1,34 @@
 # Release instructions
 
-We create releases from the command-line using the [shadow Gradle plugin](https://github.com/johnrengelman/shadow).
+We create releases from the command-line using the [shadow Gradle plugin](https://github.com/johnrengelman/shadow), which creates a JAR file with all necessary dependencies.
 
-Usage:
+### 1. Prepare for release
+Change `version` in the various `build.gradle` files to remove the `-SNAPSHOT` qualifier. 
+
+For example, if the current version is `1.1.0-SNAPSHOT`, change the `version` to `1.1.0`. 
+
+### 2. Do the release
 
 ```
 ./gradlew shadowJar
 ```
 
-...which will output a file to `\cli-app\build\libs` such as `gtfs-validator-1.1.0-SNAPSHOT-all.jar`.
+The command line output will tell you where the compiled JAR file is located - for example:
+
+>Successfully built the gtfs-validator command-line app: C:\git-projects\gtfs-validator\application\cli-app\build\libs\gtfs-validator-v1.1.0.jar
 
 This file can then be run from the command-line with the normal Java conventions:
 
 ```
-java -jar gtfs-validator-1.1.0-SNAPSHOT-all.jar -u https://transitfeeds.com/p/mbta/64/latest/download -z input.zip -i input -o output
+java -jar gtfs-validator-v1.1.0.jar -u https://transitfeeds.com/p/mbta/64/latest/download -z input.zip -i input -o output
 ```
+
+### 3. Prepare for the next development cycle
+
+Increment the `version` in the various `build.gradle` files and add the `-SNAPSHOT` qualifier. 
+
+For example, if the version you just released is `1.1.0`, change the `version` to `1.1.1-SNAPSHOT`.
+
+For more details on versioning, see [Understanding Maven Version Numbers](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8855).
 
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,19 @@
 # Release instructions
 
-To create a release jar file, we use the IntelliJ artifact build feature
+We create releases from the command-line using the [shadow Gradle plugin](https://github.com/johnrengelman/shadow).
 
-- Go to File->Project Structure
-- Select Artifacts in the left pane
-- Add a new one by clicking the '+' button
-  - of type JAR->From modules with dependencies
-- Select the Main class from cli-app module
-- Place the META-INF file at the project's root
-- In the output Layout, add both cli-app and in-memory-simple modules main resource directory content
+Usage:
 
-- Build the jar through Build->Build Artifacts
+```
+/.gradlew shadowJar
+```
+
+...which will output a file to `\cli-app\build\libs` such as `gtfs-validator-1.1.0-SNAPSHOT-all.jar`.
+
+This file can then be run from the command-line with the normal Java conventions:
+
+```
+java -jar gtfs-validator-1.1.0-SNAPSHOT-all.jar -u https://transitfeeds.com/p/mbta/64/latest/download -z input.zip -i input -o output
+```
+
 

--- a/adapter/exporter/build.gradle
+++ b/adapter/exporter/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     implementation 'com.google.protobuf:protobuf-java:3.8.0'
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.10.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.10.3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.5.2'

--- a/adapter/repository/in-memory-simple/build.gradle
+++ b/adapter/repository/in-memory-simple/build.gradle
@@ -43,9 +43,9 @@ dependencies {
 
     implementation 'commons-validator:commons-validator:1.6'
 
-    implementation 'com.fasterxml.jackson.core:jackson-core:2.10.1'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.1'
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.10.1'
+    implementation 'com.fasterxml.jackson.core:jackson-core:2.10.3'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.3'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-csv:2.10.3'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.5.2'
     testImplementation 'org.hamcrest:hamcrest:2.2'

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -37,6 +37,7 @@ jar {
 shadowJar {
     minimize {
         exclude(dependency('org.apache.logging.log4j:log4j-core'))
+        exclude(dependency('com.fasterxml.jackson.core:jackson-databind'))
     }
     // Change the JAR name from cli-app to gtfs-validator
     archiveBaseName = rootProject.name

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -33,6 +33,9 @@ jar {
 }
 
 shadowJar {
+    minimize {
+        exclude(dependency('org.apache.logging.log4j:log4j-core'))
+    }
     // Change the JAR name from cli-app to gtfs-validator
     baseName = rootProject.name
 }

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -39,7 +39,7 @@ shadowJar {
         exclude(dependency('org.apache.logging.log4j:log4j-core'))
     }
     // Change the JAR name from cli-app to gtfs-validator
-    baseName = rootProject.name
+    archiveBaseName = rootProject.name
     // Remove "-all" from the end of the JAR file name
     archiveClassifier = null
 }

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -15,11 +15,27 @@
  */
 
 plugins {
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
     id 'java'
 }
 
 group 'org.mobilitydata'
 version '1.1.0-SNAPSHOT'
+
+jar {
+    // Add the manifest within the JAR, using gtfs-validator as the title
+    manifest {
+        attributes('Implementation-Title': rootProject.name,
+                'Implementation-Version': project.version,
+                'Main-Class': 'org.mobilitydata.gtfsvalidator.Main',
+                'Multi-Release': 'true')
+    }
+}
+
+shadowJar {
+    // Change the JAR name from cli-app to gtfs-validator
+    baseName = rootProject.name
+}
 
 sourceCompatibility = JavaVersion.VERSION_11
 

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -43,6 +43,8 @@ shadowJar {
     archiveBaseName = rootProject.name
     // Remove "-all" from the end of the JAR file name
     archiveClassifier = null
+    // Add "v" to version to match previous releases
+    archiveVersion = "v" + project.version
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -40,6 +40,8 @@ shadowJar {
     }
     // Change the JAR name from cli-app to gtfs-validator
     baseName = rootProject.name
+    // Remove "-all" from the end of the JAR file name
+    archiveClassifier = null
 }
 
 sourceCompatibility = JavaVersion.VERSION_11

--- a/application/cli-app/build.gradle
+++ b/application/cli-app/build.gradle
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import org.gradle.internal.logging.text.StyledTextOutputFactory
+import org.gradle.internal.logging.text.StyledTextOutput
 
 plugins {
     id 'com.github.johnrengelman.shadow' version '5.2.0'
@@ -57,4 +59,10 @@ dependencies {
     implementation 'org.apache.logging.log4j:log4j-api:2.12.1'
     implementation 'org.apache.logging.log4j:log4j-core:2.12.1'
     testCompile group: 'junit', name: 'junit', version: '4.12'
+}
+
+// Print success message with location of compiled JAR with dependencies
+def out = services.get(StyledTextOutputFactory).create("output")
+tasks.shadowJar.doLast {
+    out.style(StyledTextOutput.Style.SuccessHeader).println "Successfully built the gtfs-validator command-line app: " + archivePath
 }


### PR DESCRIPTION
**Summary:**

~~*Work-in-progress - please do not merge*~~

This pull request adds the ability to do command-line releases using the [shadow Gradle plugin](https://github.com/johnrengelman/shadow).

Usage:

```
./gradlew shadowJar
```

...which will output a file to `\cli-app\build\libs` such as `gtfs-validator-v1.1.0-SNAPSHOT.jar`.

This file can then be run from the command-line with the normal Java conventions:

```
java -jar gtfs-validator-v1.1.0-SNAPSHOT.jar -u https://transitfeeds.com/p/mbta/64/latest/download -z input.zip -i input -o output
```

See the updated `RELEASE.md` file for more details.

TODO:
- [x] Implement basic command line release
- [x] Update release docs
- [x] Add minification - https://imperceptiblethoughts.com/shadow/configuration/minimizing/. Original release JAR was 11,090 KB, minified JAR is 6,587 KB.
- [x] Typo in release docs - fix order to `./`
- [x] Change output directory? - No, just output path to compiled JAR to console when building (see comment below)
- [x] Change file name to remove `-all`? Yes
- [x] Fix warning added during minification - see comment below. Fixed in https://github.com/MobilityData/gtfs-validator/pull/108/commits/506e03f7c1dcf900151c8b630c4405bce5e0c4ed.
- [x] Add "v" to version number to match previous releases
- [x] Update usage examples and release docs to printed file output, removed "-all"
- [x] Add SNAPSHOT instruction for generating release
- [x] Test again!

Closes #66, Closes #52