### PR TITLE
Fix #275 -- Handle absence of execution-parameters.json

### DIFF
--- a/adapter/parser/src/main/java/org/mobilitydata/gtfsvalidator/parser/JsonExecParamParser.java
+++ b/adapter/parser/src/main/java/org/mobilitydata/gtfsvalidator/parser/JsonExecParamParser.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.parser;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
+import com.google.common.base.Strings;
 import org.apache.logging.log4j.Logger;
 import org.mobilitydata.gtfsvalidator.domain.entity.ExecParam;
 import org.mobilitydata.gtfsvalidator.usecase.port.ExecParamRepository;
@@ -58,13 +59,18 @@ public class JsonExecParamParser implements ExecParamRepository.ExecParamParser 
     @Override
     public Map<String, ExecParam> parse() {
         final Map<String, ExecParam> toReturn = new HashMap<>();
+        if (Strings.isNullOrEmpty(parameterJsonString)) {
+            logger.info("could not find execution-parameters.json file  -- will consider default values for" +
+                    " execution parameters" + System.lineSeparator());
+            return toReturn;
+        }
         try {
             objectReader.readTree(parameterJsonString).fields()
-                    .forEachRemaining(field -> toReturn.put(field.getKey(), new ExecParam(field.getKey(), field.getValue().asText())));
+                    .forEachRemaining(field -> toReturn.put(field.getKey(), new ExecParam(field.getKey(),
+                            field.getValue().asText())));
             return toReturn;
         } catch (JsonProcessingException e) {
-            logger.info("could not find execution-parameters.json file  -- will consider default values for" +
-                    " execution parameters");
+            logger.error("An error occurred" + e.getMessage());
             return toReturn;
         }
     }

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepository.java
@@ -148,7 +148,7 @@ public class InMemoryExecParamRepository implements ExecParamRepository {
                                      final String[] args,
                                      final Logger logger) {
         if (Strings.isNullOrEmpty(parameterJsonString) && args.length == 0) {
-            // true when json configuration file is not present  and no arguments are not provided
+            // true when json configuration file is not present and no arguments are provided
             logger.info("No configuration file nor arguments provided"+System.lineSeparator());
             return new JsonExecParamParser(parameterJsonString, new ObjectMapper().readerFor(ExecParam.class), logger);
         } else if (!Strings.isNullOrEmpty(parameterJsonString) || args.length == 0) {

--- a/adapter/repository/in-memory-simple/src/test/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepositoryTest.java
+++ b/adapter/repository/in-memory-simple/src/test/java/org/mobilitydata/gtfsvalidator/db/InMemoryExecParamRepositoryTest.java
@@ -152,26 +152,54 @@ class InMemoryExecParamRepositoryTest {
     }
 
     @Test
-    void getParserShouldReturnApacheExecParamParser() {
-        final String[] mockString = new String[1];
+    void provideCmdLineOptionAndZeroJsonConfigFileShouldReturnApacheExecParamParser() {
+        final String[] mockArgument = new String[1];
 
         final Logger mockLogger = mock(Logger.class);
         final ExecParamRepository underTest = new InMemoryExecParamRepository(DEFAULT_EXEC_PARAMETERS, mockLogger);
 
         final ExecParamRepository.ExecParamParser toCheck = underTest.getParser(null,
-                mockString, mockLogger);
+                mockArgument, mockLogger);
         assertTrue(toCheck instanceof ApacheExecParamParser);
     }
 
     @Test
-    void getParserShouldReturnJsonExecParamParser() {
-        final String[] mockString = new String[0];
-        final String mockExecParam = "";
+    void provideZeroCmdLineOptionAndOneValidJsonConfigFileShouldReturnJsonExecParamParser() {
+        final String[] mockArgument = new String[0];
+        final String mockJsonConfigFile = "{\n" +
+                "  \"key_test\": \"value_test\"\n" +
+                "}";
 
         final Logger mockLogger = mock(Logger.class);
         final ExecParamRepository underTest = new InMemoryExecParamRepository(DEFAULT_EXEC_PARAMETERS, mockLogger);
 
-        final ExecParamRepository.ExecParamParser toCheck = underTest.getParser(mockExecParam, mockString, mockLogger);
+        final ExecParamRepository.ExecParamParser toCheck = underTest.getParser(mockJsonConfigFile, mockArgument, mockLogger);
+        assertTrue(toCheck instanceof JsonExecParamParser);
+    }
+
+    @Test
+    void provideZeroCmdLineOptionAndZeroValidJsonConfigFileShouldReturnJsonExecParamParser() {
+        final String[] mockArgument = new String[0];
+        final String mockJsonConfigFile = null;
+
+        final Logger mockLogger = mock(Logger.class);
+        final ExecParamRepository underTest = new InMemoryExecParamRepository(DEFAULT_EXEC_PARAMETERS, mockLogger);
+
+        final ExecParamRepository.ExecParamParser toCheck = underTest.getParser(mockJsonConfigFile, mockArgument, mockLogger);
+        assertTrue(toCheck instanceof JsonExecParamParser);
+    }
+
+    @Test
+    void provideBothCmdLineOptionAndValidJsonConfigFileShouldReturnJsonExecParamParser() {
+        final String[] mockArgument = new String[3];
+        final String mockJsonConfigFile = "{\n" +
+                "  \"key_test\": \"value_test\"\n" +
+                "}";
+
+        final Logger mockLogger = mock(Logger.class);
+        final ExecParamRepository underTest = new InMemoryExecParamRepository(DEFAULT_EXEC_PARAMETERS, mockLogger);
+
+        final ExecParamRepository.ExecParamParser toCheck = underTest.getParser(mockJsonConfigFile, mockArgument, mockLogger);
         assertTrue(toCheck instanceof JsonExecParamParser);
     }
 

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -143,11 +143,7 @@ public class Main {
                 config.exportResultAsFile().execute();
             }
         } catch (IOException e) {
-            if (e.getMessage().contains("execution-parameters.json")) {
-                config.printHelp().execute();
-            } else {
-                logger.error("An exception occurred: " + e);
-            }
+            logger.error("An exception occurred: " + e);
         }
         logger.info("Took " + TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startTime) + "ms");
     }

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -89,10 +89,10 @@ public class DefaultConfig {
         this.executionParametersAsString = null;
         try {
             this.executionParametersAsString = Files.readString(Paths.get("execution-parameters.json"));
-            logger.info("Configuration file with name execution-parameters.json found in working directory" +
+            logger.info("Configuration file execution-parameters.json found in working directory" +
                     System.lineSeparator());
         } catch (IOException e) {
-            logger.warn("Configuration file with name execution-parameters.json not found in working directory" +
+            logger.warn("Configuration file execution-parameters.json not found in working directory" +
                     System.lineSeparator());
         }
         specRepo = new InMemoryGtfsSpecRepository(gtfsSpecProtobufString, gtfsSchemaAsString);

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -23,9 +23,9 @@ import org.mobilitydata.gtfsvalidator.db.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.RawFileInfo;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Level;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Level;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.fareattributes.FareAttribute;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.transfers.Transfer;
@@ -50,6 +50,7 @@ public class DefaultConfig {
     private final GtfsSpecRepository specRepo;
     private final ExecParamRepository execParamRepo;
     private final Logger logger;
+    private String executionParametersAsString;
 
     @SuppressWarnings("UnstableApiUsage")
     public DefaultConfig(final Logger logger) {
@@ -83,6 +84,16 @@ public class DefaultConfig {
                     StandardCharsets.UTF_8);
         } catch (IOException e) {
             e.printStackTrace();
+        }
+
+        this.executionParametersAsString = null;
+        try {
+            this.executionParametersAsString = Files.readString(Paths.get("execution-parameters.json"));
+            logger.info("Configuration file with name execution-parameters.json found in working directory" +
+                    System.lineSeparator());
+        } catch (IOException e) {
+            logger.warn("Configuration file with name execution-parameters.json not found in working directory" +
+                    System.lineSeparator());
         }
         specRepo = new InMemoryGtfsSpecRepository(gtfsSpecProtobufString, gtfsSchemaAsString);
     }
@@ -168,8 +179,8 @@ public class DefaultConfig {
         return new ExportResultAsFile(resultRepo, execParamRepo, logger);
     }
 
-    public ParseAllExecParam parseAllExecutionParameter() throws IOException {
-        return new ParseAllExecParam(Files.readString(Paths.get("execution-parameters.json")), execParamRepo,
+    public ParseAllExecParam parseAllExecutionParameter() {
+        return new ParseAllExecParam(executionParametersAsString, execParamRepo,
                 logger);
     }
 

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/PrintHelp.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/PrintHelp.java
@@ -45,7 +45,7 @@ public class PrintHelp {
      * repository provided in the constructor or if the ExecParamRepository provided in the constructor is empty.
      */
     public boolean execute() {
-        if (Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.HELP_KEY)) || execParamRepo.isEmpty()) {
+        if (Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.HELP_KEY))) {
 
             Options options = execParamRepo.getOptions();
 


### PR DESCRIPTION
**Summary:**

This PR provides support to avoid the display of help text when not providing configuration file `execution-parameters.json`.

A new variable `executionParametersAsString` is defined. It is `null` when the file could not be find, or the `String `representation of the `.json` configuration file.

This variables is defined through a `try/catch`  block.

Additional logging information is provided regarding the absence/presence of said file.

**Expected behavior:** 

When file `execution-parameter.json` is not provided 2 possible behavior are expected:
- command line options have been provided -> we use them as execution parameters

- command line options have not been provided -> default values for execution parameters should be used.

In both cases message `"Configuration file execution-parameters.json not found in working directory"` should be logged.


<img width="1242" alt="Capture d’écran, le 2020-06-15 à 10 56 12" src="https://user-images.githubusercontent.com/35747326/84672717-e11a3380-aef6-11ea-8d06-d7ee6b0033af.png">

In the opposite scenario, if file `execution-parameters.json` is provided, message `"Configuration file execution-parameters.json found in working directory"` should be logged.

<img width="1280" alt="Capture d’écran, le 2020-06-15 à 10 54 11" src="https://user-images.githubusercontent.com/35747326/84672527-a6180000-aef6-11ea-8d70-67f988f12d02.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)