### PR TITLE
Fix #279 - Avoid occasional NPE when processing FareAttribute entitites.

### DIFF
--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
@@ -201,7 +201,7 @@ public class FareAttribute extends GtfsEntity {
          * @param transferDuration length of time in seconds before a transfer expires
          * @return builder for future object creation
          */
-        public FareAttributeBuilder transferDuration(final int transferDuration) {
+        public FareAttributeBuilder transferDuration(final Integer transferDuration) {
             this.transferDuration = transferDuration;
             return this;
         }


### PR DESCRIPTION
**Summary:**

This PR provides support to avoid occasional NPE when executing use case `ProcessParsedFareAttribute`. 
This bug was caused by the type of variables used. In this case, `fare_attributes.transfer_duration` can be null.
To avoid this, reference type `Integer` should be used instead of primitive type `int` for argument of method `transferDuration`.

**Expected behavior:** 

No NPE.
<img width="1840" alt="Capture d’écran, le 2020-06-12 à 08 56 47" src="https://user-images.githubusercontent.com/35747326/84505259-6bf6f600-ac8b-11ea-8739-73929330edaa.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)