### PR TITLE
Implement start and end times verification for a trip

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -44,7 +44,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E040](#E040) | Dataset should be valid for at least the next 7 days | 
 | [E041](#E041) | Invalid parent `location_type` for stop |
 | [E042](#E042) | Station stop (`location_type`=2) has a parent stop |
-| [E043](#E043) | Missing trip edge `arrival_time` and `departure_time` |
+| [E043](#E043) | Missing trip edge `arrival_time` or `departure_time` |
 
 ### Table of Warnings
 
@@ -234,7 +234,7 @@ Field `parent_station` must be empty when `location_type` is 2
 
 ### E043 - Missing trip edge `arrival_time` and `departure_time`
 
-First and last stop of a trip must define one or both fields
+First and last stop of a trip must define both fields
 
 # Warnings
 

--- a/RULES.md
+++ b/RULES.md
@@ -44,6 +44,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E040](#E040) | Dataset should be valid for at least the next 7 days | 
 | [E041](#E041) | Invalid parent `location_type` for stop |
 | [E042](#E042) | Station stop (`location_type`=2) has a parent stop |
+| [E043](#E043) | Missing trip edge `arrival_time` and `departure_time` |
 
 ### Table of Warnings
 
@@ -228,6 +229,12 @@ Field `parent_station` must be empty when `location_type` is 2
 
 #### References:
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
+
+<a name="E043"/>
+
+### E043 - Missing trip edge `arrival_time` and `departure_time`
+
+First and last stop of a trip must define one or both fields
 
 # Warnings
 

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -133,6 +133,11 @@ public class JsonNoticeExporter implements NoticeExporter {
     }
 
     @Override
+    public void export(final MissingTripEdgeStopTimeNotice toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
+
+    @Override
     public void export(final CannotParseColorNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -283,6 +283,26 @@ public class ProtobufNoticeExporter implements NoticeExporter {
     }
 
     @Override
+    public void export(MissingTripEdgeStopTimeNotice toExport) throws IOException {
+        String fieldName = (String) toExport.getNoticeSpecific(KEY_FIELD_NAME);
+        GtfsValidationOutputProto.GtfsProblem.Type problemType = fieldName.contains("departure") ?
+                GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_TIME_FOR_FIRST_STOP_TIME :
+                GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_TIME_FOR_LAST_STOP_TIME;
+
+        protoBuilder.clear()
+                .setCsvFileName(toExport.getFilename())
+                .setType(problemType)
+                .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
+                .setAltEntityId(fieldName)
+                .setValue("trip_id")
+                .setAltEntityValue("stop_sequence")
+                .setAltValue((String) toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE))
+                .setAltEntityName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE)))
+                .build()
+                .writeTo(streamGenerator.getStream());
+    }
+
+    @Override
     public void export(CannotParseColorNotice toExport) throws IOException {
         protoBuilder.clear()
                 .setCsvFileName(toExport.getFilename())

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -297,6 +297,22 @@ class JsonNoticeExporterTest {
     }
 
     @Test
+    void exportMissingTripEdgeStopTimeNoticeShouldWriteObject() throws IOException {
+        JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        MissingTripEdgeStopTimeNotice toExport = new MissingTripEdgeStopTimeNotice(
+                "filed_name",
+                "trip_id_XXX",
+                1234
+        );
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
+
+    @Test
     void exportInvalidColorNoticeShouldWriteObject() throws IOException {
         JsonGenerator mockGenerator = mock(JsonGenerator.class);
 

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -27,7 +27,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.time.LocalDate;
 
-import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_ROUTE_ID;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_SERVICE_ID;
 import static org.mockito.Mockito.*;
 
@@ -576,6 +575,64 @@ class ProtobufNoticeExporterTest {
         verify(mockBuilder, times(1)).setAltEntityName(ArgumentMatchers.eq(null));
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
+
+    @Test
+    void exportMissingTripStopTimeNoticeShouldMapToCsvProblemAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        // first stop (departure_time)
+        underTest.export(new MissingTripEdgeStopTimeNotice(
+                        "departure_time",
+                        "trip_id_XXX",
+                        1234
+                )
+        );
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(ArgumentMatchers.eq("stop_times.txt"));
+        verify(mockBuilder, times(1)).setType(
+                ArgumentMatchers.eq(
+                        GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_TIME_FOR_FIRST_STOP_TIME
+                )
+        );
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
+        verify(mockBuilder, times(1)).setAltEntityId(
+                ArgumentMatchers.eq("departure_time"));
+        verify(mockBuilder, times(1)).setAltEntityValue(
+                ArgumentMatchers.eq("stop_sequence"));
+        verify(mockBuilder, times(1)).setValue(ArgumentMatchers.eq("trip_id"));
+        verify(mockBuilder, times(1)).setAltValue(ArgumentMatchers.eq("trip_id_XXX"));
+        verify(mockBuilder, times(1)).setAltEntityName(ArgumentMatchers.eq("1234"));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+
+        // last stop (arrival_time)
+        underTest.export(new MissingTripEdgeStopTimeNotice(
+                        "arrival_time",
+                        "trip_id_XXX",
+                        1234
+                )
+        );
+
+        verify(mockBuilder, times(1)).setType(
+                ArgumentMatchers.eq(
+                        GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_TIME_FOR_LAST_STOP_TIME
+                )
+        );
     }
 
     @Test

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.db;
 
 import org.jetbrains.annotations.NotNull;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.fareattributes.FareAttribute;
@@ -30,11 +31,7 @@ import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.trips.Trip;
 import org.mobilitydata.gtfsvalidator.domain.entity.stops.LocationBase;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 
-import java.time.LocalDate;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 
 /**
  * This holds an internal representation of gtfs entities: each row of each file from a GTFS dataset is represented here
@@ -832,8 +829,8 @@ public class InMemoryGtfsDataRepository implements GtfsDataRepository {
      * @return an immutable map of {@link StopTime} from stop_times.txt related to the trip_id provided as parameter
      */
     @Override
-    public Map<Integer, StopTime> getStopTimeByTripId(final String tripId) {
-        return Collections.unmodifiableMap(stopTimePerTripIdStopSequence.get(tripId));
+    public SortedMap<Integer, StopTime> getStopTimeByTripId(final String tripId) {
+        return Collections.unmodifiableSortedMap(stopTimePerTripIdStopSequence.get(tripId));
     }
 
     /**

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -196,6 +196,7 @@ public class Main {
                 config.validateFeedCoversTheNext7ServiceDays().execute();
                 config.validateFeedCoversTheNext30ServiceDays().execute();
                 config.validateFeedInfoFeedEndDateIsPresent().execute();
+                config.validateTripEdgeArrivalDepartureTime().execute();
 
                 config.cleanOrCreatePath().execute(ExecParamRepository.OUTPUT_KEY);
 

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -319,6 +319,10 @@ public class DefaultConfig {
         return new ValidateTripServiceId(gtfsDataRepository, resultRepo, logger);
     }
 
+    public ValidateTripEdgeArrivalDepartureTime validateTripEdgeArrivalDepartureTime() {
+        return new ValidateTripEdgeArrivalDepartureTime(gtfsDataRepository, resultRepo, logger);
+    }
+
     public ValidateRouteAgencyId validateRouteAgencyId() {
         return new ValidateRouteAgencyId(gtfsDataRepository, resultRepo, logger);
     }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -45,6 +45,8 @@ public interface NoticeExporter {
 
     void export(MissingRequiredValueNotice toExport) throws IOException;
 
+    void export(MissingTripEdgeStopTimeNotice toExport) throws IOException;
+
     void export(CannotParseColorNotice toExport) throws IOException;
 
     void export(ExtraFileFoundNotice toExport) throws IOException;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -61,6 +61,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_040 = 40;
     protected static final int E_041 = 41;
     protected static final int E_042 = 42;
+    protected static final int E_043 = 43;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -62,6 +62,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_041 = 41;
     protected static final int E_042 = 42;
     protected static final int E_043 = 43;
+    protected static final int E_044 = 44;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingTripEdgeStopTimeNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingTripEdgeStopTimeNotice.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020. MobilityData IO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.domain.entity.notice.error;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+
+import java.io.IOException;
+
+public class MissingTripEdgeStopTimeNotice extends ErrorNotice {
+
+    public MissingTripEdgeStopTimeNotice(final String fieldName, final String tripId, final Integer stopSequence) {
+        super("stop_times.txt", E_043,
+                "Missing trip edge stop time value",
+                "Edge of trip with id:`" + tripId + "` is missing value for field:`" + fieldName
+                        + "`. Stop time composite id: " +
+                        "`trip_id`: `" + tripId + "`" + "--" +
+                        "`stop_sequence`: `" + stopSequence + "`.",
+                null);
+
+        putNoticeSpecific(KEY_FIELD_NAME, fieldName);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART, "trip_id");
+        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE, tripId);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART, "stop_sequence");
+        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE, stopSequence);
+    }
+
+    @Override
+    public void export(final NoticeExporter exporter) throws IOException {
+        exporter.export(this);
+    }
+}

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingTripEdgeStopTimeNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingTripEdgeStopTimeNotice.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 public class MissingTripEdgeStopTimeNotice extends ErrorNotice {
 
     public MissingTripEdgeStopTimeNotice(final String fieldName, final String tripId, final Integer stopSequence) {
-        super("stop_times.txt", E_043,
+        super("stop_times.txt", E_044,
                 "Missing trip edge stop time value",
                 "Edge of trip with id:`" + tripId + "` is missing value for field:`" + fieldName
                         + "`. Stop time composite id: " +

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTime.java
@@ -49,12 +49,12 @@ public class ValidateTripEdgeArrivalDepartureTime {
 
     /**
      * Use case execution method: Checks if first and last stop in sequence associated with a trip define
-     * either or both fields `departure_time` and `arrival_time`.
+     * both fields `departure_time` and `arrival_time`.
      * A new {@link MissingTripEdgeStopTimeNotice} notice is generated each time this condition is false.
      * This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
      */
     public void execute() {
-        logger.info("Validating rule E043 - Missing trip edge arrival_time and departure_time");
+        logger.info("Validating rule E043 - Missing trip edge arrival_time or departure_time");
 
         dataRepo.getTripAll().keySet().forEach(tripId -> {
             SortedMap<Integer, StopTime> stopTimesForTrip = dataRepo.getStopTimeByTripId(tripId);
@@ -62,7 +62,15 @@ public class ValidateTripEdgeArrivalDepartureTime {
             StopTime tripStartStop = stopTimesForTrip.get(stopTimesForTrip.firstKey());
             StopTime tripEndStop = stopTimesForTrip.get(stopTimesForTrip.lastKey());
 
-            if (tripStartStop.getDepartureTime() == null && tripStartStop.getArrivalTime() == null) {
+            if (tripStartStop.getArrivalTime() == null) {
+                resultRepo.addNotice(
+                        new MissingTripEdgeStopTimeNotice("arrival_time",
+                                tripId,
+                                tripStartStop.getStopSequence()
+                        )
+                );
+            }
+            if (tripStartStop.getDepartureTime() == null) {
                 resultRepo.addNotice(
                         new MissingTripEdgeStopTimeNotice("departure_time",
                                 tripId,
@@ -71,11 +79,19 @@ public class ValidateTripEdgeArrivalDepartureTime {
                 );
             }
 
-            if (tripEndStop.getArrivalTime() == null && tripEndStop.getDepartureTime() == null) {
+            if (tripEndStop.getArrivalTime() == null) {
                 resultRepo.addNotice(
                         new MissingTripEdgeStopTimeNotice("arrival_time",
                                 tripId,
-                                tripStartStop.getStopSequence()
+                                tripEndStop.getStopSequence()
+                        )
+                );
+            }
+            if (tripEndStop.getDepartureTime() == null) {
+                resultRepo.addNotice(
+                        new MissingTripEdgeStopTimeNotice("departure_time",
+                                tripId,
+                                tripEndStop.getStopSequence()
                         )
                 );
             }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTime.java
@@ -1,0 +1,84 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingTripEdgeStopTimeNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+
+import java.util.SortedMap;
+
+/**
+ * Use case for E043 to validate that all records of `trips.txt` refer to an a collection of {@code StopTime} from file
+ * `stop_times.txt` of which -when sorted by `stop_sequence`-
+ * the first and last element define either or both `departure_time` and `arrival_time`
+ */
+public class ValidateTripEdgeArrivalDepartureTime {
+    private final GtfsDataRepository dataRepo;
+    private final ValidationResultRepository resultRepo;
+    private final Logger logger;
+
+    /**
+     * @param dataRepo   a repository storing the data of a GTFS dataset
+     * @param resultRepo a repository storing information about the validation process
+     * @param logger     a logger to log information about the validation process
+     */
+    public ValidateTripEdgeArrivalDepartureTime(final GtfsDataRepository dataRepo,
+                                                final ValidationResultRepository resultRepo,
+                                                final Logger logger) {
+        this.dataRepo = dataRepo;
+        this.resultRepo = resultRepo;
+        this.logger = logger;
+    }
+
+    /**
+     * Use case execution method: Checks if first and last stop in sequence associated with a trip define
+     * either or both fields `departure_time` and `arrival_time`.
+     * A new {@link MissingTripEdgeStopTimeNotice} notice is generated each time this condition is false.
+     * This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
+     */
+    public void execute() {
+        logger.info("Validating rule E043 - Missing trip edge arrival_time and departure_time");
+
+        dataRepo.getTripAll().keySet().forEach(tripId -> {
+            SortedMap<Integer, StopTime> stopTimesForTrip = dataRepo.getStopTimeByTripId(tripId);
+
+            StopTime tripStartStop = stopTimesForTrip.get(stopTimesForTrip.firstKey());
+            StopTime tripEndStop = stopTimesForTrip.get(stopTimesForTrip.lastKey());
+
+            if (tripStartStop.getDepartureTime() == null && tripStartStop.getArrivalTime() == null) {
+                resultRepo.addNotice(
+                        new MissingTripEdgeStopTimeNotice("departure_time",
+                                tripId,
+                                tripStartStop.getStopSequence()
+                        )
+                );
+            }
+
+            if (tripEndStop.getArrivalTime() == null && tripEndStop.getDepartureTime() == null) {
+                resultRepo.addNotice(
+                        new MissingTripEdgeStopTimeNotice("arrival_time",
+                                tripId,
+                                tripStartStop.getStopSequence()
+                        )
+                );
+            }
+        });
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTime.java
@@ -54,7 +54,7 @@ public class ValidateTripEdgeArrivalDepartureTime {
      * This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
      */
     public void execute() {
-        logger.info("Validating rule E043 - Missing trip edge arrival_time or departure_time");
+        logger.info("Validating rule E044 - Missing trip edge arrival_time or departure_time");
 
         dataRepo.getTripAll().keySet().forEach(tripId -> {
             SortedMap<Integer, StopTime> stopTimesForTrip = dataRepo.getStopTimeByTripId(tripId);

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
@@ -28,8 +28,8 @@ import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.translations.Translatio
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.trips.Trip;
 import org.mobilitydata.gtfsvalidator.domain.entity.stops.LocationBase;
 
-import java.time.LocalDate;
 import java.util.Map;
+import java.util.SortedMap;
 import java.util.TreeMap;
 
 public interface GtfsDataRepository {
@@ -158,7 +158,7 @@ public interface GtfsDataRepository {
      * @param tripId identifies a trip
      * @return an immutable map of {@link StopTime} from stop_times.txt related to the trip_id provided as parameter
      */
-    Map<Integer, StopTime> getStopTimeByTripId(final String tripId);
+    SortedMap<Integer, StopTime> getStopTimeByTripId(final String tripId);
 
     /**
      * Return an immutable map representing all records from stop_times.txt. Elements of this map are mapped by

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTimeTest.java
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.trips.Trip;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingTripEdgeStopTimeNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.*;
+import static org.mockito.Mockito.*;
+
+class ValidateTripEdgeArrivalDepartureTimeTest {
+
+    @Test
+    void tripWithFirstStopMissingArrivalAndDepartureTimeShouldGenerateNotice() {
+
+        final StopTime mockStopTime0 = mock(StopTime.class);
+        when(mockStopTime0.getDepartureTime()).thenReturn(null);
+        when(mockStopTime0.getArrivalTime()).thenReturn(null);
+        final StopTime mockStopTime1 = mock(StopTime.class);
+        final StopTime mockStopTime2 = mock(StopTime.class);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+
+        when(mockDataRepo.getTripAll()).thenReturn(Map.of("trip_id__test", mock(Trip.class)));
+
+        SortedMap<Integer, StopTime> mockSortedMap =
+                new TreeMap<>(
+                        Map.of(0, mockStopTime0, 1, mockStopTime1, 2, mockStopTime2)
+                );
+
+        when(mockDataRepo.getStopTimeByTripId(ArgumentMatchers.anyString())).thenReturn(mockSortedMap);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateTripEdgeArrivalDepartureTime underTest =
+                new ValidateTripEdgeArrivalDepartureTime(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
+                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+
+        verify(mockDataRepo, times(1)).getTripAll();
+        verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
+        verifyNoInteractions(mockStopTime1);
+
+        final ArgumentCaptor<MissingTripEdgeStopTimeNotice> captor =
+                ArgumentCaptor.forClass(MissingTripEdgeStopTimeNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final MissingTripEdgeStopTimeNotice notice = captor.getValue();
+
+        assertEquals("stop_times.txt", notice.getFilename());
+        assertEquals("departure_time", notice.getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals("no id", notice.getEntityId());
+        assertEquals("trip_id", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART));
+        assertEquals("trip_id__test", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE));
+        assertEquals("stop_sequence", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART));
+        assertEquals(0, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
+
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo);
+    }
+
+    @Test
+    void tripWithLastStopMissingArrivalAndDepartureTimeShouldGenerateNotice() {
+
+        final StopTime mockStopTime0 = mock(StopTime.class);
+        final StopTime mockStopTime1 = mock(StopTime.class);
+        final StopTime mockStopTime2 = mock(StopTime.class);
+        when(mockStopTime2.getDepartureTime()).thenReturn(null);
+        when(mockStopTime2.getArrivalTime()).thenReturn(null);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+
+        when(mockDataRepo.getTripAll()).thenReturn(Map.of("trip_id__test", mock(Trip.class)));
+
+        SortedMap<Integer, StopTime> mockSortedMap =
+                new TreeMap<>(
+                        Map.of(0, mockStopTime0, 1, mockStopTime1, 2, mockStopTime2)
+                );
+
+        when(mockDataRepo.getStopTimeByTripId(ArgumentMatchers.anyString())).thenReturn(mockSortedMap);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateTripEdgeArrivalDepartureTime underTest =
+                new ValidateTripEdgeArrivalDepartureTime(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
+                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+
+        verify(mockDataRepo, times(1)).getTripAll();
+        verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
+        verifyNoInteractions(mockStopTime1);
+
+        final ArgumentCaptor<MissingTripEdgeStopTimeNotice> captor =
+                ArgumentCaptor.forClass(MissingTripEdgeStopTimeNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final MissingTripEdgeStopTimeNotice notice = captor.getValue();
+
+        assertEquals("stop_times.txt", notice.getFilename());
+        assertEquals("arrival_time", notice.getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals("no id", notice.getEntityId());
+        assertEquals("trip_id", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART));
+        assertEquals("trip_id__test", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE));
+        assertEquals("stop_sequence", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART));
+        assertEquals(0, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
+
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo);
+    }
+
+    @Test
+    void tripWithValidEdgeArrivalAndDepartureTimeShouldNotGenerateNotice() {
+
+        final StopTime mockStopTime0 = mock(StopTime.class);
+        final StopTime mockStopTime1 = mock(StopTime.class);
+        final StopTime mockStopTime2 = mock(StopTime.class);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+
+        when(mockDataRepo.getTripAll()).thenReturn(Map.of("trip_id__test", mock(Trip.class)));
+
+        SortedMap<Integer, StopTime> mockSortedMap =
+                new TreeMap<>(
+                        Map.of(0, mockStopTime0, 1, mockStopTime1, 2, mockStopTime2)
+                );
+
+        when(mockDataRepo.getStopTimeByTripId(ArgumentMatchers.anyString())).thenReturn(mockSortedMap);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateTripEdgeArrivalDepartureTime underTest =
+                new ValidateTripEdgeArrivalDepartureTime(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
+                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+
+        verify(mockDataRepo, times(1)).getTripAll();
+        verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
+        verifyNoInteractions(mockStopTime1, mockResultRepo);
+        verifyNoMoreInteractions(mockLogger, mockResultRepo);
+    }
+
+    @Test
+    void validateAllTripCheck() {
+
+        final StopTime mockStopTime0 = mock(StopTime.class);
+        final StopTime mockStopTime1 = mock(StopTime.class);
+        final StopTime mockStopTime2 = mock(StopTime.class);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+
+        when(mockDataRepo.getTripAll()).thenReturn(Map.of("trip_id__test_0", mock(Trip.class),
+                "trip_id__test_1", mock(Trip.class)));
+
+        SortedMap<Integer, StopTime> mockSortedMap =
+                new TreeMap<>(
+                        Map.of(0, mockStopTime0, 1, mockStopTime1, 2, mockStopTime2)
+                );
+
+        when(mockDataRepo.getStopTimeByTripId(ArgumentMatchers.anyString())).thenReturn(mockSortedMap);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateTripEdgeArrivalDepartureTime underTest =
+                new ValidateTripEdgeArrivalDepartureTime(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
+                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+
+        verify(mockDataRepo, times(1)).getTripAll();
+        verify(mockDataRepo, times(2)).getStopTimeByTripId(ArgumentMatchers.anyString());
+        verifyNoInteractions(mockStopTime1, mockResultRepo);
+        verifyNoMoreInteractions(mockLogger, mockResultRepo);
+    }
+}

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTimeTest.java
@@ -66,7 +66,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
+                "Validating rule E044 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
@@ -130,7 +130,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
+                "Validating rule E044 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
@@ -191,7 +191,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
+                "Validating rule E044 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
@@ -227,7 +227,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
+                "Validating rule E044 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(2)).getStopTimeByTripId(ArgumentMatchers.anyString());

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateTripEdgeArrivalDepartureTimeTest.java
@@ -40,10 +40,11 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
     void tripWithFirstStopMissingArrivalAndDepartureTimeShouldGenerateNotice() {
 
         final StopTime mockStopTime0 = mock(StopTime.class);
-        when(mockStopTime0.getDepartureTime()).thenReturn(null);
-        when(mockStopTime0.getArrivalTime()).thenReturn(null);
         final StopTime mockStopTime1 = mock(StopTime.class);
         final StopTime mockStopTime2 = mock(StopTime.class);
+        when(mockStopTime0.getDepartureTime()).thenReturn(null);
+        when(mockStopTime0.getArrivalTime()).thenReturn(null);
+        when(mockStopTime0.getStopSequence()).thenReturn(514);
 
         final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
 
@@ -65,7 +66,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
@@ -74,9 +75,19 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         final ArgumentCaptor<MissingTripEdgeStopTimeNotice> captor =
                 ArgumentCaptor.forClass(MissingTripEdgeStopTimeNotice.class);
 
-        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+        verify(mockResultRepo, times(2)).addNotice(captor.capture());
 
-        final MissingTripEdgeStopTimeNotice notice = captor.getValue();
+        MissingTripEdgeStopTimeNotice notice = captor.getAllValues().get(0);
+
+        assertEquals("stop_times.txt", notice.getFilename());
+        assertEquals("arrival_time", notice.getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals("no id", notice.getEntityId());
+        assertEquals("trip_id", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART));
+        assertEquals("trip_id__test", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE));
+        assertEquals("stop_sequence", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART));
+        assertEquals(514, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
+
+        notice = captor.getAllValues().get(1);
 
         assertEquals("stop_times.txt", notice.getFilename());
         assertEquals("departure_time", notice.getNoticeSpecific(KEY_FIELD_NAME));
@@ -84,7 +95,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         assertEquals("trip_id", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART));
         assertEquals("trip_id__test", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE));
         assertEquals("stop_sequence", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART));
-        assertEquals(0, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
+        assertEquals(514, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
 
         verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo);
     }
@@ -97,6 +108,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         final StopTime mockStopTime2 = mock(StopTime.class);
         when(mockStopTime2.getDepartureTime()).thenReturn(null);
         when(mockStopTime2.getArrivalTime()).thenReturn(null);
+        when(mockStopTime2.getStopSequence()).thenReturn(514);
 
         final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
 
@@ -118,7 +130,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
@@ -127,9 +139,9 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         final ArgumentCaptor<MissingTripEdgeStopTimeNotice> captor =
                 ArgumentCaptor.forClass(MissingTripEdgeStopTimeNotice.class);
 
-        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+        verify(mockResultRepo, times(2)).addNotice(captor.capture());
 
-        final MissingTripEdgeStopTimeNotice notice = captor.getValue();
+        MissingTripEdgeStopTimeNotice notice = captor.getAllValues().get(0);
 
         assertEquals("stop_times.txt", notice.getFilename());
         assertEquals("arrival_time", notice.getNoticeSpecific(KEY_FIELD_NAME));
@@ -137,7 +149,17 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         assertEquals("trip_id", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART));
         assertEquals("trip_id__test", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE));
         assertEquals("stop_sequence", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART));
-        assertEquals(0, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
+        assertEquals(514, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
+
+        notice = captor.getAllValues().get(1);
+
+        assertEquals("stop_times.txt", notice.getFilename());
+        assertEquals("departure_time", notice.getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals("no id", notice.getEntityId());
+        assertEquals("trip_id", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART));
+        assertEquals("trip_id__test", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE));
+        assertEquals("stop_sequence", notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART));
+        assertEquals(514, notice.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE));
 
         verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo);
     }
@@ -169,7 +191,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(1)).getStopTimeByTripId(ArgumentMatchers.eq("trip_id__test"));
@@ -205,7 +227,7 @@ class ValidateTripEdgeArrivalDepartureTimeTest {
         underTest.execute();
 
         verify(mockLogger, times(1)).info(ArgumentMatchers.eq(
-                "Validating rule E043 - Missing trip edge arrival_time and departure_time"));
+                "Validating rule E043 - Missing trip edge arrival_time or departure_time"));
 
         verify(mockDataRepo, times(1)).getTripAll();
         verify(mockDataRepo, times(2)).getStopTimeByTripId(ArgumentMatchers.anyString());


### PR DESCRIPTION
**Summary:**

closes #205 
This PR contains the required changes to validate each trip first and last stop time in `stop_times.txt` define either or both fields `departure_time` or `arrival_time`

**Expected behavior:** 

![image](https://user-images.githubusercontent.com/55884852/89231815-1583a500-d5b4-11ea-8795-22bc4ea75ee2.png)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)