### PR TITLE
Fix #291 - Make GitHub CI run on fork pull requests

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,6 +1,10 @@
 name: Java CI
 
-on: [push]
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 jobs:
   build:


### PR DESCRIPTION
**Summary:**

Change the CI configuration to run on pull requests coming from forks too

**Expected behavior:** 

This should fix GitHub so it runs on pull requests from forks.

~~I'm opening this PR from a fork, but IIRC GitHub CI only runs using the config from the master branch. So we may need to merge this PR before we see any change.~~ **EDIT** Just kidding, it's working!

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)