### PR TITLE
Update release notes to include bumping CI version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,8 @@ Increment the `version` in the various `build.gradle` files and add the `-SNAPSH
 
 For example, if the version you just released is `1.1.0`, change the `version` to `1.1.1-SNAPSHOT`.
 
+Update the GitHub CI [config file](https://github.com/MobilityData/gtfs-validator/blob/master/.github/workflows/gradle.yml) to point to the new `SNAPSHOT` version.
+
 For more details on versioning, see [Understanding Maven Version Numbers](https://docs.oracle.com/middleware/1212/core/MAVEN/maven_version.htm#MAVEN8855).
 
 


### PR DESCRIPTION
**Summary:**

Following the merge of https://github.com/MobilityData/gtfs-validator/pull/253, we need to update the version name in the GitHub CI each release.

**Expected behavior:** 

New release notes include instructions to bump CI version too.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)