### PR TITLE
Fix #249 -- Prevent NPE when executing use case ValidateRouteLongNameDoesNotContainOrEqualShortName

### DIFF
--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteLongNameDoesNotContainOrEqualShortName.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteLongNameDoesNotContainOrEqualShortName.java
@@ -51,7 +51,7 @@ public class ValidateRouteLongNameDoesNotContainOrEqualShortName {
     public void execute() {
         Collection<Route> routes = dataRepo.getRouteAll();
         routes.stream()
-                .filter(route -> route.getRouteLongName() != null &&
+                .filter(route -> route.getRouteLongName() != null && route.getRouteShortName() != null &&
                         route.getRouteLongName().contains(route.getRouteShortName()))
                 .forEach(route -> {
                     if (route.getRouteLongName().equals(route.getRouteShortName())) {

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteLongNameDoesNotContainOrEqualShortNameTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateRouteLongNameDoesNotContainOrEqualShortNameTest.java
@@ -55,6 +55,30 @@ public class ValidateRouteLongNameDoesNotContainOrEqualShortNameTest {
     }
 
     @Test
+    void nullShortRouteNameShouldNotGenerateNotice() {
+
+        Route mockRoute = mock(Route.class);
+        when(mockRoute.getRouteShortName()).thenReturn(null);
+        when(mockRoute.getRouteLongName()).thenReturn("This is a long name for route abc");
+
+        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getRouteAll()).thenReturn(List.of(mockRoute));
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateRouteLongNameDoesNotContainOrEqualShortName underTest =
+                new ValidateRouteLongNameDoesNotContainOrEqualShortName(mockDataRepo, mockResultRepo);
+
+        underTest.execute();
+
+        verify(mockDataRepo, times(1)).getRouteAll();
+        verify(mockRoute, times(1)).getRouteLongName();
+        verify(mockRoute, times(1)).getRouteShortName();
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo);
+    }
+
+    @Test
     void longRouteNameNotContainingShortNameShouldNotGenerateNotice() {
 
         Route mockRoute = mock(Route.class);
@@ -75,7 +99,7 @@ public class ValidateRouteLongNameDoesNotContainOrEqualShortNameTest {
 
         verify(mockDataRepo, times(1)).getRouteAll();
         verify(mockRoute, times(2)).getRouteLongName();
-        verify(mockRoute, times(1)).getRouteShortName();
+        verify(mockRoute, times(2)).getRouteShortName();
         verifyNoInteractions(mockResultRepo);
         verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo);
     }
@@ -101,7 +125,7 @@ public class ValidateRouteLongNameDoesNotContainOrEqualShortNameTest {
 
         verify(mockDataRepo, times(1)).getRouteAll();
         verify(mockRoute, times(3)).getRouteLongName();
-        verify(mockRoute, times(2)).getRouteShortName();
+        verify(mockRoute, times(3)).getRouteShortName();
         verify(mockRoute, times(1)).getRouteId();
         verify(mockResultRepo, times(1)).addNotice(any(RouteLongNameContainsShortNameNotice.class));
         verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo);
@@ -128,7 +152,7 @@ public class ValidateRouteLongNameDoesNotContainOrEqualShortNameTest {
 
         verify(mockDataRepo, times(1)).getRouteAll();
         verify(mockRoute, times(3)).getRouteLongName();
-        verify(mockRoute, times(2)).getRouteShortName();
+        verify(mockRoute, times(3)).getRouteShortName();
         verify(mockRoute, times(1)).getRouteId();
         verify(mockResultRepo, times(1)).addNotice(any(RouteLongNameEqualsShortNameNotice.class));
         verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo);


### PR DESCRIPTION
**Summary:**

This PR provides support to avoid throwing NPE with validating that field `route_short_name` is not contained in `route_long_name` or equal to that same field. 

To do so, we extend the filter to filter out route entities with null route_short_name. New test have been implemented, and existing tests have been adapted.

**Expected behavior:** 

The rule is no longer executed on routes with null fields `route_short_name` or `route_long_name`, which prevents NPE to be thrown.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~