### PR TITLE
Implement #241 - Implement semantic validation of field route_sort_order of file routes.txt

### DIFF
--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -226,4 +226,9 @@ public class JsonNoticeExporter implements NoticeExporter {
     public void export(RouteLongNameContainsShortNameNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }
+
+    @Override
+    public void export(SuspiciousRouteSortOrderNotice toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
 }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -453,6 +453,16 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .writeTo(streamGenerator.getStream());
     }
 
+    @Override
+    public void export(final SuspiciousRouteSortOrderNotice toExport) throws IOException {
+        outOfRangeNoticeToProto(toExport.getFilename(),
+                toExport.getEntityId(),
+                toExport.getFieldName(),
+                String.valueOf(toExport.getRangeMin()),
+                String.valueOf(toExport.getRangeMax()),
+                String.valueOf(toExport.getActualValue()));
+    }
+
     public static class ProtobufOutputStreamGenerator {
         private final String targetPath;
         private final List<OutputStream> openedStreamCollection = new ArrayList<>();

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -536,4 +536,17 @@ class JsonNoticeExporterTest {
         verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
         verifyNoMoreInteractions(mockGenerator);
     }
+
+    @Test
+    void exportSuspiciousRouteSortOrderNoticeShouldWriteObject() throws IOException {
+        final JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        final JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        SuspiciousRouteSortOrderNotice toExport = new SuspiciousRouteSortOrderNotice(FILENAME,
+                "route_sort_order", "entity_id", 3, 60, 77);
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
 }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -1141,4 +1141,42 @@ class ProtobufNoticeExporterTest {
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }
+
+    @Test
+    void exportSuspiciousRouteSortOrderNoticeShouldMapToCsvProblemAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        underTest.export(new SuspiciousRouteSortOrderNotice(FILENAME, "field_name", "entity_id",
+                0, 66, 666));
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(ArgumentMatchers.eq(FILENAME));
+        verify(mockBuilder, times(1)).setType(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_OUT_OF_RANGE));
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
+        verify(mockBuilder, times(1)).setAltEntityId(ArgumentMatchers.eq("entity_id"));
+        verify(mockBuilder, times(1)).addCsvColumnName(
+                ArgumentMatchers.eq("field_name"));
+        verify(mockBuilder, times(1)).setValue(
+                ArgumentMatchers.eq("0.0"));
+        verify(mockBuilder, times(1)).setAltValue(
+                ArgumentMatchers.eq("66.0"));
+        verify(mockBuilder, times(1)).setAltEntityValue(
+                ArgumentMatchers.eq("666.0"));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
 }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -1171,11 +1171,11 @@ class ProtobufNoticeExporterTest {
         verify(mockBuilder, times(1)).addCsvColumnName(
                 ArgumentMatchers.eq("field_name"));
         verify(mockBuilder, times(1)).setValue(
-                ArgumentMatchers.eq("0.0"));
+                ArgumentMatchers.eq("0"));
         verify(mockBuilder, times(1)).setAltValue(
-                ArgumentMatchers.eq("66.0"));
+                ArgumentMatchers.eq("66"));
         verify(mockBuilder, times(1)).setAltEntityValue(
-                ArgumentMatchers.eq("666.0"));
+                ArgumentMatchers.eq("666"));
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
@@ -222,6 +222,12 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                         getExecParamByKey(EXCLUSION_KEY).getValue().toString()
                         : null;
             }
+            case ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY:
+            case ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY: {
+                return hasExecParamValue(key) ?
+                        getExecParamByKey(key).getValue().get(0)
+                        : defaultValue.get(0);
+            }
         }
         throw new IllegalArgumentException("Requested key is not handled");
     }
@@ -250,6 +256,10 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                 "Export validation results as proto");
         options.addOption(String.valueOf(EXCLUSION_KEY.charAt(1)), EXCLUSION_KEY, true,
                 "Exclude files from semantic GTFS validation");
