### PR TITLE
Implement #255 -- Rework  command line options nomenclature

### DIFF
--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
@@ -183,12 +183,12 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                 return hasExecParamValue(key) ? getExecParamByKey(URL_KEY).getValue().get(0) : defaultValue.get(0);
             }
 
-            case ZIP_INPUT_KEY: {
-                String zipInputPath = hasExecParamValue(ZIP_INPUT_KEY)
-                        ? getExecParamByKey(ZIP_INPUT_KEY).getValue().get(0)
+            case INPUT_KEY: {
+                String zipInputPath = hasExecParamValue(INPUT_KEY)
+                        ? getExecParamByKey(INPUT_KEY).getValue().get(0)
                         : System.getProperty("user.dir");
 
-                if (!hasExecParamValue(URL_KEY) & !hasExecParamValue(ZIP_INPUT_KEY)) {
+                if (!hasExecParamValue(URL_KEY) & !hasExecParamValue(INPUT_KEY)) {
                     logger.info("--url and relative path to zip file(--zip option) not provided. Trying to " +
                             "find zip in: " + zipInputPath);
                     List<String> zipList;
@@ -211,7 +211,7 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                         logger.info("zip file found: " + zipList.get(0));
                         zipInputPath = zipList.get(0);
                     }
-                } else if (!hasExecParamValue(ZIP_INPUT_KEY)) {
+                } else if (!hasExecParamValue(INPUT_KEY)) {
                     zipInputPath += File.separator + "input.zip";
                 }
                 return zipInputPath;
@@ -238,7 +238,7 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
         final Options options = new Options();
         options.addOption(String.valueOf(URL_KEY.charAt(0)), URL_KEY, true,
                 "URL to GTFS zipped archive");
-        options.addOption(String.valueOf(ZIP_INPUT_KEY.charAt(0)), ZIP_INPUT_KEY, true,
+        options.addOption(String.valueOf(INPUT_KEY.charAt(0)), INPUT_KEY, true,
                 "if --url is used, where to place " +
                         "the downloaded archive. Otherwise, relative path pointing to a valid GTFS zipped archive on disk");
         options.addOption(String.valueOf(EXTRACT_KEY.charAt(0)), EXTRACT_KEY, true,

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
@@ -183,12 +183,12 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                 return hasExecParamValue(key) ? getExecParamByKey(URL_KEY).getValue().get(0) : defaultValue.get(0);
             }
 
-            case ZIP_KEY: {
-                String zipInputPath = hasExecParamValue(ZIP_KEY)
-                        ? getExecParamByKey(ZIP_KEY).getValue().get(0)
+            case ZIP_INPUT_KEY: {
+                String zipInputPath = hasExecParamValue(ZIP_INPUT_KEY)
+                        ? getExecParamByKey(ZIP_INPUT_KEY).getValue().get(0)
                         : System.getProperty("user.dir");
 
-                if (!hasExecParamValue(URL_KEY) & !hasExecParamValue(ZIP_KEY)) {
+                if (!hasExecParamValue(URL_KEY) & !hasExecParamValue(ZIP_INPUT_KEY)) {
                     logger.info("--url and relative path to zip file(--zip option) not provided. Trying to " +
                             "find zip in: " + zipInputPath);
                     List<String> zipList;
@@ -211,7 +211,7 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                         logger.info("zip file found: " + zipList.get(0));
                         zipInputPath = zipList.get(0);
                     }
-                } else if (!hasExecParamValue(ZIP_KEY)) {
+                } else if (!hasExecParamValue(ZIP_INPUT_KEY)) {
                     zipInputPath += File.separator + "input.zip";
                 }
                 return zipInputPath;
@@ -238,7 +238,7 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
         final Options options = new Options();
         options.addOption(String.valueOf(URL_KEY.charAt(0)), URL_KEY, true,
                 "URL to GTFS zipped archive");
-        options.addOption(String.valueOf(ZIP_KEY.charAt(0)), ZIP_KEY, true,
+        options.addOption(String.valueOf(ZIP_INPUT_KEY.charAt(0)), ZIP_INPUT_KEY, true,
                 "if --url is used, where to place " +
                         "the downloaded archive. Otherwise, relative path pointing to a valid GTFS zipped archive on disk");
         options.addOption(String.valueOf(EXTRACT_KEY.charAt(0)), EXTRACT_KEY, true,

--- a/config/src/main/resources/default-execution-parameters.json
+++ b/config/src/main/resources/default-execution-parameters.json
@@ -4,6 +4,6 @@
   "output": "output",
   "proto": false,
   "url": null,
-  "zipinput": null,
+  "input": null,
   "exclude": null
 }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/DownloadArchiveFromNetwork.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/DownloadArchiveFromNetwork.java
@@ -59,7 +59,7 @@ public class DownloadArchiveFromNetwork {
         if (execParamRepo.hasExecParamValue(execParamRepo.URL_KEY)) {
             logger.info("Downloading archive"+System.lineSeparator());
             final String url = execParamRepo.getExecParamValue(execParamRepo.URL_KEY);
-            final String targetPath = execParamRepo.getExecParamValue(execParamRepo.ZIP_INPUT_KEY);
+            final String targetPath = execParamRepo.getExecParamValue(execParamRepo.INPUT_KEY);
             try {
                 URL sourceUrl = new URL(url);
                 Files.copy(

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/DownloadArchiveFromNetwork.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/DownloadArchiveFromNetwork.java
@@ -59,7 +59,7 @@ public class DownloadArchiveFromNetwork {
         if (execParamRepo.hasExecParamValue(execParamRepo.URL_KEY)) {
             logger.info("Downloading archive"+System.lineSeparator());
             final String url = execParamRepo.getExecParamValue(execParamRepo.URL_KEY);
-            final String targetPath = execParamRepo.getExecParamValue(execParamRepo.ZIP_KEY);
+            final String targetPath = execParamRepo.getExecParamValue(execParamRepo.ZIP_INPUT_KEY);
             try {
                 URL sourceUrl = new URL(url);
                 Files.copy(

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/LogExecutionInfo.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/LogExecutionInfo.java
@@ -41,9 +41,9 @@ public class LogExecutionInfo {
      */
     public void execute() {
         if (execParamRepo.hasExecParamValue(execParamRepo.URL_KEY) & !execParamRepo
-                .hasExecParamValue(execParamRepo.ZIP_INPUT_KEY)) {
+                .hasExecParamValue(execParamRepo.INPUT_KEY)) {
             logger.info("--url provided but no location to place zip (--zip option). Using default: " +
-                    execParamRepo.getExecParamValue(execParamRepo.ZIP_INPUT_KEY) + System.lineSeparator());
+                    execParamRepo.getExecParamValue(execParamRepo.INPUT_KEY) + System.lineSeparator());
         }
 
         if (!execParamRepo.hasExecParamValue(execParamRepo.EXTRACT_KEY)) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/LogExecutionInfo.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/LogExecutionInfo.java
@@ -41,9 +41,9 @@ public class LogExecutionInfo {
      */
     public void execute() {
         if (execParamRepo.hasExecParamValue(execParamRepo.URL_KEY) & !execParamRepo
-                .hasExecParamValue(execParamRepo.ZIP_KEY)) {
+                .hasExecParamValue(execParamRepo.ZIP_INPUT_KEY)) {
             logger.info("--url provided but no location to place zip (--zip option). Using default: " +
-                    execParamRepo.getExecParamValue(execParamRepo.ZIP_KEY) + System.lineSeparator());
+                    execParamRepo.getExecParamValue(execParamRepo.ZIP_INPUT_KEY) + System.lineSeparator());
         }
 
         if (!execParamRepo.hasExecParamValue(execParamRepo.EXTRACT_KEY)) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/UnzipInputArchive.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/UnzipInputArchive.java
@@ -69,7 +69,7 @@ public class UnzipInputArchive {
 
         logger.info("Unzipping archive"+System.lineSeparator());
 
-        final String zipInputPath = execParamRepo.getExecParamValue(execParamRepo.ZIP_INPUT_KEY);
+        final String zipInputPath = execParamRepo.getExecParamValue(execParamRepo.INPUT_KEY);
         final ZipFile inputZip = new ZipFile(zipInputPath);
 
         Enumeration<? extends ZipEntry> zipEntries = inputZip.entries();

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/UnzipInputArchive.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/UnzipInputArchive.java
@@ -69,7 +69,7 @@ public class UnzipInputArchive {
 
         logger.info("Unzipping archive"+System.lineSeparator());
 
-        final String zipInputPath = execParamRepo.getExecParamValue(execParamRepo.ZIP_KEY);
+        final String zipInputPath = execParamRepo.getExecParamValue(execParamRepo.ZIP_INPUT_KEY);
         final ZipFile inputZip = new ZipFile(zipInputPath);
 
         Enumeration<? extends ZipEntry> zipEntries = inputZip.entries();

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ExecParamRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ExecParamRepository.java
@@ -33,7 +33,7 @@ public interface ExecParamRepository {
     String OUTPUT_KEY = "output";
     String PROTO_KEY = "proto";
     String URL_KEY = "url";
-    String ZIP_INPUT_KEY = "input";
+    String INPUT_KEY = "input";
     String EXCLUSION_KEY = "exclude";
 
     ExecParam getExecParamByKey(final String optionName);

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ExecParamRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ExecParamRepository.java
@@ -33,7 +33,7 @@ public interface ExecParamRepository {
     String OUTPUT_KEY = "output";
     String PROTO_KEY = "proto";
     String URL_KEY = "url";
-    String ZIP_KEY = "zipinput";
+    String ZIP_INPUT_KEY = "input";
     String EXCLUSION_KEY = "exclude";
 
     ExecParam getExecParamByKey(final String optionName);


### PR DESCRIPTION
**Summary:**

This PR provides support to rework the nomenclature used for command line options.
- `zipinput` -> input
- class constant `ZIP_KEY` -> `INPUT_KEY` 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~