### PR TITLE
Fix #251 - New rule - `calendar.txt` `end_date` is before `start_date`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -30,6 +30,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E026](#E026) | Invalid route type | 
 | [E027](#E027) | Missing route short name and long name | 
 | [E028](#E028) | Route long name equals short name | 
+| [E032](#E032) | `calendar.txt` `end_date` is before `start_date` |
 
 ### Table of Warnings
 
@@ -104,6 +105,15 @@ A Route color and a Route text color should be contrasting. Minimum Contrast Rat
 <a name="E028"/>
 
 ### E028 - Route long name equals short name
+
+<a name="E032"/>
+
+### E032 - `calendar.txt` `end_date` is before `start_date`
+
+In `calendar.txt`, the `end_date` of a service record must not be earlier than the `start_date`.
+
+#### References:
+* [calendar.txt specification](https://gtfs.org/reference/static/#calendartxt)
 
 # Warnings
 

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -226,4 +226,9 @@ public class JsonNoticeExporter implements NoticeExporter {
     public void export(RouteLongNameContainsShortNameNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }
+
+    @Override
+    public void export(CalendarEndDateBeforeStartDate toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
 }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -228,7 +228,7 @@ public class JsonNoticeExporter implements NoticeExporter {
     }
 
     @Override
-    public void export(CalendarEndDateBeforeStartDate toExport) throws IOException {
+    public void export(CalendarEndDateBeforeStartDateNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }
 }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -453,6 +453,16 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .writeTo(streamGenerator.getStream());
     }
 
+    @Override
+    public void export(CalendarEndDateBeforeStartDate toExport) throws IOException {
+        protoBuilder.clear()
+                .setCsvFileName(toExport.getFilename())
+                .setType(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CALENDAR_START_AND_END_DATE_OUT_OF_ORDER)
+                .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
+                .build()
+                .writeTo(streamGenerator.getStream());
+    }
+
     public static class ProtobufOutputStreamGenerator {
         private final String targetPath;
         private final List<OutputStream> openedStreamCollection = new ArrayList<>();

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -454,7 +454,7 @@ public class ProtobufNoticeExporter implements NoticeExporter {
     }
 
     @Override
-    public void export(CalendarEndDateBeforeStartDate toExport) throws IOException {
+    public void export(CalendarEndDateBeforeStartDateNotice toExport) throws IOException {
         protoBuilder.clear()
                 .setCsvFileName(toExport.getFilename())
                 .setType(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CALENDAR_START_AND_END_DATE_OUT_OF_ORDER)

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -543,7 +543,7 @@ class JsonNoticeExporterTest {
         JsonGenerator mockGenerator = mock(JsonGenerator.class);
 
         JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
-        CalendarEndDateBeforeStartDate toExport = new CalendarEndDateBeforeStartDate(
+        CalendarEndDateBeforeStartDateNotice toExport = new CalendarEndDateBeforeStartDateNotice(
                 FILENAME,
                 "wkend",
                 LocalDateTime.of(2020, 2, 1, 12, 35, 59),

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -25,6 +25,7 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.net.URL;
+import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.*;
 
@@ -531,6 +532,23 @@ class JsonNoticeExporterTest {
 
         JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
         RouteLongNameContainsShortNameNotice toExport = new RouteLongNameContainsShortNameNotice(FILENAME, "entity_id");
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
+
+    @Test
+    void exportCalendarEndDateBeforeStartDateShouldWriteObject() throws IOException {
+        JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        CalendarEndDateBeforeStartDate toExport = new CalendarEndDateBeforeStartDate(
+                FILENAME,
+                "wkend",
+                LocalDateTime.of(2020, 2, 1, 12, 35, 59),
+                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+        );
         underTest.export(toExport);
 
         verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -25,7 +25,7 @@ import org.mockito.InOrder;
 
 import java.io.IOException;
 import java.net.URL;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import static org.mockito.Mockito.*;
 
@@ -548,8 +548,8 @@ class JsonNoticeExporterTest {
         CalendarEndDateBeforeStartDateNotice toExport = new CalendarEndDateBeforeStartDateNotice(
                 FILENAME,
                 "wkend",
-                LocalDateTime.of(2020, 2, 1, 12, 35, 59),
-                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+                LocalDate.of(2020, 2, 1),
+                LocalDate.of(2020, 1, 1)
         );
         underTest.export(toExport);
 

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -1158,7 +1158,7 @@ class ProtobufNoticeExporterTest {
         when(mockStreamGenerator.getStream()).thenReturn(mockStream);
 
         ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
-        underTest.export(new CalendarEndDateBeforeStartDate(
+        underTest.export(new CalendarEndDateBeforeStartDateNotice(
                 FILENAME,
                 "wkend",
                 LocalDateTime.of(2020, 2, 1, 12, 35, 59),

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -25,7 +25,7 @@ import org.mockito.ArgumentMatchers;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 import static org.mockito.Mockito.*;
 
@@ -1161,8 +1161,8 @@ class ProtobufNoticeExporterTest {
         underTest.export(new CalendarEndDateBeforeStartDateNotice(
                 FILENAME,
                 "wkend",
-                LocalDateTime.of(2020, 2, 1, 12, 35, 59),
-                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+                LocalDate.of(2020, 2, 1),
+                LocalDate.of(2020, 1, 1)
         ));
 
         verify(mockBuilder, times(1)).clear();

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -25,6 +25,7 @@ import org.mockito.ArgumentMatchers;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URL;
+import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.*;
 
@@ -1137,6 +1138,39 @@ class ProtobufNoticeExporterTest {
                 ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_ROUTE_SHORT_NAME_IS_CONTAINED_IN_LONG_NAME));
         verify(mockBuilder, times(1)).setSeverity(
                 ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.WARNING));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
+
+    @Test
+    void exportCalendarEndDateBeforeStartDateAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        underTest.export(new CalendarEndDateBeforeStartDate(
+                FILENAME,
+                "wkend",
+                LocalDateTime.of(2020, 2, 1, 12, 35, 59),
+                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+        ));
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(ArgumentMatchers.eq(FILENAME));
+        verify(mockBuilder, times(1)).setType(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CALENDAR_START_AND_END_DATE_OUT_OF_ORDER));
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
@@ -298,6 +298,16 @@ public class InMemoryGtfsDataRepository implements GtfsDataRepository {
     }
 
     /**
+     * Return a collection of Calendar objects representing all the rows from calendar.txt
+     *
+     * @return a collection of Calendar objects representing all the rows from calendar.txt
+     */
+    @Override
+    public Collection<Calendar> getCalendarAll() {
+        return calendarPerServiceId.values();
+    }
+
+    /**
      * Add a Transfer representing a row from transfers.txt to this {@link GtfsDataRepository}. Return the entity added
      * to the repository if the uniqueness constraint of route based on composite key from_stop_id and to_stop_id is
      * respected, if this requirement is not met, returns null.

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -137,6 +137,7 @@ public class Main {
                 config.validateRouteTypeIsInOptions().execute();
                 config.validateBothRouteNamesPresence().execute();
                 config.validateRouteLongNameDoesNotContainShortName().execute();
+                config.validateCalendarEndDateBeforeStartDate().execute();
 
                 config.cleanOrCreatePath().execute(ExecParamRepository.OUTPUT_KEY);
 

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -23,9 +23,9 @@ import org.mobilitydata.gtfsvalidator.db.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.RawFileInfo;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Level;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Level;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.fareattributes.FareAttribute;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.transfers.Transfer;
@@ -162,6 +162,10 @@ public class DefaultConfig {
 
     public ValidateRouteLongNameDoesNotContainOrEqualShortName validateRouteLongNameDoesNotContainShortName() {
         return new ValidateRouteLongNameDoesNotContainOrEqualShortName(gtfsDataRepository, resultRepo, logger);
+    }
+
+    public ValidateCalendarEndDateBeforeStartDate validateCalendarEndDateBeforeStartDate() {
+        return new ValidateCalendarEndDateBeforeStartDate(gtfsDataRepository, resultRepo, logger);
     }
 
     public ExportResultAsFile exportResultAsFile() {

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -83,5 +83,5 @@ public interface NoticeExporter {
 
     void export(RouteLongNameContainsShortNameNotice toExport) throws IOException;
 
-    void export(CalendarEndDateBeforeStartDate toExport) throws IOException;
+    void export(CalendarEndDateBeforeStartDateNotice toExport) throws IOException;
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -82,4 +82,6 @@ public interface NoticeExporter {
     void export(RouteLongNameEqualsShortNameNotice toExport) throws IOException;
 
     void export(RouteLongNameContainsShortNameNotice toExport) throws IOException;
+
+    void export(CalendarEndDateBeforeStartDate toExport) throws IOException;
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -46,6 +46,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final String E_026 = "E026";
     protected static final String E_027 = "E027";
     protected static final String E_028 = "E028";
+    protected static final String E_032 = "E032";
 
     public ErrorNotice(final String filename,
                        final String noticeId,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDate.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDate.java
@@ -1,0 +1,23 @@
+package org.mobilitydata.gtfsvalidator.domain.entity.notice.error;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+public class CalendarEndDateBeforeStartDate extends ErrorNotice {
+
+    public CalendarEndDateBeforeStartDate(final String filename, final String entityId, final LocalDateTime startDate, final LocalDateTime endDate) {
+        super(filename, E_032,
+                "calendar.txt end_date is before start_date",
+                "Then end_date of " + endDate.toString() + " occurs before the start_date of " + startDate.toString() +
+                        " for service_id:" + entityId + " in file:" + filename + ".",
+                entityId);
+    }
+
+    @Override
+    public void export(final NoticeExporter exporter) throws IOException {
+        exporter.export(this);
+    }
+}

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
@@ -11,8 +11,8 @@ public class CalendarEndDateBeforeStartDateNotice extends ErrorNotice {
     public CalendarEndDateBeforeStartDateNotice(final String filename, final String entityId, final LocalDateTime startDate, final LocalDateTime endDate) {
         super(filename, E_032,
                 "calendar.txt end_date is before start_date",
-                "Then end_date of " + endDate + " occurs before the start_date of " + startDate +
-                        " for service_id: " + entityId + " in file: " + filename + ".",
+                "Then end_date of " + endDate.toLocalDate() + " occurs before the start_date of " +
+                        startDate.toLocalDate() + " for service_id: " + entityId + " in file: " + filename + ".",
                 entityId);
     }
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
@@ -4,15 +4,16 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 public class CalendarEndDateBeforeStartDateNotice extends ErrorNotice {
 
-    public CalendarEndDateBeforeStartDateNotice(final String filename, final String entityId, final LocalDateTime startDate, final LocalDateTime endDate) {
+    public CalendarEndDateBeforeStartDateNotice(final String filename, final String entityId, final LocalDate startDate,
+                                                final LocalDate endDate) {
         super(filename, E_032,
                 "calendar.txt end_date is before start_date",
-                "Then end_date of " + endDate.toLocalDate() + " occurs before the start_date of " +
-                        startDate.toLocalDate() + " for service_id: " + entityId + " in file: " + filename + ".",
+                "Then end_date of " + endDate + " occurs before the start_date of " +
+                        startDate + " for service_id: " + entityId + " in file: " + filename + ".",
                 entityId);
     }
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
@@ -6,9 +6,9 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
 import java.io.IOException;
 import java.time.LocalDateTime;
 
-public class CalendarEndDateBeforeStartDate extends ErrorNotice {
+public class CalendarEndDateBeforeStartDateNotice extends ErrorNotice {
 
-    public CalendarEndDateBeforeStartDate(final String filename, final String entityId, final LocalDateTime startDate, final LocalDateTime endDate) {
+    public CalendarEndDateBeforeStartDateNotice(final String filename, final String entityId, final LocalDateTime startDate, final LocalDateTime endDate) {
         super(filename, E_032,
                 "calendar.txt end_date is before start_date",
                 "Then end_date of " + endDate.toString() + " occurs before the start_date of " + startDate.toString() +

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/CalendarEndDateBeforeStartDateNotice.java
@@ -11,8 +11,8 @@ public class CalendarEndDateBeforeStartDateNotice extends ErrorNotice {
     public CalendarEndDateBeforeStartDateNotice(final String filename, final String entityId, final LocalDateTime startDate, final LocalDateTime endDate) {
         super(filename, E_032,
                 "calendar.txt end_date is before start_date",
-                "Then end_date of " + endDate.toString() + " occurs before the start_date of " + startDate.toString() +
-                        " for service_id:" + entityId + " in file:" + filename + ".",
+                "Then end_date of " + endDate + " occurs before the start_date of " + startDate +
+                        " for service_id: " + entityId + " in file: " + filename + ".",
                 entityId);
     }
 

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDate.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDate.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2020. MobilityData IO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.CalendarEndDateBeforeStartDateNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+
+import java.util.Collection;
+
+/**
+ * Use case for E032 to validate that a calendar.txt end_date must not be earlier than the start_date.
+ */
+public class ValidateCalendarEndDateBeforeStartDate {
+    private final GtfsDataRepository dataRepo;
+    private final ValidationResultRepository resultRepo;
+    private final Logger logger;
+
+    /**
+     * @param dataRepo   a repository storing the data of a GTFS dataset
+     * @param resultRepo a repository storing information about the validation process
+     */
+    public ValidateCalendarEndDateBeforeStartDate(final GtfsDataRepository dataRepo,
+                                                  final ValidationResultRepository resultRepo,
+                                                  final Logger logger) {
+        this.dataRepo = dataRepo;
+        this.resultRepo = resultRepo;
+        this.logger = logger;
+    }
+
+    /**
+     * Use case execution method: Checks if `end_date` of a service record is earlier than the `start_date` for every
+     * Calendar entry in a {@link GtfsDataRepository}. A new notice is generated each time this condition is true.
+     * This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
+     */
+    public void execute() {
+        logger.info("Validating rule 'E032 - calendar.txt end_date is before start_date'" + System.lineSeparator());
+        Collection<Calendar> calendars = dataRepo.getCalendarAll();
+        calendars.stream()
+                .filter(calendar -> calendar.getEndDate().isBefore(calendar.getStartDate()))
+                .forEach(calendar -> resultRepo.addNotice(new CalendarEndDateBeforeStartDateNotice("calendar.txt",
+                        calendar.getServiceId(), calendar.getStartDate(), calendar.getEndDate())));
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
@@ -17,18 +17,17 @@
 package org.mobilitydata.gtfsvalidator.usecase.port;
 
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Level;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.fareattributes.FareAttribute;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.trips.Trip;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.transfers.Transfer;
-
-import java.util.Collection;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.trips.Trip;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
 
 public interface GtfsDataRepository {
     Agency addAgency(final Agency newAgency) throws IllegalArgumentException;
@@ -52,6 +51,8 @@ public interface GtfsDataRepository {
     Calendar addCalendar(final Calendar newCalendar) throws IllegalArgumentException;
 
     Calendar getCalendarByServiceId(final String serviceId);
+
+    Collection<Calendar> getCalendarAll();
 
     Trip addTrip(final Trip newTrip) throws IllegalArgumentException;
 

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
@@ -16,10 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.usecase.port;
 
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Level;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.fareattributes.FareAttribute;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDateNoticeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDateNoticeTest.java
@@ -1,0 +1,167 @@
+/*
+ * Copyright (c) 2020. MobilityData IO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.CalendarEndDateBeforeStartDateNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Unit tests to validate behavior of use case for "E032 - calendar.txt end_date is before start_date"
+ */
+class ValidateCalendarEndDateBeforeStartDateNoticeTest {
+
+    // TODO - below test throws an NPE, but calendar.txt start_date and end_date are required and marked @NonNull,
+    // so checking for them within the use case is flagged as "these fields are always non-null".
+    // Do we include a null test for required GTFS fields?
+
+//    @Test
+//    void nullCalendarStartAndEndDateShouldNotGenerateNotice() {
+//        Calendar mockCalendar = mock(Calendar.class);
+//        when(mockCalendar.getStartDate()).thenReturn(null);
+//        when(mockCalendar.getEndDate()).thenReturn(null);
+//
+//        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+//        when(mockDataRepo.getCalendarAll()).thenReturn(List.of(mockCalendar));
+//
+//        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+//
+//        Logger mockLogger = mock(Logger.class);
+//
+//        ValidateCalendarEndDateBeforeStartDate underTest = new ValidateCalendarEndDateBeforeStartDate(
+//                mockDataRepo,
+//                mockResultRepo,
+//                mockLogger);
+//
+//        underTest.execute();
+//
+//        verify(mockDataRepo, times(1)).getCalendarAll();
+//        verify(mockCalendar, times(1)).getStartDate();
+//        verify(mockCalendar, times(1)).getEndDate();
+//        verify(mockLogger, times(1)).info("Validating rule 'E032 - calendar.txt end_date is " +
+//                "before start_date'" + System.lineSeparator());
+//        verifyNoInteractions(mockResultRepo);
+//        verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
+//    }
+
+    @Test
+    void startDateBeforeEndDateShouldNotGenerateNotice() {
+        Calendar mockCalendar = mock(Calendar.class);
+        when(mockCalendar.getStartDate()).thenReturn(
+                LocalDateTime.of(2020, 1, 1, 12, 35, 59));
+        when(mockCalendar.getEndDate()).thenReturn(
+                LocalDateTime.of(2020, 2, 1, 12, 35, 59)
+        );
+
+        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getCalendarAll()).thenReturn(List.of(mockCalendar));
+
+        Logger mockLogger = mock(Logger.class);
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateCalendarEndDateBeforeStartDate underTest = new ValidateCalendarEndDateBeforeStartDate(
+                mockDataRepo,
+                mockResultRepo,
+                mockLogger);
+
+        underTest.execute();
+
+        verify(mockDataRepo, times(1)).getCalendarAll();
+        verify(mockCalendar, times(1)).getStartDate();
+        verify(mockCalendar, times(1)).getEndDate();
+        verify(mockLogger, times(1)).info("Validating rule 'E032 - calendar.txt end_date is " +
+                "before start_date'" + System.lineSeparator());
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
+    }
+
+    @Test
+    void sameStartAndEndDateShouldNotGenerateNotice() {
+        Calendar mockCalendar = mock(Calendar.class);
+        when(mockCalendar.getStartDate()).thenReturn(
+                LocalDateTime.of(2020, 1, 1, 12, 35, 59));
+        when(mockCalendar.getEndDate()).thenReturn(
+                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+        );
+
+        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getCalendarAll()).thenReturn(List.of(mockCalendar));
+
+        Logger mockLogger = mock(Logger.class);
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateCalendarEndDateBeforeStartDate underTest = new ValidateCalendarEndDateBeforeStartDate(
+                mockDataRepo,
+                mockResultRepo,
+                mockLogger);
+
+        underTest.execute();
+
+        verify(mockDataRepo, times(1)).getCalendarAll();
+        verify(mockCalendar, times(1)).getStartDate();
+        verify(mockCalendar, times(1)).getEndDate();
+        verify(mockLogger, times(1)).info("Validating rule 'E032 - calendar.txt end_date is " +
+                "before start_date'" + System.lineSeparator());
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
+    }
+
+    @Test
+    void endDateBeforeStartDateShouldGenerateNotice() {
+        Calendar mockCalendar = mock(Calendar.class);
+        when(mockCalendar.getStartDate()).thenReturn(
+                LocalDateTime.of(2020, 2, 1, 12, 35, 59));
+        when(mockCalendar.getEndDate()).thenReturn(
+                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+        );
+
+        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getCalendarAll()).thenReturn(List.of(mockCalendar));
+
+        Logger mockLogger = mock(Logger.class);
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateCalendarEndDateBeforeStartDate underTest = new ValidateCalendarEndDateBeforeStartDate(
+                mockDataRepo,
+                mockResultRepo,
+                mockLogger);
+
+        underTest.execute();
+
+        verify(mockDataRepo, times(1)).getCalendarAll();
+        verify(mockCalendar, times(2)).getStartDate();
+        verify(mockCalendar, times(2)).getEndDate();
+        verify(mockCalendar, times(1)).getServiceId();
+        verify(mockResultRepo, times(1))
+                .addNotice(any(CalendarEndDateBeforeStartDateNotice.class));
+        verify(mockLogger, times(1)).info("Validating rule 'E032 - calendar.txt end_date is " +
+                "before start_date'" + System.lineSeparator());
+        verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
+    }
+}

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDateNoticeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDateNoticeTest.java
@@ -34,39 +34,6 @@ import static org.mockito.Mockito.*;
  */
 class ValidateCalendarEndDateBeforeStartDateNoticeTest {
 
-    // TODO - below test throws an NPE, but calendar.txt start_date and end_date are required and marked @NonNull,
-    // so checking for them within the use case is flagged as "these fields are always non-null".
-    // Do we include a null test for required GTFS fields?
-
-//    @Test
-//    void nullCalendarStartAndEndDateShouldNotGenerateNotice() {
-//        Calendar mockCalendar = mock(Calendar.class);
-//        when(mockCalendar.getStartDate()).thenReturn(null);
-//        when(mockCalendar.getEndDate()).thenReturn(null);
-//
-//        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
-//        when(mockDataRepo.getCalendarAll()).thenReturn(List.of(mockCalendar));
-//
-//        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
-//
-//        Logger mockLogger = mock(Logger.class);
-//
-//        ValidateCalendarEndDateBeforeStartDate underTest = new ValidateCalendarEndDateBeforeStartDate(
-//                mockDataRepo,
-//                mockResultRepo,
-//                mockLogger);
-//
-//        underTest.execute();
-//
-//        verify(mockDataRepo, times(1)).getCalendarAll();
-//        verify(mockCalendar, times(1)).getStartDate();
-//        verify(mockCalendar, times(1)).getEndDate();
-//        verify(mockLogger, times(1)).info("Validating rule 'E032 - calendar.txt end_date is " +
-//                "before start_date'" + System.lineSeparator());
-//        verifyNoInteractions(mockResultRepo);
-//        verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
-//    }
-
     @Test
     void startDateBeforeEndDateShouldNotGenerateNotice() {
         Calendar mockCalendar = mock(Calendar.class);

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDateNoticeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateCalendarEndDateBeforeStartDateNoticeTest.java
@@ -23,7 +23,7 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.CalendarEndDate
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -34,13 +34,14 @@ import static org.mockito.Mockito.*;
  */
 class ValidateCalendarEndDateBeforeStartDateNoticeTest {
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void startDateBeforeEndDateShouldNotGenerateNotice() {
         Calendar mockCalendar = mock(Calendar.class);
         when(mockCalendar.getStartDate()).thenReturn(
-                LocalDateTime.of(2020, 1, 1, 12, 35, 59));
+                LocalDate.of(2020, 1, 1));
         when(mockCalendar.getEndDate()).thenReturn(
-                LocalDateTime.of(2020, 2, 1, 12, 35, 59)
+                LocalDate.of(2020, 2, 1)
         );
 
         GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
@@ -66,13 +67,14 @@ class ValidateCalendarEndDateBeforeStartDateNoticeTest {
         verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void sameStartAndEndDateShouldNotGenerateNotice() {
         Calendar mockCalendar = mock(Calendar.class);
         when(mockCalendar.getStartDate()).thenReturn(
-                LocalDateTime.of(2020, 1, 1, 12, 35, 59));
+                LocalDate.of(2020, 1, 1));
         when(mockCalendar.getEndDate()).thenReturn(
-                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+                LocalDate.of(2020, 1, 1)
         );
 
         GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
@@ -98,13 +100,14 @@ class ValidateCalendarEndDateBeforeStartDateNoticeTest {
         verifyNoMoreInteractions(mockCalendar, mockDataRepo, mockResultRepo, mockLogger);
     }
 
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void endDateBeforeStartDateShouldGenerateNotice() {
         Calendar mockCalendar = mock(Calendar.class);
         when(mockCalendar.getStartDate()).thenReturn(
-                LocalDateTime.of(2020, 2, 1, 12, 35, 59));
+                LocalDate.of(2020, 2, 1));
         when(mockCalendar.getEndDate()).thenReturn(
-                LocalDateTime.of(2020, 1, 1, 12, 35, 59)
+                LocalDate.of(2020, 1, 1)
         );
 
         GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);


### PR DESCRIPTION
**Summary:**

~~*Please don't merge - work-in-progress*~~

This PR implements a new validation rule for https://github.com/MobilityData/gtfs-validator/issues/133 - checking if `calendar.txt` `end_date` is before `start_date`.

I'm following the documentation at https://github.com/MobilityData/gtfs-validator/pull/251.

Done (Steps 1-4):
- [x] Rules.md
- [x] Notice impl
- [x] Exporters and tests impl

TODO (Steps 5-8):
- [x] Use case for rule impl
- [x] Use case test impl
- [x] Instantiate use case
- [x] Retrieve and execute use case
- [x] Resolve discussion for null test case on GTFS required fields (e.g., remove commented code)

Closes #133

**Expected behavior:** 

Execute a new rule for https://github.com/MobilityData/gtfs-validator/issues/133 checking if the calendar.txt record end date is before the start date.

**Other thoughts so far:** 
* Exporter test code, especially for protocol buffers, includes a lot of duplication
* In `ProtobufNoticeExporter`, maybe move inner class `ProtobufOutputStreamGenerator` to the top of the file so that new `export()` methods can just be added to the bottom of the file?
* Testing notice message output text would be useful - we hit a number of output message formatting bugs on the GTFS-RT validator, and it's always been on my TODO list to go back and add more unit tests for this. This would have also helped me catch an output issue related to https://github.com/MobilityData/gtfs-validator/issues/276 earlier.
* For use cases, each rule requires a loop through the entire list of entities being examined (e.g., loop through all routes). For `m` rules and `n` entities, that's a time complexity of O(m*n). You can probably get away with that for tables that typically have a small amount of records, but this design will definitely have a performance hit for tables with lots of records like shapes.txt, stop_times.txt, and (in some feed) calendar_dates.txt. We may want to consider an alternate design for rules on these tables where multiple rules are implemented in a single use case.
* For each use case, it would be helpful to document the rule ID (e.g., `E001`) in the Javadocs for the class.
* There should be an interface for rules (use cases) to enforce contract for methods
* In `DefaultConfig`, maybe move all validation rules to the end of the file so new rules just get added to the bottom? Right now it seems like they should be added in the middle of the class with the other `Validate*` methods
* Seems like it would greatly simplify the use of the configuration to support a `DefaultConfig.validateAll()` method for all semantic rules, rather than having to call all the individual `config.validate*()` methods

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)