### PR TITLE
Fix #124 - build InMemoryGtfsSpecRepo with resource content instead of name

### DIFF
--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -41,7 +41,7 @@ import java.nio.file.Paths;
  * process. Hence, this is created before calling the different use case of the validation process in the main method.
  */
 public class DefaultConfig {
-    private final GtfsSpecRepository specRepo = new InMemoryGtfsSpecRepository("gtfs_spec.asciipb");
+    private final GtfsSpecRepository specRepo;// = new InMemoryGtfsSpecRepository("gtfs_spec.asciipb");
     private final RawFileRepository rawFileRepo = new InMemoryRawFileRepository();
     private final ValidationResultRepository resultRepo = new InMemoryValidationResultRepository();
     private final ExecParamRepository execParamRepo;
@@ -50,15 +50,28 @@ public class DefaultConfig {
     @SuppressWarnings("UnstableApiUsage")
     public DefaultConfig(final Logger logger) {
         this.logger = logger;
-        String defaultParameterJsonString;
+        String defaultParameterJsonString = null;
         try {
             defaultParameterJsonString = Resources.toString(
                     Resources.getResource("default-execution-parameters.json"),
                     StandardCharsets.UTF_8);
         } catch (IOException e) {
-            defaultParameterJsonString = "[]";
+            e.printStackTrace();
         }
         execParamRepo = new InMemoryExecParamRepository(defaultParameterJsonString, this.logger);
+
+        String gtfsSpecProtobufString = null;
+
+        try {
+            gtfsSpecProtobufString = Resources.toString(
+                    Resources.getResource("gtfs_spec.asciipb"),
+                    StandardCharsets.UTF_8
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        specRepo = new InMemoryGtfsSpecRepository(gtfsSpecProtobufString);
     }
 
     public DownloadArchiveFromNetwork downloadArchiveFromNetwork() {

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -41,7 +41,7 @@ import java.nio.file.Paths;
  * process. Hence, this is created before calling the different use case of the validation process in the main method.
  */
 public class DefaultConfig {
-    private final GtfsSpecRepository specRepo;// = new InMemoryGtfsSpecRepository("gtfs_spec.asciipb");
+    private final GtfsSpecRepository specRepo;
     private final RawFileRepository rawFileRepo = new InMemoryRawFileRepository();
     private final ValidationResultRepository resultRepo = new InMemoryValidationResultRepository();
     private final ExecParamRepository execParamRepo;


### PR DESCRIPTION
**Summary:**

This PR fixes #124 by retrieving the gtfs specification ascii protobuf file content instead of passing the file name to the `InMemoryGtfsSpecRepo` constructor

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)