### PR TITLE
chore: Improve CLI Main.main() error messages

### DIFF
--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -146,9 +146,9 @@ public class Main {
             config.exportResultAsFile(asProto, outputPath).execute();
 
         } catch (ParseException e) {
-            logger.error("Could not parse command line arguments: " + e.getMessage());
+            logger.error("Could not parse command line arguments: " + e);
         } catch (IOException e) {
-            logger.error("An exception occurred: " + e.getMessage());
+            logger.error("An exception occurred: " + e);
         }
 
         logger.info("Took " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");


### PR DESCRIPTION
**Summary:**

Prior to this patch, errors caught in the CLI `Main.main()` method were only partially output (see https://github.com/MobilityData/gtfs-validator/issues/112) - the type of the exception was missing.

For example, the output message looked like:

>[ERROR] 2020-04-15 17:06:38.743 [main] Main - An exception occurred: C:\git-projects\gtfs-validator\application\cli-app\build\libs\output\results.json

After this patch, the full error message is output:

>[ERROR] 2020-04-15 17:28:34.059 [main] Main - An exception occurred: java.nio.file.NoSuchFileException: C:\git-projects\gtfs-validator\output\results.json

**Expected behavior:** 

The full caught exception type and message should be output to the command-line when running the validator.