+        options.addOption(ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY, ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY, true,
+                "Minimum admissible value for field route_sort_order of file routes.txt");
+        options.addOption(ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY, ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY, true,
+                "Maximum admissible value for field route_sort_order of file routes.txt");
         // Commands --proto and --help take no arguments, contrary to command --exclude that can take multiple arguments
         // Other commands only take 1 argument
         options.getOptions().forEach(option -> {

--- a/config/src/main/resources/default-execution-parameters.json
+++ b/config/src/main/resources/default-execution-parameters.json
@@ -5,5 +5,7 @@
   "proto": false,
   "url": null,
   "zipinput": null,
-  "exclude": null
+  "exclude": null,
+  "route__route_sort_order_lower_bound": 0,
+  "route__route_sort_order_upper_bound": 3000
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -82,4 +82,6 @@ public interface NoticeExporter {
     void export(RouteLongNameEqualsShortNameNotice toExport) throws IOException;
 
     void export(RouteLongNameContainsShortNameNotice toExport) throws IOException;
+
+    void export(SuspiciousRouteSortOrderNotice toExport) throws IOException;
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/warning/SuspiciousRouteSortOrderNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/warning/SuspiciousRouteSortOrderNotice.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020. MobilityData IO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.domain.entity.notice.warning;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+
+import java.io.IOException;
+
+public class SuspiciousRouteSortOrderNotice extends ErrorNotice {
+    private final String fieldName;
+    private final int rangeMin;
+    private final int rangeMax;
+    private final int actualValue;
+
+    public SuspiciousRouteSortOrderNotice(
+            final String filename,
+            final String fieldName,
+            final String entityId,
+            final int rangeMin,
+            final int rangeMax,
+            final int actualValue) {
+        super(filename, E_010,
+                "Out of range integer value",
+                "Suspicious value for field:" + fieldName + " of entity with id:" + entityId +
+                        " -- min:" + rangeMin + " max:" + rangeMax + " actual:" + actualValue,
+                entityId);
+        this.fieldName = fieldName;
+        this.rangeMax = rangeMax;
+        this.rangeMin = rangeMin;
+        this.actualValue = actualValue;
+    }
+
+    @Override
+    public void export(final NoticeExporter exporter) throws IOException {
+        exporter.export(this);
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public int getRangeMin() {
+        return rangeMin;
+    }
+
+    public int getRangeMax() {
+        return rangeMax;
+    }
+
+    public int getActualValue() {
+        return actualValue;
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteSortSemanticValue.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteSortSemanticValue.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.SuspiciousRouteSortOrderNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.ExecParamRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+
+import java.util.Collection;
+
+/**
+ * Use case to semantically validate the value of field route_sort_order in routes.txt
+ */
+public class ValidateRouteSortSemanticValue {
+    private final ExecParamRepository execParamRepository;
+    private final GtfsDataRepository gtfsDataRepository;
+    private final ValidationResultRepository validationResultRepository;
+
+    public ValidateRouteSortSemanticValue(final ExecParamRepository execParamRepository,
+                                          final GtfsDataRepository gtfsDataRepository,
+                                          final ValidationResultRepository validationResultRepository) {
+        this.execParamRepository = execParamRepository;
+        this.gtfsDataRepository = gtfsDataRepository;
+        this.validationResultRepository = validationResultRepository;
+    }
+
+    /**
+     * Use case execution method. Verifies if the value of field route_sort_order is between the numeric bounds
+     * corresponding to this field.
+     */
+    public void execute() {
+        final Collection<Route> routePerId = gtfsDataRepository.getRouteAll();
+        final int routeSortOrderLowerBound = Integer.parseInt(execParamRepository
+                .getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY));
+        final int routeSortOrderUpperBound = Integer.parseInt(execParamRepository
+                .getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY));
+        routePerId.forEach(route -> {
+            final Integer routeSortOrder = route.getRouteSortOrder();
+            if (routeSortOrder != null) {
+                if (routeSortOrder < routeSortOrderLowerBound || routeSortOrder > routeSortOrderUpperBound) {
+                    validationResultRepository.addNotice(new SuspiciousRouteSortOrderNotice("routes.txt",
+                            "route_sort_order", route.getRouteId(), routeSortOrderLowerBound,
+                            routeSortOrderUpperBound, routeSortOrder));
+                }
+            }
+        });
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ExecParamRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ExecParamRepository.java
@@ -35,6 +35,8 @@ public interface ExecParamRepository {
     String URL_KEY = "url";
     String ZIP_KEY = "zipinput";
     String EXCLUSION_KEY = "exclude";
+    String ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY = "route__route_sort_order_lower_bound";
+    String ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY = "route__route_sort_order_upper_bound";
 
     ExecParam getExecParamByKey(final String optionName);
 

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteSortSemanticValueTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteSortSemanticValueTest.java
@@ -1,0 +1,176 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.SuspiciousRouteSortOrderNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.ExecParamRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ValidateRouteSortSemanticValueTest {
+
+    @Test
+    void routeWithTooBigRouteSortOrderShouldGenerateNotice() {
+        final ExecParamRepository mockExecParamRepo = mock(ExecParamRepository.class);
+        when(mockExecParamRepo.getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY))
+                .thenReturn("30");
+        when(mockExecParamRepo.getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY))
+                .thenReturn("50");
+
+        final GtfsDataRepository mockGtfsDataRepo = mock(GtfsDataRepository.class);
+        final Route mockRoute = mock(Route.class);
+        when(mockRoute.getRouteSortOrder()).thenReturn(70);
+        when(mockRoute.getRouteId()).thenReturn("route id");
+        final Collection<Route> mockRouteCollection = new ArrayList<>(List.of(mockRoute));
+        when(mockGtfsDataRepo.getRouteAll()).thenReturn(mockRouteCollection);
+
+        final ValidationResultRepository mockResultRepo = spy(ValidationResultRepository.class);
+        final ValidateRouteSortSemanticValue underTest =
+                new ValidateRouteSortSemanticValue(mockExecParamRepo, mockGtfsDataRepo, mockResultRepo);
+
+        underTest.execute();
+
+        InOrder inOrder = Mockito.inOrder(mockGtfsDataRepo, mockExecParamRepo, mockResultRepo, mockRoute);
+
+        inOrder.verify(mockGtfsDataRepo, times(1)).getRouteAll();
+        inOrder.verify(mockExecParamRepo, times(1)).getExecParamValue(
+                ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY);
+        inOrder.verify(mockExecParamRepo, times(1)).getExecParamValue(
+                ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY);
+
+        // suppressed warning since the results of method getRouteSortOrder is not to be checked here
+        //noinspection ResultOfMethodCallIgnored
+        inOrder.verify(mockRoute, times(1)).getRouteSortOrder();
+
+        final ArgumentCaptor<SuspiciousRouteSortOrderNotice> captor =
+                ArgumentCaptor.forClass(SuspiciousRouteSortOrderNotice.class);
+
+        inOrder.verify(mockResultRepo, times(1)).addNotice(captor.capture());
+        // suppressed warning since the results of method getRouteId is not to be checked here
+        //noinspection ResultOfMethodCallIgnored
+        verify(mockRoute, times(1)).getRouteId();
+        final List<SuspiciousRouteSortOrderNotice> noticeList = captor.getAllValues();
+
+        assertEquals("routes.txt", noticeList.get(0).getFilename());
+        assertEquals("route_sort_order", noticeList.get(0).getFieldName());
+        assertEquals("route id", noticeList.get(0).getEntityId());
+        assertEquals(30, noticeList.get(0).getRangeMin());
+        assertEquals(50, noticeList.get(0).getRangeMax());
+        assertEquals(70, noticeList.get(0).getActualValue());
+        verifyNoMoreInteractions(mockExecParamRepo, mockGtfsDataRepo, mockResultRepo, mockRoute);
+    }
+
+    @Test
+    void routeWithTooSmallRouteSortOrderShouldGenerateNotice() {
+        final ExecParamRepository mockExecParamRepo = mock(ExecParamRepository.class);
+        when(mockExecParamRepo.getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY))
+                .thenReturn("30");
+        when(mockExecParamRepo.getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY))
+                .thenReturn("50");
+
+        final GtfsDataRepository mockGtfsDataRepo = mock(GtfsDataRepository.class);
+        final Route mockRoute = mock(Route.class);
+        when(mockRoute.getRouteSortOrder()).thenReturn(20);
+        when(mockRoute.getRouteId()).thenReturn("route id");
+        final Collection<Route> mockRouteCollection = new ArrayList<>(List.of(mockRoute));
+        when(mockGtfsDataRepo.getRouteAll()).thenReturn(mockRouteCollection);
+
+        final ValidationResultRepository mockResultRepo = spy(ValidationResultRepository.class);
+        final ValidateRouteSortSemanticValue underTest =
+                new ValidateRouteSortSemanticValue(mockExecParamRepo, mockGtfsDataRepo, mockResultRepo);
+
+        underTest.execute();
+
+        InOrder inOrder = Mockito.inOrder(mockGtfsDataRepo, mockExecParamRepo, mockResultRepo, mockRoute);
+
+        inOrder.verify(mockGtfsDataRepo, times(1)).getRouteAll();
+        inOrder.verify(mockExecParamRepo, times(1)).getExecParamValue(
+                ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY);
+        inOrder.verify(mockExecParamRepo, times(1)).getExecParamValue(
+                ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY);
+
+        // suppressed warning since the results of method getRouteSortOrder is not to be checked here
+        //noinspection ResultOfMethodCallIgnored
+        inOrder.verify(mockRoute, times(1)).getRouteSortOrder();
+
+        final ArgumentCaptor<SuspiciousRouteSortOrderNotice> captor =
+                ArgumentCaptor.forClass(SuspiciousRouteSortOrderNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+        // suppressed warning since the results of method getRouteId is not to be checked here
+        //noinspection ResultOfMethodCallIgnored
+        inOrder.verify(mockRoute, times(1)).getRouteId();
+
+        final List<SuspiciousRouteSortOrderNotice> noticeList = captor.getAllValues();
+
+        assertEquals("routes.txt", noticeList.get(0).getFilename());
+        assertEquals("route_sort_order", noticeList.get(0).getFieldName());
+        assertEquals("route id", noticeList.get(0).getEntityId());
+        assertEquals(30, noticeList.get(0).getRangeMin());
+        assertEquals(50, noticeList.get(0).getRangeMax());
+        assertEquals(20, noticeList.get(0).getActualValue());
+        verifyNoMoreInteractions(mockExecParamRepo, mockGtfsDataRepo, mockResultRepo, mockRoute);
+    }
+
+
+    @Test
+    void routeWithoutSuspiciousRouteSortOrderShouldNotGenerateNotice() {
+        final ExecParamRepository mockExecParamRepo = mock(ExecParamRepository.class);
+        when(mockExecParamRepo.getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY))
+                .thenReturn("30");
+        when(mockExecParamRepo.getExecParamValue(ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY))
+                .thenReturn("50");
+
+        final GtfsDataRepository mockGtfsDataRepo = mock(GtfsDataRepository.class);
+        final Route mockRoute = mock(Route.class);
+        when(mockRoute.getRouteSortOrder()).thenReturn(40);
+        when(mockRoute.getRouteId()).thenReturn("route id");
+        final Collection<Route> mockRouteCollection = new ArrayList<>(List.of(mockRoute));
+        when(mockGtfsDataRepo.getRouteAll()).thenReturn(mockRouteCollection);
+
+        final ValidationResultRepository mockResultRepo = spy(ValidationResultRepository.class);
+        final ValidateRouteSortSemanticValue underTest =
+                new ValidateRouteSortSemanticValue(mockExecParamRepo, mockGtfsDataRepo, mockResultRepo);
+
+        underTest.execute();
+
+        InOrder inOrder = Mockito.inOrder(mockGtfsDataRepo, mockExecParamRepo, mockResultRepo, mockRoute);
+
+        inOrder.verify(mockGtfsDataRepo, times(1)).getRouteAll();
+        inOrder.verify(mockExecParamRepo, times(1)).getExecParamValue(
+                ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_LOWER_BOUND_KEY);
+        inOrder.verify(mockExecParamRepo, times(1)).getExecParamValue(
+                ExecParamRepository.ROUTE__ROUTE_SORT_ORDER_UPPER_BOUND_KEY);
+
+        // suppressed warning since the results of method getRouteSortOrder is not to be checked here
+        //noinspection ResultOfMethodCallIgnored
+        inOrder.verify(mockRoute, times(1)).getRouteSortOrder();
+        verifyNoMoreInteractions(mockExecParamRepo, mockGtfsDataRepo, mockResultRepo, mockRoute);
+    }
+}


### PR DESCRIPTION
**Summary:**

This PR provides code to validate semantically field routes.route_sort_order.  To do so, thresholds have to be provided by user. If said thresholds are not provided, the implementation uses default values for these thresholds.

- new notice `SuspiciousRouteSortOrderNotice` has been added
- support to provide threshold for said field has been added: these are user configurable via configuration file and/or command line

**Expected behavior:** 

Field routes.route_sort_order should be semantically validated following the thresholds provided as input from the software user.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~