### PR TITLE
Implement Duplicate column (CSV rule)

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -240,7 +240,7 @@ Field `parent_station` must be empty when `location_type` is 2
 
 ### E043 - Duplicated field
 
-Some file contains the same column name twice
+A file cannot contain the same header value twice (i.e., duplicated column of data).
 
 # Warnings
 

--- a/RULES.md
+++ b/RULES.md
@@ -6,7 +6,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 
 | Error ID      | Error Title         |
 |---------------|---------------------------|
-| [E001](#E001) | | 
+| [E001](#E001) | Missing required field | 
 | [E002](#E002) | | 
 | [E003](#E003) | | 
 | [E004](#E004) | | 
@@ -44,13 +44,14 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E040](#E040) | Dataset should be valid for at least the next 7 days | 
 | [E041](#E041) | Invalid parent `location_type` for stop |
 | [E042](#E042) | Station stop (`location_type`=2) has a parent stop |
+| [E043](#E043) | Duplicated field |
 
 ### Table of Warnings
 
 | Warning ID    | Warning Title             |
 |---------------|---------------------------|
 | [W001](#W001) | | 
-| [W002](#W002) | | 
+| [W002](#W002) | Non standard field name | 
 | [W003](#W003) | | 
 | [W004](#W004) | | 
 | [W005](#W005) | Route short name too long |
@@ -62,6 +63,12 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [W009](#W011) | `feed_start_date` should be provided if `feed_end_date` is provided | 
 
 # Errors
+
+<a name="E001"/>
+
+### E001 - Missing required field
+
+A field marked as `required` is missing 
 
 <a name="E022"/>
 
@@ -222,14 +229,26 @@ Any other combination raise this error
 
 <a name="E042"/>
 
-### E042 - Station stop (`location_type`=2) has a parent stop
+### E042 - Station stop (`location_type` = 2) has a parent stop
 
 Field `parent_station` must be empty when `location_type` is 2
 
 #### References:
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
 
+<a name="E043"/>
+
+### E043 - Duplicated field
+
+Some file contains the same column name twice
+
 # Warnings
+
+<a name="W002"/>
+
+### W002 - Non standard field name
+
+A field not defined in the specification was found. It will be ignored.
 
 <a name="W005"/>
 

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -123,6 +123,11 @@ public class JsonNoticeExporter implements NoticeExporter {
     }
 
     @Override
+    public void export(final DuplicatedHeaderNotice toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
+
+    @Override
     public void export(final MissingRequiredFileNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -256,6 +256,17 @@ public class ProtobufNoticeExporter implements NoticeExporter {
     }
 
     @Override
+    public void export(DuplicatedHeaderNotice toExport) throws IOException {
+        protoBuilder.clear()
+                .setCsvFileName(toExport.getFilename())
+                .setType(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_DUPLICATE_COLUMN_NAME)
+                .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
+                .setAltEntityId((String) toExport.getNoticeSpecific(KEY_DUPLICATED_HEADER_NAME))
+                .build()
+                .writeTo(streamGenerator.getStream());
+    }
+
+    @Override
     public void export(MissingRequiredFileNotice toExport) throws IOException {
         protoBuilder.clear()
                 .setCsvFileName(toExport.getFilename())

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -269,6 +269,18 @@ class JsonNoticeExporterTest {
     }
 
     @Test
+    void exportDuplicatedHeaderNoticeShouldWriteObject() throws IOException {
+        JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        DuplicatedHeaderNotice toExport = new DuplicatedHeaderNotice(FILENAME, "duplicated_header");
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
+
+    @Test
     void exportMissingRequiredFileNoticeShouldWriteObject() throws IOException {
         JsonGenerator mockGenerator = mock(JsonGenerator.class);
 

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.time.LocalDate;
 
-import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_ROUTE_ID;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_SERVICE_ID;
 import static org.mockito.Mockito.*;
 
@@ -507,6 +506,36 @@ class ProtobufNoticeExporterTest {
                 ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
         verify(mockBuilder, times(1)).setAltEntityId(
                 ArgumentMatchers.eq("missing_header"));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
+
+    @Test
+    void exportDuplicatedHeaderNoticeShouldMapToCsvProblemAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        underTest.export(new DuplicatedHeaderNotice(FILENAME, "duplicated_header"));
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(ArgumentMatchers.eq(FILENAME));
+        verify(mockBuilder, times(1)).setType(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_DUPLICATE_COLUMN_NAME));
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
+        verify(mockBuilder, times(1)).setAltEntityId(
+                ArgumentMatchers.eq("duplicated_header"));
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryRawFileRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryRawFileRepository.java
@@ -58,18 +58,18 @@ public class InMemoryRawFileRepository implements RawFileRepository {
     }
 
     /**
-     * Returns the collection of headers for GTFS CSV file from a {@link RawFileInfo}
+     * Returns the collection of headers for GTFS CSV file from a {@link RawFileInfo} including duplicates
      *
      * @param file information regarding a file location and expected content (file name)
      * @return the collection of headers for a given GTFS CSV file
      */
     @Override
-    public Collection<String> getActualHeadersForFile(RawFileInfo file) {
+    public List<String> getActualHeadersForFile(RawFileInfo file) {
         File csvFile = new File(file.getPath() + File.separator + file.getFilename());
         CsvMapper mapper = new CsvMapper();
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
 
-        Collection<String> toReturn = new ArrayList<>();
+        List<String> toReturn = new ArrayList<>();
 
         try {
             ((CsvSchema) (mapper.readerFor(Map.class)

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryRawFileRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryRawFileRepository.java
@@ -69,7 +69,7 @@ public class InMemoryRawFileRepository implements RawFileRepository {
         CsvMapper mapper = new CsvMapper();
         CsvSchema schema = CsvSchema.emptySchema().withHeader();
 
-        Collection<String> toReturn = new HashSet<>();
+        Collection<String> toReturn = new ArrayList<>();
 
         try {
             ((CsvSchema) (mapper.readerFor(Map.class)
@@ -77,7 +77,7 @@ public class InMemoryRawFileRepository implements RawFileRepository {
                     .readValues(csvFile).getParser().getSchema())).iterator().forEachRemaining(column -> toReturn.add(column.getName()));
         } catch (IOException e) {
             //TODO: this should go back up to use case level so it can be properly reported
-            return Collections.emptySet();
+            return Collections.emptyList();
         }
 
         return toReturn;

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -124,7 +124,8 @@ public class DefaultConfig {
                 specRepo,
                 rawFileRepo.findByName(filename).orElse(RawFileInfo.builder().build()),
                 rawFileRepo,
-                resultRepo
+                resultRepo,
+                logger
         );
     }
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -41,6 +41,8 @@ public interface NoticeExporter {
 
     void export(MissingHeaderNotice toExport) throws IOException;
 
+    void export(DuplicatedHeaderNotice toExport) throws IOException;
+
     void export(MissingRequiredFileNotice toExport) throws IOException;
 
     void export(MissingRequiredValueNotice toExport) throws IOException;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -61,6 +61,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_040 = 40;
     protected static final int E_041 = 41;
     protected static final int E_042 = 42;
+    protected static final int E_043 = 43;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
@@ -43,6 +43,7 @@ public abstract class Notice {
     public static final String KEY_EXPECTED_LENGTH = "expectedLength";
     public static final String KEY_ACTUAL_LENGTH = "actualLength";
     public static final String KEY_MISSING_HEADER_NAME = "missingHeaderName";
+    public static final String KEY_DUPLICATED_HEADER_NAME = "duplicatedHeaderName";
     public static final String KEY_EXTRA_HEADER_NAME = "extraHeaderName";
     public static final String KEY_CONTRAST_RATIO = "contrastRatio";
     public static final String KEY_SHORT_NAME_LENGTH = "shortNameLength";

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/DuplicatedHeaderNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/DuplicatedHeaderNotice.java
@@ -21,14 +21,14 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
 
 import java.io.IOException;
 
-public class MissingHeaderNotice extends ErrorNotice {
+public class DuplicatedHeaderNotice extends ErrorNotice {
 
-    public MissingHeaderNotice(final String filename, final String missingHeaderName) {
-        super(filename, E_001,
-                "Missing required field",
-                "File `" + filename + " is missing required field name: `" + missingHeaderName + "`",
+    public DuplicatedHeaderNotice(final String filename, final String duplicatedHeaderName) {
+        super(filename, E_043,
+                "Field is duplicated",
+                "File `" + filename + " contains duplicated field: `" + duplicatedHeaderName + "`",
                 null);
-        putNoticeSpecific(KEY_MISSING_HEADER_NAME, missingHeaderName);
+        putNoticeSpecific(KEY_DUPLICATED_HEADER_NAME, duplicatedHeaderName);
     }
 
     @Override

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateHeadersForFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateHeadersForFile.java
@@ -25,7 +25,6 @@ import org.mobilitydata.gtfsvalidator.usecase.port.GtfsSpecRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.RawFileRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -76,7 +75,7 @@ public class ValidateHeadersForFile {
 
         List<String> expectedRequiredHeaderList = specRepo.getRequiredHeadersForFile(rawFileInfo);
         List<String> expectedOptionalHeaderList = specRepo.getOptionalHeadersForFile(rawFileInfo);
-        Collection<String> actualHeaderList = rawFileRepo.getActualHeadersForFile(rawFileInfo);
+        List<String> actualHeaderList = rawFileRepo.getActualHeadersForFile(rawFileInfo);
 
         // Duplicated headers
         Set<String> headerSet = new HashSet<>();

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateHeadersForFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateHeadersForFile.java
@@ -16,7 +16,9 @@
 
 package org.mobilitydata.gtfsvalidator.usecase;
 
+import org.apache.logging.log4j.Logger;
 import org.mobilitydata.gtfsvalidator.domain.entity.RawFileInfo;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.DuplicatedHeaderNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingHeaderNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.NonStandardHeaderNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsSpecRepository;
@@ -24,7 +26,9 @@ import org.mobilitydata.gtfsvalidator.usecase.port.RawFileRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Use case to validate the headers of a csv file. This checks that headers marked as required by the GTFS specification
@@ -36,42 +40,59 @@ public class ValidateHeadersForFile {
     private final RawFileInfo rawFileInfo;
     private final RawFileRepository rawFileRepo;
     private final ValidationResultRepository resultRepo;
+    private final Logger logger;
 
     /**
      * @param specRepo    a repository storing information about the GTFS specification used
      * @param rawFileInfo an object containing information regarding a file location and expected content
      * @param rawFileRepo a repository storing information about a GTFS dataset
      * @param resultRepo  a repository storing information about the validation process
+     * @param logger      a logger displaying information about the validation process
      */
     public ValidateHeadersForFile(final GtfsSpecRepository specRepo,
                                   final RawFileInfo rawFileInfo,
                                   final RawFileRepository rawFileRepo,
-                                  final ValidationResultRepository resultRepo
+                                  final ValidationResultRepository resultRepo,
+                                  final Logger logger
     ) {
         this.specRepo = specRepo;
         this.rawFileInfo = rawFileInfo;
         this.rawFileRepo = rawFileRepo;
         this.resultRepo = resultRepo;
+        this.logger = logger;
     }
 
     /**
      * Use case execution method: for a file, checks the presence of all headers marked as "required" in the
      * GTFS specification. A {@link MissingHeaderNotice} is generated each time a required header is missing.
-     * A {@link NonStandardHeaderNotice} is generated for each header not marked as "required". These notices are
+     * A {@link NonStandardHeaderNotice} is generated for each header not marked as "required".
+     * A {@link DuplicatedHeaderNotice} is generated for each duplicated header. These notices are
      * then added to the {@link ValidationResultRepository} provided in the constructor.
      */
     public void execute() {
+        logger.info("Validating rules :'E001 - Missing required field");
+        logger.info("                  'E043 - Duplicated field");
+        logger.info("                  'W002 - Non standard field name");
+
         List<String> expectedRequiredHeaderList = specRepo.getRequiredHeadersForFile(rawFileInfo);
         List<String> expectedOptionalHeaderList = specRepo.getOptionalHeadersForFile(rawFileInfo);
         Collection<String> actualHeaderList = rawFileRepo.getActualHeadersForFile(rawFileInfo);
 
-        //Missing headers
+        // Duplicated headers
+        Set<String> headerSet = new HashSet<>();
+        actualHeaderList.forEach(actualHeader -> {
+            if (!headerSet.add(actualHeader)) {
+                resultRepo.addNotice(new DuplicatedHeaderNotice(rawFileInfo.getFilename(), actualHeader));
+            }
+        });
+
+        // Missing headers
         expectedRequiredHeaderList.stream()
                 .filter(expectedHeader -> !(actualHeaderList.contains(expectedHeader)))
                 .forEach(missingHeader -> resultRepo.addNotice(new MissingHeaderNotice(rawFileInfo.getFilename(),
                         missingHeader)));
 
-        //Extra headers
+        // Extra headers
         actualHeaderList.stream()
                 .filter(header ->
                         !expectedOptionalHeaderList.contains(header) && !expectedRequiredHeaderList.contains(header))

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/RawFileRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/RawFileRepository.java
@@ -19,7 +19,7 @@ package org.mobilitydata.gtfsvalidator.usecase.port;
 import org.mobilitydata.gtfsvalidator.domain.entity.RawEntity;
 import org.mobilitydata.gtfsvalidator.domain.entity.RawFileInfo;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -32,7 +32,7 @@ public interface RawFileRepository {
 
     Optional<RawFileInfo> findByName(String filename);
 
-    Collection<String> getActualHeadersForFile(RawFileInfo file);
+    List<String> getActualHeadersForFile(RawFileInfo file);
 
     Set<String> getFilenameAll();
 


### PR DESCRIPTION
**Summary:**

close #129 

This PR adds a rule to check if a column is duplicated in an input file.
A `DuplicatedHeaderNotice` is built for each duplicate found, even for out of spec fields.

**Expected behavior:** 

[MTBA_duplicated_agency_name.zip](https://github.com/MobilityData/gtfs-validator/files/4997168/MTBA_duplicated_agency_name.zip)


![image](https://user-images.githubusercontent.com/55884852/88847270-c94ff380-d1b4-11ea-91d4-630d28e6e2c7.png)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)