### PR TITLE
Implement #186 - Remove notice collection from gtfs entities builder parametric constructor

### DIFF
--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Agency.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Agency.java
@@ -21,6 +21,7 @@ import org.jetbrains.annotations.Nullable;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredValueNotice;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -130,11 +131,7 @@ public class Agency extends GtfsEntity {
         private String agencyPhone;
         private String agencyFareUrl;
         private String agencyEmail;
-        private final List<Notice> noticeCollection;
-
-        public AgencyBuilder(final List<Notice> noticeCollection) {
-            this.noticeCollection = noticeCollection;
-        }
+        private final List<Notice> noticeCollection = new ArrayList<>();
 
         /**
          * Sets field agencyName value and returns this

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
@@ -24,6 +24,7 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredValueNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.UnexpectedEnumValueNotice;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -153,11 +154,7 @@ public class Route extends GtfsEntity {
         private String routeTextColor;
         private Integer routeSortOrder;
         private Integer originalRouteTypeInteger;
-        private final List<Notice> noticeCollection;
-
-        public RouteBuilder(final List<Notice> noticeCollection) {
-            this.noticeCollection = noticeCollection;
-        }
+        private final List<Notice> noticeCollection = new ArrayList<>();
 
         /**
          * Sets field routeId value and returns this

--- a/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/AgencyTest.java
+++ b/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/AgencyTest.java
@@ -17,16 +17,12 @@
 package org.mobilitydata.gtfsvalidator.domain.entity.gtfs;
 
 import org.junit.jupiter.api.Test;
-import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredValueNotice;
-import org.mockito.ArgumentCaptor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
 
 class AgencyTest {
     private static final String STRING_TEST_VALUE = "test_value";
@@ -35,111 +31,92 @@ class AgencyTest {
     // "@SuppressWarnings("ConstantConditions")" is used here to suppress lint.
     @Test
     public void createAgencyWithNullAgencyNameShouldGenerateMissingRequiredValueNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder(mockNoticeCollection);
+        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder();
 
         //noinspection ConstantConditions
-        underTest.agencyId(STRING_TEST_VALUE)
+        final EntityBuildResult<?> entityBuildResult = underTest.agencyId(STRING_TEST_VALUE)
                 .agencyName(null)
                 .agencyUrl(STRING_TEST_VALUE)
                 .agencyTimezone(STRING_TEST_VALUE)
                 .agencyLang(STRING_TEST_VALUE)
                 .agencyPhone(STRING_TEST_VALUE)
                 .agencyFareUrl(STRING_TEST_VALUE)
-                .agencyEmail(STRING_TEST_VALUE);
-
-        final EntityBuildResult<?> entityBuildResult = underTest.build();
-
-        final ArgumentCaptor<MissingRequiredValueNotice> captor =
-                ArgumentCaptor.forClass(MissingRequiredValueNotice.class);
-
-        verify(mockNoticeCollection, times(1)).clear();
-        verify(mockNoticeCollection, times(1)).add(captor.capture());
-
-        final List<MissingRequiredValueNotice> noticeList = captor.getAllValues();
-
-        assertEquals("agency.txt", noticeList.get(0).getFilename());
-        assertEquals("agency_name", noticeList.get(0).getFieldName());
-        assertEquals(STRING_TEST_VALUE, noticeList.get(0).getEntityId());
+                .agencyEmail(STRING_TEST_VALUE)
+                .build();
 
         assertTrue(entityBuildResult.getData() instanceof List);
-        verifyNoMoreInteractions(mockNoticeCollection);
+        //noinspection unchecked to avoid lint
+        final List<MissingRequiredValueNotice> noticeCollection =
+                (List<MissingRequiredValueNotice>) entityBuildResult.getData();
+        final MissingRequiredValueNotice notice = noticeCollection.get(0);
+
+        assertEquals("agency.txt", notice.getFilename());
+        assertEquals("agency_name", notice.getFieldName());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+        assertEquals(1, noticeCollection.size());
     }
 
     // Field agencyUrl is annotated as `@NonNull` but test require this field to be null. Therefore annotation
     // "@SuppressWarnings("ConstantConditions")" is used here to suppress lint.
     @Test
     public void createAgencyWithNullAgencyUrlShouldGenerateMissingRequiredValueNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder(mockNoticeCollection);
+        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder();
 
         //noinspection ConstantConditions
-        underTest.agencyId(STRING_TEST_VALUE)
+        final EntityBuildResult<?> entityBuildResult = underTest.agencyId(STRING_TEST_VALUE)
                 .agencyName(STRING_TEST_VALUE)
                 .agencyUrl(null)
                 .agencyTimezone(STRING_TEST_VALUE)
                 .agencyLang(STRING_TEST_VALUE)
                 .agencyPhone(STRING_TEST_VALUE)
                 .agencyFareUrl(STRING_TEST_VALUE)
-                .agencyEmail(STRING_TEST_VALUE);
-
-        final EntityBuildResult<?> entityBuildResult = underTest.build();
-
-        final ArgumentCaptor<MissingRequiredValueNotice> captor =
-                ArgumentCaptor.forClass(MissingRequiredValueNotice.class);
-
-        verify(mockNoticeCollection, times(1)).clear();
-        verify(mockNoticeCollection, times(1)).add(captor.capture());
-
-        final List<MissingRequiredValueNotice> noticeList = captor.getAllValues();
-
-        assertEquals("agency.txt", noticeList.get(0).getFilename());
-        assertEquals("agency_url", noticeList.get(0).getFieldName());
-        assertEquals(STRING_TEST_VALUE, noticeList.get(0).getEntityId());
+                .agencyEmail(STRING_TEST_VALUE)
+                .build();
 
         assertTrue(entityBuildResult.getData() instanceof List);
-        verifyNoMoreInteractions(mockNoticeCollection);
+        //noinspection unchecked to avoid lint
+        final List<MissingRequiredValueNotice> noticeCollection =
+                (List<MissingRequiredValueNotice>) entityBuildResult.getData();
+        final MissingRequiredValueNotice notice = noticeCollection.get(0);
+
+        assertEquals("agency.txt", notice.getFilename());
+        assertEquals("agency_url", notice.getFieldName());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+        assertEquals(1, noticeCollection.size());
     }
 
     // Field agencyTimezone is annotated as `@NonNull` but test require this field to be null. Therefore annotation
     // "@SuppressWarnings("ConstantConditions")" is used here to suppress lint.
     @Test
     public void createAgencyWithNullTimezoneShouldGenerateMissingRequiredValueNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder(mockNoticeCollection);
+        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder();
 
         //noinspection ConstantConditions
-        underTest.agencyId(STRING_TEST_VALUE)
+        final EntityBuildResult<?> entityBuildResult = underTest.agencyId(STRING_TEST_VALUE)
                 .agencyName(STRING_TEST_VALUE)
                 .agencyUrl(STRING_TEST_VALUE)
                 .agencyTimezone(null)
                 .agencyLang(STRING_TEST_VALUE)
                 .agencyPhone(STRING_TEST_VALUE)
                 .agencyFareUrl(STRING_TEST_VALUE)
-                .agencyEmail(STRING_TEST_VALUE);
-
-        final EntityBuildResult<?> entityBuildResult = underTest.build();
-
-        final ArgumentCaptor<MissingRequiredValueNotice> captor =
-                ArgumentCaptor.forClass(MissingRequiredValueNotice.class);
-
-        verify(mockNoticeCollection, times(1)).clear();
-        verify(mockNoticeCollection, times(1)).add(captor.capture());
-
-        final List<MissingRequiredValueNotice> noticeList = captor.getAllValues();
-
-        assertEquals("agency.txt", noticeList.get(0).getFilename());
-        assertEquals("agency_timezone", noticeList.get(0).getFieldName());
-        assertEquals(STRING_TEST_VALUE, noticeList.get(0).getEntityId());
+                .agencyEmail(STRING_TEST_VALUE)
+                .build();
 
         assertTrue(entityBuildResult.getData() instanceof List);
-        verifyNoMoreInteractions(mockNoticeCollection);
+        //noinspection unchecked to avoid lint
+        final List<MissingRequiredValueNotice> noticeCollection =
+                (List<MissingRequiredValueNotice>) entityBuildResult.getData();
+        final MissingRequiredValueNotice notice = noticeCollection.get(0);
+
+        assertEquals("agency.txt", notice.getFilename());
+        assertEquals("agency_timezone", notice.getFieldName());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+        assertEquals(1, noticeCollection.size());
     }
 
     @Test
     public void createAgencyWithValidValuesShouldNotGenerateNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder(mockNoticeCollection);
+        final Agency.AgencyBuilder underTest = new Agency.AgencyBuilder();
 
         underTest.agencyId(STRING_TEST_VALUE);
         underTest.agencyName(STRING_TEST_VALUE);
@@ -152,9 +129,6 @@ class AgencyTest {
 
         final EntityBuildResult<?> entityBuildResult = underTest.build();
 
-        verify(mockNoticeCollection, times(1)).clear();
-
         assertTrue(entityBuildResult.getData() instanceof Agency);
-        verifyNoMoreInteractions(mockNoticeCollection);
     }
 }

--- a/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/RouteTest.java
+++ b/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/RouteTest.java
@@ -18,20 +18,15 @@ package org.mobilitydata.gtfsvalidator.domain.entity.gtfs;
 
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
-import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredValueNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.UnexpectedEnumValueNotice;
-import org.mockito.ArgumentCaptor;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.*;
 
 class RouteTest {
-
     private static final String STRING_TEST_VALUE = "test_value";
     private static final int INT_TEST_VALUE = 0;
 
@@ -40,10 +35,9 @@ class RouteTest {
     @SuppressWarnings("ConstantConditions")
     @Test
     public void createRouteWithNullRouteIdShouldGenerateMissingRequiredValueNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Route.RouteBuilder underTest = new Route.RouteBuilder(mockNoticeCollection);
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
 
-        underTest.routeId(null)
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(null)
                 .agencyId(STRING_TEST_VALUE)
                 .routeShortName(STRING_TEST_VALUE)
                 .routeLongName(STRING_TEST_VALUE)
@@ -52,32 +46,27 @@ class RouteTest {
                 .routeUrl(STRING_TEST_VALUE)
                 .routeColor(STRING_TEST_VALUE)
                 .routeTextColor(STRING_TEST_VALUE)
-                .routeSortOrder(INT_TEST_VALUE);
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
 
-        final EntityBuildResult<?> entityBuildResult = underTest.build();
-
-        final ArgumentCaptor<MissingRequiredValueNotice> captor =
-                ArgumentCaptor.forClass(MissingRequiredValueNotice.class);
-
-        verify(mockNoticeCollection, times(1)).clear();
-        verify(mockNoticeCollection, times(1)).add(captor.capture());
-
-        final List<MissingRequiredValueNotice> noticeList = captor.getAllValues();
-
-        assertEquals("routes.txt", noticeList.get(0).getFilename());
-        assertEquals("route_id", noticeList.get(0).getFieldName());
-        assertEquals("no id", noticeList.get(0).getEntityId());
         assertTrue(entityBuildResult.getData() instanceof List);
+        //noinspection unchecked to avoid lint
+        final List<MissingRequiredValueNotice> noticeCollection =
+                (List<MissingRequiredValueNotice>) entityBuildResult.getData();
 
-        verifyNoMoreInteractions(mockNoticeCollection);
+        final MissingRequiredValueNotice notice = noticeCollection.get(0);
+
+        assertEquals("routes.txt", notice.getFilename());
+        assertEquals("route_id", notice.getFieldName());
+        assertEquals("no id", notice.getEntityId());
+        assertEquals(1, noticeCollection.size());
     }
 
     @Test
     public void createRouteWithInvalidRouteTypeShouldGenerateUnexpectedEnumValueNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Route.RouteBuilder underTest = new Route.RouteBuilder(mockNoticeCollection);
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
 
-        underTest.routeId(STRING_TEST_VALUE)
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
                 .agencyId(STRING_TEST_VALUE)
                 .routeShortName(STRING_TEST_VALUE)
                 .routeLongName(STRING_TEST_VALUE)
@@ -86,33 +75,27 @@ class RouteTest {
                 .routeUrl(STRING_TEST_VALUE)
                 .routeColor(STRING_TEST_VALUE)
                 .routeTextColor(STRING_TEST_VALUE)
-                .routeSortOrder(INT_TEST_VALUE);
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
 
-        final EntityBuildResult<?> entityBuildResult = underTest.build();
-
-        final ArgumentCaptor<UnexpectedEnumValueNotice> captor =
-                ArgumentCaptor.forClass(UnexpectedEnumValueNotice.class);
-
-        verify(mockNoticeCollection, times(1)).clear();
-        verify(mockNoticeCollection, times(1)).add(captor.capture());
-
-        final List<UnexpectedEnumValueNotice> noticeList = captor.getAllValues();
-
-        assertEquals("routes.txt", noticeList.get(0).getFilename());
-        assertEquals("route_type", noticeList.get(0).getFieldName());
-        assertEquals(STRING_TEST_VALUE, noticeList.get(0).getEntityId());
-        assertEquals("15", noticeList.get(0).getEnumValue());
         assertTrue(entityBuildResult.getData() instanceof List);
+        //noinspection unchecked to avoid lint
+        final List<UnexpectedEnumValueNotice> noticeCollection =
+                (List<UnexpectedEnumValueNotice>) entityBuildResult.getData();
 
-        verifyNoMoreInteractions(mockNoticeCollection);
+        final UnexpectedEnumValueNotice notice = noticeCollection.get(0);
+        assertEquals("routes.txt", notice.getFilename());
+        assertEquals("route_type", notice.getFieldName());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+        assertEquals("15", notice.getEnumValue());
+        assertEquals(1, noticeCollection.size());
     }
 
     @Test
     public void createRouteWithValidValuesForFieldShouldNotGenerateNotice() {
-        @SuppressWarnings("unchecked") final List<Notice> mockNoticeCollection = mock(ArrayList.class);
-        final Route.RouteBuilder underTest = new Route.RouteBuilder(mockNoticeCollection);
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
 
-        underTest.routeId(STRING_TEST_VALUE)
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
                 .agencyId(STRING_TEST_VALUE)
                 .routeShortName(STRING_TEST_VALUE)
                 .routeLongName(STRING_TEST_VALUE)
@@ -121,12 +104,9 @@ class RouteTest {
                 .routeUrl(STRING_TEST_VALUE)
                 .routeColor(STRING_TEST_VALUE)
                 .routeTextColor(STRING_TEST_VALUE)
-                .routeSortOrder(INT_TEST_VALUE);
-
-        final EntityBuildResult<?> entityBuildResult = underTest.build();
-        verify(mockNoticeCollection, times(1)).clear();
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
 
         assertTrue(entityBuildResult.getData() instanceof Route);
-        verifyNoMoreInteractions(mockNoticeCollection);
     }
 }


### PR DESCRIPTION
**Summary:**

This PR removes the notice collection from the parametric constructor of gtfs entities builder. Therefore, the default parametric constructor will be used. 

Tests have been adapted to said change.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [N/A] Include screenshot(s) showing how this pull request works and fixes the issue(s)