### PR TITLE
Implement #290 - Improve GTFS entity builders

### DIFF
--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Agency.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Agency.java
@@ -255,7 +255,7 @@ public class Agency extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public AgencyBuilder clearFieldAll() {
+        public AgencyBuilder clear() {
             agencyId = null;
             agencyName = null;
             agencyUrl = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Agency.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Agency.java
@@ -230,8 +230,6 @@ public class Agency extends GtfsEntity {
          * are met. Otherwise, method returns an entity representing a list of notices.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (agencyName == null || agencyUrl == null || agencyTimezone == null) {
 
                 if (agencyName == null) {
@@ -251,6 +249,23 @@ public class Agency extends GtfsEntity {
                 return new EntityBuildResult<>(new Agency(agencyId, agencyName, agencyUrl, agencyTimezone, agencyLang,
                         agencyPhone, agencyFareUrl, agencyEmail));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public AgencyBuilder clearFieldAll() {
+            agencyId = null;
+            agencyName = null;
+            agencyUrl = null;
+            agencyTimezone = null;
+            agencyLang = null;
+            agencyPhone = null;
+            agencyFareUrl = null;
+            agencyEmail = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Attribution.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Attribution.java
@@ -162,11 +162,11 @@ public class Attribution extends GtfsEntity {
         private String routeId;
         private String tripId;
         private String organizationName;
-        private boolean isProducer;
+        private Boolean isProducer;
         private Integer originalIsProducerInteger;
-        private boolean isAuthority;
+        private Boolean isAuthority;
         private Integer originalIsAuthorityInteger;
-        private boolean isOperator;
+        private Boolean isOperator;
         private Integer originalIsOperatorInteger;
         private String attributionUrl;
         private String attributionEmail;
@@ -321,7 +321,6 @@ public class Attribution extends GtfsEntity {
          * official GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
             if (organizationName == null ||
                     (originalIsOperatorInteger != null &&
                             (originalIsOperatorInteger < 0 || originalIsOperatorInteger > 1)) ||
@@ -369,6 +368,29 @@ public class Attribution extends GtfsEntity {
                         organizationName, isProducer, isOperator, isAuthority, attributionUrl, attributionEmail,
                         attributionPhone));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public AttributionBuilder clearFieldAll() {
+            attributionId = null;
+            agencyId = null;
+            routeId = null;
+            tripId = null;
+            organizationName = null;
+            isProducer = null;
+            originalIsProducerInteger = null;
+            isAuthority = null;
+            originalIsAuthorityInteger = null;
+            isOperator = null;
+            originalIsOperatorInteger = null;
+            attributionUrl = null;
+            attributionEmail = null;
+            attributionPhone = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Attribution.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Attribution.java
@@ -321,6 +321,7 @@ public class Attribution extends GtfsEntity {
          * official GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
+            noticeCollection.clear();
             if (organizationName == null ||
                     (originalIsOperatorInteger != null &&
                             (originalIsOperatorInteger < 0 || originalIsOperatorInteger > 1)) ||
@@ -331,9 +332,9 @@ public class Attribution extends GtfsEntity {
                     ((isAuthority == isProducer) && (isAuthority == isOperator) &&
                             (originalIsProducerInteger == null || originalIsProducerInteger == 0))
             ) {
-                final String entityId = attributionId + "; " + agencyId + "; " + routeId + "; " + tripId + "; " +
-                        organizationName + "; " + isProducer + "; " + isOperator + "; " + isAuthority + "; " +
-                        attributionUrl + "; " + attributionEmail + "; " + attributionPhone;
+                final String entityId = getAttributionMappingKey(attributionId, agencyId, routeId, tripId,
+                        organizationName, isProducer, isOperator, isAuthority, attributionUrl, attributionEmail,
+                        attributionPhone);
 
                 if (organizationName == null) {
                     noticeCollection.add(new MissingRequiredValueNotice("attributions.txt",
@@ -401,8 +402,8 @@ public class Attribution extends GtfsEntity {
      */
     public static String getAttributionMappingKey(final String attributionId, final String agencyId,
                                                   final String routeId, final String tripId,
-                                                  final String organizationName, final boolean isProducer,
-                                                  final boolean isOperator, final boolean isAuthority,
+                                                  final String organizationName, final Boolean isProducer,
+                                                  final Boolean isOperator, final Boolean isAuthority,
                                                   final String attributionUrl, final String attributionEmail,
                                                   final String attributionPhone) {
         return attributionId+agencyId+routeId+tripId+organizationName+isProducer+isOperator+isAuthority+attributionUrl+

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Attribution.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Attribution.java
@@ -375,7 +375,7 @@ public class Attribution extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public AttributionBuilder clearFieldAll() {
+        public AttributionBuilder clear() {
             attributionId = null;
             agencyId = null;
             routeId = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Calendar.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Calendar.java
@@ -354,7 +354,6 @@ public class Calendar extends GtfsEntity {
          * are met. Otherwise, method returns list of {@link Notice}.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
             if (monday == null || tuesday == null || wednesday == null || thursday == null || friday == null
                     || saturday == null || sunday == null || startDate == null || endDate == null || serviceId == null) {
                 if (originalMondayInteger == null) {
@@ -431,6 +430,32 @@ public class Calendar extends GtfsEntity {
                 return new EntityBuildResult<>(new Calendar(serviceId, monday, tuesday, wednesday, thursday, friday,
                         saturday, sunday, startDate, endDate));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public CalendarBuilder clearFieldAll() {
+            serviceId = null;
+            monday = null;
+            originalMondayInteger = null;
+            tuesday = null;
+            originalTuesdayInteger = null;
+            wednesday = null;
+            originalWednesdayInteger = null;
+            thursday = null;
+            originalThursdayInteger = null;
+            friday = null;
+            originalFridayInteger = null;
+            saturday = null;
+            originalSaturdayInteger = null;
+            sunday = null;
+            originalSundayInteger = null;
+            startDate = null;
+            endDate = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Calendar.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Calendar.java
@@ -436,7 +436,7 @@ public class Calendar extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public CalendarBuilder clearFieldAll() {
+        public CalendarBuilder clear() {
             serviceId = null;
             monday = null;
             originalMondayInteger = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FareRule.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FareRule.java
@@ -176,7 +176,7 @@ public class FareRule extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public FareRuleBuilder clearFieldAll() {
+        public FareRuleBuilder clear() {
             fareId = null;
             routeId = null;
             originId = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FareRule.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FareRule.java
@@ -163,8 +163,6 @@ public class FareRule extends GtfsEntity {
          * official GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (fareId == null) {
                 noticeCollection.add(new MissingRequiredValueNotice("fare_rules.txt", "fare_id",
                         fareId));
@@ -172,6 +170,20 @@ public class FareRule extends GtfsEntity {
             } else {
                 return new EntityBuildResult<>(new FareRule(fareId, routeId, originId, destinationId, containsId));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public FareRuleBuilder clearFieldAll() {
+            fareId = null;
+            routeId = null;
+            originId = null;
+            destinationId = null;
+            containsId = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FeedInfo.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FeedInfo.java
@@ -256,7 +256,7 @@ public class FeedInfo extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public FeedInfoBuilder clearFieldAll() {
+        public FeedInfoBuilder clear() {
             feedPublisherName = null;
             feedPublisherUrl = null;
             feedLang = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FeedInfo.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/FeedInfo.java
@@ -232,8 +232,6 @@ public class FeedInfo extends GtfsEntity {
          * GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (feedPublisherName == null || feedPublisherUrl == null || feedLang == null) {
                 if (feedPublisherName == null) {
                     noticeCollection.add(new MissingRequiredValueNotice("feed_info.txt",
@@ -252,6 +250,23 @@ public class FeedInfo extends GtfsEntity {
                 return new EntityBuildResult<>(new FeedInfo(feedPublisherName, feedPublisherUrl, feedLang,
                         feedStartDate, feedEndDate, feedVersion, feedContactEmail, feedContactUrl));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public FeedInfoBuilder clearFieldAll() {
+            feedPublisherName = null;
+            feedPublisherUrl = null;
+            feedLang = null;
+            feedStartDate = null;
+            feedEndDate = null;
+            feedVersion = null;
+            feedContactEmail = null;
+            feedContactUrl = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Level.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Level.java
@@ -137,7 +137,7 @@ public class Level extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public LevelBuilder clearFieldAll() {
+        public LevelBuilder clear() {
             levelId = null;
             levelIndex = null;
             levelName = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Level.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/Level.java
@@ -118,8 +118,6 @@ public class Level extends GtfsEntity {
          * GTFS specification are met. Otherwise, method returns an entity representing a collection of notices.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (levelId == null || levelIndex == null) {
                 if (levelId == null) {
                     noticeCollection.add(new MissingRequiredValueNotice("levels.txt", "level_id",
@@ -133,6 +131,18 @@ public class Level extends GtfsEntity {
             } else {
                 return new EntityBuildResult<>(new Level(levelId, levelIndex, levelName));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public LevelBuilder clearFieldAll() {
+            levelId = null;
+            levelIndex = null;
+            levelName = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/calendardates/CalendarDate.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/calendardates/CalendarDate.java
@@ -120,7 +120,6 @@ public class CalendarDate extends GtfsEntity {
          * official GTFS specification are met. Otherwise, method returns a collection of notices describing the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
             if (serviceId == null || date == null || exceptionType == null) {
                 if (serviceId == null) {
                     noticeCollection.add(new MissingRequiredValueNotice("calendar_dates.txt",
@@ -143,6 +142,19 @@ public class CalendarDate extends GtfsEntity {
             } else {
                 return new EntityBuildResult<>(new CalendarDate(serviceId, date, exceptionType));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public CalendarDateBuilder clearFieldAll() {
+            serviceId = null;
+            date = null;
+            exceptionType = null;
+            originalExceptionTypeInteger = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/calendardates/CalendarDate.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/calendardates/CalendarDate.java
@@ -148,7 +148,7 @@ public class CalendarDate extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public CalendarDateBuilder clearFieldAll() {
+        public CalendarDateBuilder clear() {
             serviceId = null;
             date = null;
             exceptionType = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
@@ -215,8 +215,6 @@ public class FareAttribute extends GtfsEntity {
          * official GTFS specification are met. Otherwise, method returns a collection pf notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (price == null || price < 0 || fareId == null || currencyType == null ||
                     !PaymentMethod.isEnumValueValid(originalPaymentMethodInteger) ||
                     !Transfers.isEnumValueValid(originalTransferInteger) ||

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
@@ -271,7 +271,7 @@ public class FareAttribute extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public FareAttributeBuilder clearFieldAll() {
+        public FareAttributeBuilder clear() {
             fareId = null;
             price = null;
             currencyType = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
@@ -268,5 +268,23 @@ public class FareAttribute extends GtfsEntity {
             return new EntityBuildResult<>(new FareAttribute(fareId, price, currencyType, paymentMethod, transfers,
                     agencyId, transferDuration));
         }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public FareAttributeBuilder clearFieldAll() {
+            fareId = null;
+            price = null;
+            currencyType = null;
+            paymentMethod = null;
+            transfers = null;
+            agencyId = null;
+            transferDuration = null;
+            originalPaymentMethodInteger = null;
+            originalTransferInteger = null;
+            noticeCollection.clear();
+            return this;
+        }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/pathways/Pathway.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/pathways/Pathway.java
@@ -327,8 +327,6 @@ public class Pathway extends GtfsEntity {
          * official GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (pathwayId == null ||
                     fromStopId == null ||
                     toStopId == null ||

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/pathways/Pathway.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/pathways/Pathway.java
@@ -399,7 +399,7 @@ public class Pathway extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public PathwayBuilder clearFieldAll() {
+        public PathwayBuilder clear() {
             pathwayId = null;
             fromStopId = null;
             toStopId = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/pathways/Pathway.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/pathways/Pathway.java
@@ -396,5 +396,28 @@ public class Pathway extends GtfsEntity {
                         reversedSignpostedAs));
             }
         }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public PathwayBuilder clearFieldAll() {
+            pathwayId = null;
+            fromStopId = null;
+            toStopId = null;
+            pathwayMode = null;
+            isBidirectional = null;
+            length = null;
+            traversalTime = null;
+            stairCount = null;
+            maxSlope = null;
+            minWidth = null;
+            signpostedAs = null;
+            reversedSignpostedAs = null;
+            originalPathwayModeInteger = null;
+            originalIsBiDirectionalInteger = null;
+            noticeCollection.clear();
+            return this;
+        }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
@@ -300,7 +300,7 @@ public class Route extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public RouteBuilder clearFieldAll() {
+        public RouteBuilder clear() {
             routeId = null;
             agencyId = null;
             routeShortName = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
@@ -276,8 +276,6 @@ public class Route extends GtfsEntity {
          * are met. Otherwise, method returns an entity representing a list of notices.
          */
         public EntityBuildResult<?> build() throws IllegalArgumentException {
-            noticeCollection.clear();
-
             if (routeId == null || routeType == null) {
                 if (routeId == null) {
                     noticeCollection.add(new MissingRequiredValueNotice("routes.txt", "route_id",
@@ -296,6 +294,26 @@ public class Route extends GtfsEntity {
                 return new EntityBuildResult(new Route(routeId, agencyId, routeShortName, routeLongName, routeDesc,
                         routeType, routeUrl, routeColor, routeTextColor, routeSortOrder));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public RouteBuilder clearFieldAll() {
+            routeId = null;
+            agencyId = null;
+            routeShortName = null;
+            routeLongName = null;
+            routeDesc = null;
+            routeType = null;
+            routeUrl = null;
+            routeColor = null;
+            routeTextColor = null;
+            routeSortOrder = null;
+            originalRouteTypeInteger = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/transfers/Transfer.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/transfers/Transfer.java
@@ -147,8 +147,6 @@ public class Transfer extends GtfsEntity {
          * GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues,
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (fromStopId == null || toStopId == null || transferType == null ||
                     (minTransferTime != null && minTransferTime < 0)) {
 
@@ -175,6 +173,20 @@ public class Transfer extends GtfsEntity {
             } else {
                 return new EntityBuildResult<>(new Transfer(fromStopId, toStopId, transferType, minTransferTime));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public TransferBuilder clearFieldAll() {
+            fromStopId = null;
+            toStopId = null;
+            transferType = null;
+            originalTransferTypeInteger = null;
+            minTransferTime = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/transfers/Transfer.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/transfers/Transfer.java
@@ -179,7 +179,7 @@ public class Transfer extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public TransferBuilder clearFieldAll() {
+        public TransferBuilder clear() {
             fromStopId = null;
             toStopId = null;
             transferType = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/trips/Trip.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/trips/Trip.java
@@ -321,7 +321,7 @@ public class Trip extends GtfsEntity {
          * Method to reset all fields of builder. Returns builder with all fields set to null.
          * @return builder with all fields set to null;
          */
-        public TripBuilder clearFieldAll() {
+        public TripBuilder clear() {
             routeId = null;
             serviceId = null;
             tripId = null;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/trips/Trip.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/trips/Trip.java
@@ -281,8 +281,6 @@ public class Trip extends GtfsEntity {
          * GTFS specification are met. Otherwise, method returns a collection of notices specifying the issues.
          */
         public EntityBuildResult<?> build() {
-            noticeCollection.clear();
-
             if (routeId == null || serviceId == null || tripId == null ||
                     !DirectionId.isEnumValueValid(originalDirectionIdInteger) ||
                     !WheelchairAccessibleStatus.isEnumValueValid(originalWheelchairAccessibleStatusInteger) ||
@@ -317,6 +315,28 @@ public class Trip extends GtfsEntity {
                 return new EntityBuildResult<>(new Trip(routeId, serviceId, tripId, tripHeadsign, tripShortName,
                         directionId, blockId, shapeId, wheelchairAccessibleStatus, bikesAllowedStatus));
             }
+        }
+
+        /**
+         * Method to reset all fields of builder. Returns builder with all fields set to null.
+         * @return builder with all fields set to null;
+         */
+        public TripBuilder clearFieldAll() {
+            routeId = null;
+            serviceId = null;
+            tripId = null;
+            tripHeadsign = null;
+            tripShortName = null;
+            directionId = null;
+            blockId = null;
+            shapeId = null;
+            wheelchairAccessibleStatus = null;
+            bikesAllowedStatus = null;
+            originalWheelchairAccessibleStatusInteger = null;
+            originalBikesAllowedStatusInteger = null;
+            originalDirectionIdInteger = null;
+            noticeCollection.clear();
+            return this;
         }
     }
 }

--- a/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/AttributionTest.java
+++ b/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/AttributionTest.java
@@ -37,7 +37,7 @@ class AttributionTest {
         final EntityBuildResult<?> entityBuildResult = underTest.organizationName(null)
                 .isProducer(1)
                 .build();
-        final String entityId = "null; null; null; null; null; true; false; false; null; null; null";
+        final String entityId = "nullnullnullnullnulltruenullnullnullnullnull";
         assertTrue(entityBuildResult.getData() instanceof List);
         //noinspection unchecked to avoid lint
         final List<MissingRequiredValueNotice> noticeCollection =
@@ -58,7 +58,7 @@ class AttributionTest {
                 .isProducer(4)
                 .isAuthority(1)
                 .build();
-        final String entityId = "null; null; null; null; organization name; false; false; true; null; null; null";
+        final String entityId = "nullnullnullnullorganization namefalsenulltruenullnullnull";
         assertTrue(entityBuildResult.getData() instanceof List);
         //  Warning suppressed since this test is designed so that method .getData() returns a list of notices. Thereby,
         // there is no need for cast check
@@ -84,7 +84,7 @@ class AttributionTest {
                 .isProducer(1)
                 .isOperator(4)
                 .build();
-        final String entityId = "null; null; null; null; organization name; true; false; false; null; null; null";
+        final String entityId = "nullnullnullnullorganization nametruefalsenullnullnullnull";
         assertTrue(entityBuildResult.getData() instanceof List);
         //  Warning suppressed since this test is designed so that method .getData() returns a list of notices. Thereby,
         // there is no need for cast check
@@ -110,7 +110,7 @@ class AttributionTest {
                 .isProducer(1)
                 .isAuthority(4)
                 .build();
-        final String entityId = "null; null; null; null; organization name; true; false; false; null; null; null";
+        final String entityId = "nullnullnullnullorganization nametruenullfalsenullnullnull";
         assertTrue(entityBuildResult.getData() instanceof List);
         //  Warning suppressed since this test is designed so that method .getData() returns a list of notices. Thereby,
         // there is no need for cast check
@@ -137,7 +137,7 @@ class AttributionTest {
                 .isAuthority(0)
                 .isOperator(0)
                 .build();
-        final String entityId = "null; null; null; null; organization name; false; false; false; null; null; null";
+        final String entityId = "nullnullnullnullorganization namefalsefalsefalsenullnullnull";
         assertTrue(entityBuildResult.getData() instanceof List);
         //  Warning suppressed since this test is designed so that method .getData() returns a list of notices. Thereby,
         // there is no need for cast check

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgency.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgency.java
@@ -63,7 +63,7 @@ public class ProcessParsedAgency {
         final String agencyFareUrl = (String) validatedAgencyEntity.get("agency_fare_url");
         final String agencyEmail = (String) validatedAgencyEntity.get("agency_email");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .agencyId(agencyId)
                 .agencyName(agencyName)
                 .agencyUrl(agencyUrl)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgency.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgency.java
@@ -63,7 +63,8 @@ public class ProcessParsedAgency {
         final String agencyFareUrl = (String) validatedAgencyEntity.get("agency_fare_url");
         final String agencyEmail = (String) validatedAgencyEntity.get("agency_email");
 
-        builder.agencyId(agencyId)
+        builder.clearFieldAll()
+                .agencyId(agencyId)
                 .agencyName(agencyName)
                 .agencyUrl(agencyUrl)
                 .agencyTimezone(agencyTimezone)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttribution.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttribution.java
@@ -67,6 +67,7 @@ public class ProcessParsedAttribution {
         final String attributionPhone = (String) validatedAttributionEntity.get("attribution_phone");
 
         final EntityBuildResult<?> attribution = builder.attributionId(attributionId)
+                .clearFieldAll()
                 .agencyId(agencyId)
                 .routeId(routeId)
                 .tripId(tripId)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttribution.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttribution.java
@@ -67,7 +67,7 @@ public class ProcessParsedAttribution {
         final String attributionPhone = (String) validatedAttributionEntity.get("attribution_phone");
 
         final EntityBuildResult<?> attribution = builder.attributionId(attributionId)
-                .clearFieldAll()
+                .clear()
                 .agencyId(agencyId)
                 .routeId(routeId)
                 .tripId(tripId)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendar.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendar.java
@@ -66,7 +66,8 @@ public class ProcessParsedCalendar {
         final LocalDate startDate = (LocalDate) validatedParsedCalendar.get("start_date");
         final LocalDate endDate = (LocalDate) validatedParsedCalendar.get("end_date");
 
-        builder.serviceId(serviceId)
+        builder.clearFieldAll()
+                .serviceId(serviceId)
                 .monday(monday)
                 .tuesday(tuesday)
                 .wednesday(wednesday)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendar.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendar.java
@@ -66,7 +66,7 @@ public class ProcessParsedCalendar {
         final LocalDate startDate = (LocalDate) validatedParsedCalendar.get("start_date");
         final LocalDate endDate = (LocalDate) validatedParsedCalendar.get("end_date");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .serviceId(serviceId)
                 .monday(monday)
                 .tuesday(tuesday)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDate.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDate.java
@@ -59,7 +59,7 @@ public class ProcessParsedCalendarDate {
         final LocalDate date = (LocalDate) validatedParsedRoute.get("date");
         final Integer exceptionType = (Integer) validatedParsedRoute.get("exception_type");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .serviceId(serviceId)
                 .date(date)
                 .exceptionType(exceptionType);

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDate.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDate.java
@@ -59,7 +59,8 @@ public class ProcessParsedCalendarDate {
         final LocalDate date = (LocalDate) validatedParsedRoute.get("date");
         final Integer exceptionType = (Integer) validatedParsedRoute.get("exception_type");
 
-        builder.serviceId(serviceId)
+        builder.clearFieldAll()
+                .serviceId(serviceId)
                 .date(date)
                 .exceptionType(exceptionType);
 

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttribute.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttribute.java
@@ -62,7 +62,8 @@ public class ProcessParsedFareAttribute {
         final String agencyId = (String) validatedFareAttribute.get("agency_id");
         final Integer transferDuration = (Integer) validatedFareAttribute.get("transfer_duration");
 
-        builder.fareId(fareId)
+        builder.clearFieldAll()
+                .fareId(fareId)
                 .price(price)
                 .currencyType(currencyType)
                 .paymentMethod(paymentMethod)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttribute.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttribute.java
@@ -62,7 +62,7 @@ public class ProcessParsedFareAttribute {
         final String agencyId = (String) validatedFareAttribute.get("agency_id");
         final Integer transferDuration = (Integer) validatedFareAttribute.get("transfer_duration");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .fareId(fareId)
                 .price(price)
                 .currencyType(currencyType)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRule.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRule.java
@@ -60,7 +60,8 @@ public class ProcessParsedFareRule {
         final String destinationId = (String) validatedParsedFareRuleEntity.get("destination_id");
         final String containsId = (String) validatedParsedFareRuleEntity.get("contains_id");
 
-        builder.fareId(fareId)
+        builder.clearFieldAll()
+                .fareId(fareId)
                 .routeId(routeId)
                 .originId(originId)
                 .destinationId(destinationId)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRule.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRule.java
@@ -60,7 +60,7 @@ public class ProcessParsedFareRule {
         final String destinationId = (String) validatedParsedFareRuleEntity.get("destination_id");
         final String containsId = (String) validatedParsedFareRuleEntity.get("contains_id");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .fareId(fareId)
                 .routeId(routeId)
                 .originId(originId)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfo.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfo.java
@@ -65,7 +65,7 @@ public class ProcessParsedFeedInfo {
         final String feedContactEmail = (String) validatedFeedInfo.get("feed_contact_email");
         final String feedContactUrl = (String) validatedFeedInfo.get("feed_contact_url");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .feedPublisherName(feedPublisherName)
                 .feedPublisherUrl(feedPublisherUrl)
                 .feedLang(feedLang)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfo.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfo.java
@@ -65,7 +65,8 @@ public class ProcessParsedFeedInfo {
         final String feedContactEmail = (String) validatedFeedInfo.get("feed_contact_email");
         final String feedContactUrl = (String) validatedFeedInfo.get("feed_contact_url");
 
-        builder.feedPublisherName(feedPublisherName)
+        builder.clearFieldAll()
+                .feedPublisherName(feedPublisherName)
                 .feedPublisherUrl(feedPublisherUrl)
                 .feedLang(feedLang)
                 .feedStartDate(feedStartDate)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevel.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevel.java
@@ -58,7 +58,8 @@ public class ProcessParsedLevel {
         final Float levelIndex = (Float) validatedParsedLevel.get("level_index");
         final String levelName = (String) validatedParsedLevel.get("level_name");
 
-        builder.levelId(levelId)
+        builder.clearFieldAll()
+                .levelId(levelId)
                 .levelIndex(levelIndex)
                 .levelName(levelName);
         final EntityBuildResult<?> level = builder.build();

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevel.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevel.java
@@ -58,7 +58,7 @@ public class ProcessParsedLevel {
         final Float levelIndex = (Float) validatedParsedLevel.get("level_index");
         final String levelName = (String) validatedParsedLevel.get("level_name");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .levelId(levelId)
                 .levelIndex(levelIndex)
                 .levelName(levelName);

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathway.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathway.java
@@ -67,7 +67,8 @@ public class ProcessParsedPathway {
         final String signpostedAs = (String) validatedParsedPathway.get("signposted_as");
         final String reversedSignpostedAs = (String) validatedParsedPathway.get("reserved_signposted_as");
 
-        builder.pathwayId(pathwayId)
+        builder.clearFieldAll()
+                .pathwayId(pathwayId)
                 .fromStopId(fromStopId)
                 .toStopId(toStopId)
                 .pathwayMode(pathwayMode)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathway.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathway.java
@@ -67,7 +67,7 @@ public class ProcessParsedPathway {
         final String signpostedAs = (String) validatedParsedPathway.get("signposted_as");
         final String reversedSignpostedAs = (String) validatedParsedPathway.get("reserved_signposted_as");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .pathwayId(pathwayId)
                 .fromStopId(fromStopId)
                 .toStopId(toStopId)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRoute.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRoute.java
@@ -54,7 +54,6 @@ public class ProcessParsedRoute {
      * @param validatedParsedRoute entity to be processed and added to the GTFS data repository
      */
     public void execute(final ParsedEntity validatedParsedRoute) {
-
         final String routeId = (String) validatedParsedRoute.get("route_id");
         final String agencyId = (String) validatedParsedRoute.get("agency_id");
         final String routeShortName = (String) validatedParsedRoute.get("route_short_name");
@@ -66,7 +65,8 @@ public class ProcessParsedRoute {
         final String routeTextColor = (String) validatedParsedRoute.get("route_text_color");
         final Integer routeSortOrder = (Integer) validatedParsedRoute.get("route_sort_order");
 
-        builder.routeId(routeId)
+        builder.clearFieldAll()
+                .routeId(routeId)
                 .agencyId(agencyId)
                 .routeShortName(routeShortName)
                 .routeLongName(routeLongName)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRoute.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRoute.java
@@ -65,7 +65,7 @@ public class ProcessParsedRoute {
         final String routeTextColor = (String) validatedParsedRoute.get("route_text_color");
         final Integer routeSortOrder = (Integer) validatedParsedRoute.get("route_sort_order");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .routeId(routeId)
                 .agencyId(agencyId)
                 .routeShortName(routeShortName)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransfer.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransfer.java
@@ -59,7 +59,8 @@ public class ProcessParsedTransfer {
         final Integer transferType = (Integer) validatedParsedTransfer.get("transfer_type");
         final Integer minTransferTime = (Integer) validatedParsedTransfer.get("min_transfer_time");
 
-        builder.fromStopId(fromStopId)
+        builder.clearFieldAll()
+                .fromStopId(fromStopId)
                 .toStopId(toStopId)
                 .transferType(transferType)
                 .minTransferTime(minTransferTime);

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransfer.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransfer.java
@@ -59,7 +59,7 @@ public class ProcessParsedTransfer {
         final Integer transferType = (Integer) validatedParsedTransfer.get("transfer_type");
         final Integer minTransferTime = (Integer) validatedParsedTransfer.get("min_transfer_time");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .fromStopId(fromStopId)
                 .toStopId(toStopId)
                 .transferType(transferType)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTrip.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTrip.java
@@ -65,7 +65,7 @@ public class ProcessParsedTrip {
         final Integer wheelchairAccessible = (Integer) validatedTripEntity.get("wheelchair_accessible");
         final Integer bikesAllowed = (Integer) validatedTripEntity.get("bikes_allowed");
 
-        builder.clearFieldAll()
+        builder.clear()
                 .routeId(routeId)
                 .serviceId(serviceId)
                 .tripId(tripId)

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTrip.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTrip.java
@@ -65,7 +65,8 @@ public class ProcessParsedTrip {
         final Integer wheelchairAccessible = (Integer) validatedTripEntity.get("wheelchair_accessible");
         final Integer bikesAllowed = (Integer) validatedTripEntity.get("bikes_allowed");
 
-        builder.routeId(routeId)
+        builder.clearFieldAll()
+                .routeId(routeId)
                 .serviceId(serviceId)
                 .tripId(tripId)
                 .tripHeadsign(tripHeadsign)

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgencyTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgencyTest.java
@@ -85,7 +85,7 @@ class ProcessParsedAgencyTest {
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_FARE_URL));
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_EMAIL));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).agencyId(anyString());
         verify(mockBuilder, times(1)).agencyName(anyString());
         verify(mockBuilder, times(1)).agencyUrl(anyString());
@@ -144,7 +144,7 @@ class ProcessParsedAgencyTest {
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_FARE_URL));
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_EMAIL));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).agencyId(AGENCY_ID);
         verify(mockBuilder, times(1)).agencyName(AGENCY_NAME);
         verify(mockBuilder, times(1)).agencyUrl(AGENCY_URL);
@@ -212,7 +212,7 @@ class ProcessParsedAgencyTest {
 
         verify(mockGtfsDataRepo, times(1)).addAgency(ArgumentMatchers.isA(Agency.class));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).agencyId(anyString());
         verify(mockBuilder, times(1)).agencyName(anyString());
         verify(mockBuilder, times(1)).agencyUrl(anyString());

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgencyTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAgencyTest.java
@@ -85,6 +85,7 @@ class ProcessParsedAgencyTest {
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_FARE_URL));
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_EMAIL));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).agencyId(anyString());
         verify(mockBuilder, times(1)).agencyName(anyString());
         verify(mockBuilder, times(1)).agencyUrl(anyString());
@@ -143,6 +144,7 @@ class ProcessParsedAgencyTest {
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_FARE_URL));
         verify(mockParsedAgency, times(1)).get(ArgumentMatchers.eq(AGENCY_EMAIL));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).agencyId(AGENCY_ID);
         verify(mockBuilder, times(1)).agencyName(AGENCY_NAME);
         verify(mockBuilder, times(1)).agencyUrl(AGENCY_URL);
@@ -210,6 +212,7 @@ class ProcessParsedAgencyTest {
 
         verify(mockGtfsDataRepo, times(1)).addAgency(ArgumentMatchers.isA(Agency.class));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).agencyId(anyString());
         verify(mockBuilder, times(1)).agencyName(anyString());
         verify(mockBuilder, times(1)).agencyUrl(anyString());

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttributionTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttributionTest.java
@@ -93,6 +93,7 @@ class ProcessParsedAttributionTest {
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_EMAIL));
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_PHONE));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).attributionId(ArgumentMatchers.eq(ATTRIBUTION_ID));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(ROUTE_ID));
@@ -159,6 +160,7 @@ class ProcessParsedAttributionTest {
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_EMAIL));
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_PHONE));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).attributionId(ArgumentMatchers.eq(ATTRIBUTION_ID));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(ROUTE_ID));
@@ -238,6 +240,7 @@ class ProcessParsedAttributionTest {
         //noinspection ResultOfMethodCallIgnored
         verify(mockParsedAttribution, times(1)).getEntityId();
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).attributionId(ArgumentMatchers.eq(ATTRIBUTION_ID));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(ROUTE_ID));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttributionTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedAttributionTest.java
@@ -93,7 +93,7 @@ class ProcessParsedAttributionTest {
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_EMAIL));
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_PHONE));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).attributionId(ArgumentMatchers.eq(ATTRIBUTION_ID));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(ROUTE_ID));
@@ -160,7 +160,7 @@ class ProcessParsedAttributionTest {
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_EMAIL));
         verify(mockParsedAttribution, times(1)).get(ArgumentMatchers.eq(ATTRIBUTION_PHONE));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).attributionId(ArgumentMatchers.eq(ATTRIBUTION_ID));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(ROUTE_ID));
@@ -240,7 +240,7 @@ class ProcessParsedAttributionTest {
         //noinspection ResultOfMethodCallIgnored
         verify(mockParsedAttribution, times(1)).getEntityId();
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).attributionId(ArgumentMatchers.eq(ATTRIBUTION_ID));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(ROUTE_ID));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDateTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDateTest.java
@@ -58,6 +58,7 @@ class ProcessParsedCalendarDateTest {
         verify(mockParsedCalendarDate, times(1))
                 .get(ArgumentMatchers.eq("exception_type"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).serviceId(ArgumentMatchers.eq("service_id"));
         verify(mockBuilder, times(1)).date(ArgumentMatchers.eq(date));
         verify(mockBuilder, times(1)).exceptionType(ArgumentMatchers.eq(1));
@@ -110,6 +111,7 @@ class ProcessParsedCalendarDateTest {
         verify(mockParsedCalendarDate, times(1))
                 .get(ArgumentMatchers.eq("exception_type"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).serviceId(ArgumentMatchers.eq("service_id"));
         verify(mockBuilder, times(1)).date(ArgumentMatchers.eq(date));
         verify(mockBuilder, times(1)).exceptionType(ArgumentMatchers.eq(1));
@@ -162,6 +164,7 @@ class ProcessParsedCalendarDateTest {
         verify(mockGtfsDataRepo, times(1))
                 .addCalendarDate(ArgumentMatchers.eq(mockCalendarDate));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).serviceId(ArgumentMatchers.eq("service_id"));
         verify(mockBuilder, times(1)).date(ArgumentMatchers.eq(date));
         verify(mockBuilder, times(1)).exceptionType(ArgumentMatchers.eq(1));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDateTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarDateTest.java
@@ -58,7 +58,7 @@ class ProcessParsedCalendarDateTest {
         verify(mockParsedCalendarDate, times(1))
                 .get(ArgumentMatchers.eq("exception_type"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).serviceId(ArgumentMatchers.eq("service_id"));
         verify(mockBuilder, times(1)).date(ArgumentMatchers.eq(date));
         verify(mockBuilder, times(1)).exceptionType(ArgumentMatchers.eq(1));
@@ -111,7 +111,7 @@ class ProcessParsedCalendarDateTest {
         verify(mockParsedCalendarDate, times(1))
                 .get(ArgumentMatchers.eq("exception_type"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).serviceId(ArgumentMatchers.eq("service_id"));
         verify(mockBuilder, times(1)).date(ArgumentMatchers.eq(date));
         verify(mockBuilder, times(1)).exceptionType(ArgumentMatchers.eq(1));
@@ -164,7 +164,7 @@ class ProcessParsedCalendarDateTest {
         verify(mockGtfsDataRepo, times(1))
                 .addCalendarDate(ArgumentMatchers.eq(mockCalendarDate));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).serviceId(ArgumentMatchers.eq("service_id"));
         verify(mockBuilder, times(1)).date(ArgumentMatchers.eq(date));
         verify(mockBuilder, times(1)).exceptionType(ArgumentMatchers.eq(1));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarTest.java
@@ -92,7 +92,7 @@ class ProcessParsedCalendarTest {
         verify(mockParsedCalendar, times(1)).get(START_DATE);
         verify(mockParsedCalendar, times(1)).get(END_DATE);
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).monday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).tuesday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).wednesday(ArgumentMatchers.eq(0));
@@ -158,7 +158,7 @@ class ProcessParsedCalendarTest {
         verify(mockParsedCalendar, times(1)).get(START_DATE);
         verify(mockParsedCalendar, times(1)).get(END_DATE);
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).monday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).tuesday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).wednesday(ArgumentMatchers.eq(0));
@@ -224,7 +224,7 @@ class ProcessParsedCalendarTest {
 
         verify(mockGtfsDataRepo, times(1)).addCalendar(ArgumentMatchers.eq(mockCalendar));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).monday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).tuesday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).wednesday(ArgumentMatchers.eq(0));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedCalendarTest.java
@@ -92,6 +92,7 @@ class ProcessParsedCalendarTest {
         verify(mockParsedCalendar, times(1)).get(START_DATE);
         verify(mockParsedCalendar, times(1)).get(END_DATE);
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).monday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).tuesday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).wednesday(ArgumentMatchers.eq(0));
@@ -157,6 +158,7 @@ class ProcessParsedCalendarTest {
         verify(mockParsedCalendar, times(1)).get(START_DATE);
         verify(mockParsedCalendar, times(1)).get(END_DATE);
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).monday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).tuesday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).wednesday(ArgumentMatchers.eq(0));
@@ -222,6 +224,7 @@ class ProcessParsedCalendarTest {
 
         verify(mockGtfsDataRepo, times(1)).addCalendar(ArgumentMatchers.eq(mockCalendar));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).monday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).tuesday(ArgumentMatchers.eq(0));
         verify(mockBuilder, times(1)).wednesday(ArgumentMatchers.eq(0));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttributeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttributeTest.java
@@ -89,6 +89,7 @@ class ProcessParsedFareAttributeTest {
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(TRANSFER_DURATION));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fareId(ArgumentMatchers.eq(STRING_TEST));
         verify(mockBuilder, times(1)).price(ArgumentMatchers.eq(VALID_PRICE_FLOAT));
         verify(mockBuilder, times(1)).currencyType(ArgumentMatchers.eq(STRING_TEST));
@@ -152,6 +153,7 @@ class ProcessParsedFareAttributeTest {
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(TRANSFER_DURATION));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fareId(ArgumentMatchers.eq(null));
         verify(mockBuilder, times(1)).price(ArgumentMatchers.eq(VALID_PRICE_FLOAT));
         verify(mockBuilder, times(1)).currencyType(ArgumentMatchers.eq(STRING_TEST));
@@ -216,6 +218,7 @@ class ProcessParsedFareAttributeTest {
         //noinspection ResultOfMethodCallIgnored
         verify(mockParsedFareAttribute, times(1)).getEntityId();
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fareId(ArgumentMatchers.eq(STRING_TEST));
         verify(mockBuilder, times(1)).price(ArgumentMatchers.eq(VALID_PRICE_FLOAT));
         verify(mockBuilder, times(1)).currencyType(ArgumentMatchers.eq(STRING_TEST));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttributeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareAttributeTest.java
@@ -89,7 +89,7 @@ class ProcessParsedFareAttributeTest {
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(TRANSFER_DURATION));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fareId(ArgumentMatchers.eq(STRING_TEST));
         verify(mockBuilder, times(1)).price(ArgumentMatchers.eq(VALID_PRICE_FLOAT));
         verify(mockBuilder, times(1)).currencyType(ArgumentMatchers.eq(STRING_TEST));
@@ -153,7 +153,7 @@ class ProcessParsedFareAttributeTest {
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(AGENCY_ID));
         verify(mockParsedFareAttribute, times(1)).get(ArgumentMatchers.eq(TRANSFER_DURATION));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fareId(ArgumentMatchers.eq(null));
         verify(mockBuilder, times(1)).price(ArgumentMatchers.eq(VALID_PRICE_FLOAT));
         verify(mockBuilder, times(1)).currencyType(ArgumentMatchers.eq(STRING_TEST));
@@ -218,7 +218,7 @@ class ProcessParsedFareAttributeTest {
         //noinspection ResultOfMethodCallIgnored
         verify(mockParsedFareAttribute, times(1)).getEntityId();
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fareId(ArgumentMatchers.eq(STRING_TEST));
         verify(mockBuilder, times(1)).price(ArgumentMatchers.eq(VALID_PRICE_FLOAT));
         verify(mockBuilder, times(1)).currencyType(ArgumentMatchers.eq(STRING_TEST));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRuleTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRuleTest.java
@@ -76,6 +76,7 @@ class ProcessParsedFareRuleTest {
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(DESTINATION_ID));
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(CONTAINS_ID));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fareId(FARE_ID);
         verify(mockBuilder, times(1)).routeId(ROUTE_ID);
         verify(mockBuilder, times(1)).originId(ORIGIN_ID);
@@ -121,6 +122,7 @@ class ProcessParsedFareRuleTest {
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(DESTINATION_ID));
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(CONTAINS_ID));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fareId(FARE_ID);
         verify(mockBuilder, times(1)).routeId(ROUTE_ID);
         verify(mockBuilder, times(1)).originId(ORIGIN_ID);
@@ -178,6 +180,7 @@ class ProcessParsedFareRuleTest {
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(DESTINATION_ID));
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(CONTAINS_ID));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fareId(FARE_ID);
         verify(mockBuilder, times(1)).routeId(ROUTE_ID);
         verify(mockBuilder, times(1)).originId(ORIGIN_ID);

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRuleTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFareRuleTest.java
@@ -76,7 +76,7 @@ class ProcessParsedFareRuleTest {
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(DESTINATION_ID));
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(CONTAINS_ID));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fareId(FARE_ID);
         verify(mockBuilder, times(1)).routeId(ROUTE_ID);
         verify(mockBuilder, times(1)).originId(ORIGIN_ID);
@@ -122,7 +122,7 @@ class ProcessParsedFareRuleTest {
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(DESTINATION_ID));
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(CONTAINS_ID));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fareId(FARE_ID);
         verify(mockBuilder, times(1)).routeId(ROUTE_ID);
         verify(mockBuilder, times(1)).originId(ORIGIN_ID);
@@ -180,7 +180,7 @@ class ProcessParsedFareRuleTest {
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(DESTINATION_ID));
         verify(mockParsedFareRule, times(1)).get(ArgumentMatchers.eq(CONTAINS_ID));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fareId(FARE_ID);
         verify(mockBuilder, times(1)).routeId(ROUTE_ID);
         verify(mockBuilder, times(1)).originId(ORIGIN_ID);

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfoTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfoTest.java
@@ -91,7 +91,7 @@ class ProcessParsedFeedInfoTest {
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_EMAIL));
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_URL));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1))
                 .feedPublisherName(ArgumentMatchers.eq(FEED_PUBLISHER_NAME));
         verify(mockBuilder, times(1)).feedPublisherUrl(ArgumentMatchers.eq(FEED_PUBLISHER_URL));
@@ -157,7 +157,7 @@ class ProcessParsedFeedInfoTest {
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_EMAIL));
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_URL));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1))
                 .feedPublisherName(ArgumentMatchers.eq(FEED_PUBLISHER_NAME));
         verify(mockBuilder, times(1)).feedPublisherUrl(ArgumentMatchers.eq(FEED_PUBLISHER_URL));
@@ -221,7 +221,7 @@ class ProcessParsedFeedInfoTest {
 
         verify(mockGtfsDataRepo, times(1)).addFeedInfo(ArgumentMatchers.eq(mockFeedInfo));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1))
                 .feedPublisherName(ArgumentMatchers.eq(FEED_PUBLISHER_NAME));
         verify(mockBuilder, times(1)).feedPublisherUrl(ArgumentMatchers.eq(FEED_PUBLISHER_URL));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfoTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedFeedInfoTest.java
@@ -91,6 +91,7 @@ class ProcessParsedFeedInfoTest {
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_EMAIL));
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_URL));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1))
                 .feedPublisherName(ArgumentMatchers.eq(FEED_PUBLISHER_NAME));
         verify(mockBuilder, times(1)).feedPublisherUrl(ArgumentMatchers.eq(FEED_PUBLISHER_URL));
@@ -156,6 +157,7 @@ class ProcessParsedFeedInfoTest {
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_EMAIL));
         verify(mockParsedFeedInfo, times(1)).get(ArgumentMatchers.eq(FEED_CONTACT_URL));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1))
                 .feedPublisherName(ArgumentMatchers.eq(FEED_PUBLISHER_NAME));
         verify(mockBuilder, times(1)).feedPublisherUrl(ArgumentMatchers.eq(FEED_PUBLISHER_URL));
@@ -219,6 +221,7 @@ class ProcessParsedFeedInfoTest {
 
         verify(mockGtfsDataRepo, times(1)).addFeedInfo(ArgumentMatchers.eq(mockFeedInfo));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1))
                 .feedPublisherName(ArgumentMatchers.eq(FEED_PUBLISHER_NAME));
         verify(mockBuilder, times(1)).feedPublisherUrl(ArgumentMatchers.eq(FEED_PUBLISHER_URL));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevelTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevelTest.java
@@ -68,7 +68,7 @@ class ProcessParsedLevelTest {
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_index"));
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_name"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).levelId("level id");
         verify(mockBuilder, times(1)).levelIndex(2.0f);
         verify(mockBuilder, times(1)).levelName("level name");
@@ -117,7 +117,7 @@ class ProcessParsedLevelTest {
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_index"));
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_name"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).levelId(ArgumentMatchers.eq("level id"));
         verify(mockBuilder, times(1)).levelIndex(ArgumentMatchers.eq(2.0f));
         verify(mockBuilder, times(1)).levelName(ArgumentMatchers.eq("level name"));
@@ -164,7 +164,7 @@ class ProcessParsedLevelTest {
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_index"));
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_name"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).levelId(ArgumentMatchers.eq("level id"));
         verify(mockBuilder, times(1)).levelIndex(ArgumentMatchers.eq(2.0f));
         verify(mockBuilder, times(1)).levelName(ArgumentMatchers.eq("level name"));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevelTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedLevelTest.java
@@ -68,6 +68,7 @@ class ProcessParsedLevelTest {
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_index"));
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_name"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).levelId("level id");
         verify(mockBuilder, times(1)).levelIndex(2.0f);
         verify(mockBuilder, times(1)).levelName("level name");
@@ -116,6 +117,7 @@ class ProcessParsedLevelTest {
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_index"));
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_name"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).levelId(ArgumentMatchers.eq("level id"));
         verify(mockBuilder, times(1)).levelIndex(ArgumentMatchers.eq(2.0f));
         verify(mockBuilder, times(1)).levelName(ArgumentMatchers.eq("level name"));
@@ -162,6 +164,7 @@ class ProcessParsedLevelTest {
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_index"));
         verify(mockParsedLevel, times(1)).get(ArgumentMatchers.eq("level_name"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).levelId(ArgumentMatchers.eq("level id"));
         verify(mockBuilder, times(1)).levelIndex(ArgumentMatchers.eq(2.0f));
         verify(mockBuilder, times(1)).levelName(ArgumentMatchers.eq("level name"));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathwayTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathwayTest.java
@@ -88,7 +88,7 @@ class ProcessParsedPathwayTest {
         inOrder.verify(mockParsedPathway, times(1))
                 .get(ArgumentMatchers.eq(RESERVED_SIGNPOSTED_AS));
 
-        inOrder.verify(mockBuilder, times(1)).clearFieldAll();
+        inOrder.verify(mockBuilder, times(1)).clear();
         inOrder.verify(mockBuilder, times(1)).pathwayId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         inOrder.verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         inOrder.verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
@@ -163,7 +163,7 @@ class ProcessParsedPathwayTest {
         verify(mockParsedPathway, times(1)).get(ArgumentMatchers.eq(SIGNPOSTED_AS));
         verify(mockParsedPathway, times(1)).get(ArgumentMatchers.eq(RESERVED_SIGNPOSTED_AS));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).pathwayId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
@@ -243,7 +243,7 @@ class ProcessParsedPathwayTest {
 
         verify(mockGtfsDataRepo, times(1)).addPathway(ArgumentMatchers.eq(mockPathway));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).pathwayId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathwayTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedPathwayTest.java
@@ -88,6 +88,7 @@ class ProcessParsedPathwayTest {
         inOrder.verify(mockParsedPathway, times(1))
                 .get(ArgumentMatchers.eq(RESERVED_SIGNPOSTED_AS));
 
+        inOrder.verify(mockBuilder, times(1)).clearFieldAll();
         inOrder.verify(mockBuilder, times(1)).pathwayId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         inOrder.verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         inOrder.verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
@@ -162,6 +163,7 @@ class ProcessParsedPathwayTest {
         verify(mockParsedPathway, times(1)).get(ArgumentMatchers.eq(SIGNPOSTED_AS));
         verify(mockParsedPathway, times(1)).get(ArgumentMatchers.eq(RESERVED_SIGNPOSTED_AS));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).pathwayId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
@@ -241,6 +243,7 @@ class ProcessParsedPathwayTest {
 
         verify(mockGtfsDataRepo, times(1)).addPathway(ArgumentMatchers.eq(mockPathway));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).pathwayId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq(STRING_TEST_VALUE));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRouteTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRouteTest.java
@@ -96,6 +96,7 @@ class ProcessParsedRouteTest {
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_TEXT_COLOR));
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_SORT_ORDER));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.anyString());
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.anyString());
         verify(mockBuilder, times(1)).routeShortName(ArgumentMatchers.anyString());
@@ -162,6 +163,7 @@ class ProcessParsedRouteTest {
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_TEXT_COLOR));
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_SORT_ORDER));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).routeShortName(ArgumentMatchers.eq(STRING_TEST_VALUE));
@@ -231,6 +233,7 @@ class ProcessParsedRouteTest {
 
         verify(mockGtfsDataRepo, times(1)).addRoute(ArgumentMatchers.isA(Route.class));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).routeId(anyString());
         verify(mockBuilder, times(1)).agencyId(anyString());
         verify(mockBuilder, times(1)).routeShortName(anyString());

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRouteTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedRouteTest.java
@@ -96,7 +96,7 @@ class ProcessParsedRouteTest {
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_TEXT_COLOR));
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_SORT_ORDER));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.anyString());
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.anyString());
         verify(mockBuilder, times(1)).routeShortName(ArgumentMatchers.anyString());
@@ -163,7 +163,7 @@ class ProcessParsedRouteTest {
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_TEXT_COLOR));
         verify(mockParsedRoute, times(1)).get(ArgumentMatchers.eq(ROUTE_SORT_ORDER));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).routeId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).agencyId(ArgumentMatchers.eq(STRING_TEST_VALUE));
         verify(mockBuilder, times(1)).routeShortName(ArgumentMatchers.eq(STRING_TEST_VALUE));
@@ -233,7 +233,7 @@ class ProcessParsedRouteTest {
 
         verify(mockGtfsDataRepo, times(1)).addRoute(ArgumentMatchers.isA(Route.class));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).routeId(anyString());
         verify(mockBuilder, times(1)).agencyId(anyString());
         verify(mockBuilder, times(1)).routeShortName(anyString());

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransferTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransferTest.java
@@ -71,7 +71,7 @@ class ProcessParsedTransferTest {
         verify(mockParsedTransfer, times(1))
                 .get(ArgumentMatchers.eq("min_transfer_time"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq("stop id 0"));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq("stop id 1"));
         verify(mockBuilder, times(1)).transferType(ArgumentMatchers.eq(1));
@@ -117,7 +117,7 @@ class ProcessParsedTransferTest {
         verify(mockParsedTransfer, times(1))
                 .get(ArgumentMatchers.eq("min_transfer_time"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         // parameter of method .fromStopId is annotated as non null, for the purpose of this test, we suppress the
         // warning resulting form passing null value to method.
         //noinspection ConstantConditions
@@ -183,7 +183,7 @@ class ProcessParsedTransferTest {
         //noinspection ResultOfMethodCallIgnored
         verify(mockParsedTransfer, times(1)).getEntityId();
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq("stop id 0"));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq("stop id 1"));
         verify(mockBuilder, times(1)).transferType(ArgumentMatchers.eq(1));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransferTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTransferTest.java
@@ -71,6 +71,7 @@ class ProcessParsedTransferTest {
         verify(mockParsedTransfer, times(1))
                 .get(ArgumentMatchers.eq("min_transfer_time"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq("stop id 0"));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq("stop id 1"));
         verify(mockBuilder, times(1)).transferType(ArgumentMatchers.eq(1));
@@ -116,6 +117,7 @@ class ProcessParsedTransferTest {
         verify(mockParsedTransfer, times(1))
                 .get(ArgumentMatchers.eq("min_transfer_time"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         // parameter of method .fromStopId is annotated as non null, for the purpose of this test, we suppress the
         // warning resulting form passing null value to method.
         //noinspection ConstantConditions
@@ -181,6 +183,7 @@ class ProcessParsedTransferTest {
         //noinspection ResultOfMethodCallIgnored
         verify(mockParsedTransfer, times(1)).getEntityId();
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).fromStopId(ArgumentMatchers.eq("stop id 0"));
         verify(mockBuilder, times(1)).toStopId(ArgumentMatchers.eq("stop id 1"));
         verify(mockBuilder, times(1)).transferType(ArgumentMatchers.eq(1));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTripTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTripTest.java
@@ -70,6 +70,7 @@ class ProcessParsedTripTest {
                 .get(ArgumentMatchers.eq("wheelchair_accessible"));
         verify(mockParsedTrip, times(1)).get(ArgumentMatchers.eq("bikes_allowed"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).routeId("route_id");
         verify(mockBuilder, times(1)).serviceId("service_id");
         verify(mockBuilder, times(1)).tripId("trip_id");
@@ -134,6 +135,7 @@ class ProcessParsedTripTest {
                 .get(ArgumentMatchers.eq("wheelchair_accessible"));
         verify(mockParsedTrip, times(1)).get(ArgumentMatchers.eq("bikes_allowed"));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         // parameter of method .routeId() is annotated as non null, removing this warning for the purpose of the test
         //noinspection ConstantConditions
         verify(mockBuilder, times(1)).routeId(null);
@@ -198,6 +200,7 @@ class ProcessParsedTripTest {
 
         verify(mockGtfsDataRepo, times(1)).addTrip(ArgumentMatchers.isA(Trip.class));
 
+        verify(mockBuilder, times(1)).clearFieldAll();
         verify(mockBuilder, times(1)).routeId("route_id");
         verify(mockBuilder, times(1)).serviceId("service_id");
         verify(mockBuilder, times(1)).tripId("trip_id");

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTripTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedTripTest.java
@@ -70,7 +70,7 @@ class ProcessParsedTripTest {
                 .get(ArgumentMatchers.eq("wheelchair_accessible"));
         verify(mockParsedTrip, times(1)).get(ArgumentMatchers.eq("bikes_allowed"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).routeId("route_id");
         verify(mockBuilder, times(1)).serviceId("service_id");
         verify(mockBuilder, times(1)).tripId("trip_id");
@@ -135,7 +135,7 @@ class ProcessParsedTripTest {
                 .get(ArgumentMatchers.eq("wheelchair_accessible"));
         verify(mockParsedTrip, times(1)).get(ArgumentMatchers.eq("bikes_allowed"));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         // parameter of method .routeId() is annotated as non null, removing this warning for the purpose of the test
         //noinspection ConstantConditions
         verify(mockBuilder, times(1)).routeId(null);
@@ -200,7 +200,7 @@ class ProcessParsedTripTest {
 
         verify(mockGtfsDataRepo, times(1)).addTrip(ArgumentMatchers.isA(Trip.class));
 
-        verify(mockBuilder, times(1)).clearFieldAll();
+        verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).routeId("route_id");
         verify(mockBuilder, times(1)).serviceId("service_id");
         verify(mockBuilder, times(1)).tripId("trip_id");


### PR DESCRIPTION
**Summary:**

This PR provides support to add a `clear` method to GTFS entities builder. Calling said method sets all builder's field to `null`. This PR also provides support to use static method to generate mapping key of `Attribution` GTFS entities inside `AttributionBuilder.build` method

**Expected behavior:** 

Fields of builders should be set to `null` after calling said method.
Attribution Mapping key should be generated via static method

Please note that these methods are not tested because builders' fields are private, and we chose  not to provide getters on builders.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~