### PR TITLE
Implements #198 - Stop times Departure Time after Arrival Time verification

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -44,6 +44,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E040](#E040) | Dataset should be valid for at least the next 7 days | 
 | [E041](#E041) | Invalid parent `location_type` for stop |
 | [E042](#E042) | Station stop (`location_type`=2) has a parent stop |
+| [E043](#E043) | `arrival_time` after `departure_time` in `stop_times.txt` |
 
 ### Table of Warnings
 
@@ -226,8 +227,14 @@ Any other combination raise this error
 
 Field `parent_station` must be empty when `location_type` is 2
 
+<a name="E043"/>
+
+### E043 - `arrival_time` after `departure_time` in `stop_times.txt`
+
+The `departure_time` must not precede the `arrival_time` in `stop_times.txt` if both are given. 
+
 #### References:
-* [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
+* [stop_times.txt specification](http://gtfs.org/reference/static/#stop_timestxt)
 
 # Warnings
 

--- a/RULES.md
+++ b/RULES.md
@@ -227,6 +227,9 @@ Any other combination raise this error
 
 Field `parent_station` must be empty when `location_type` is 2
 
+#### References:
+* [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
+
 <a name="E043"/>
 
 ### E043 - `arrival_time` after `departure_time` in `stop_times.txt`

--- a/RULES.md
+++ b/RULES.md
@@ -45,7 +45,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E041](#E041) | Invalid parent `location_type` for stop |
 | [E042](#E042) | Station stop (`location_type`=2) has a parent stop |
 | [E043](#E043) | Duplicated field |
-| [E044](#E044) | `arrival_time` after `departure_time` in `stop_times.txt` |
+| [E045](#E045) | `arrival_time` after `departure_time` in `stop_times.txt` |
 
 ### Table of Warnings
 
@@ -243,9 +243,9 @@ Field `parent_station` must be empty when `location_type` is 2
 
 A file cannot contain the same header value twice (i.e., duplicated column of data).
 
-<a name="E044"/>
+<a name="E045"/>
 
-### E044 - `arrival_time` after `departure_time` in `stop_times.txt`
+### E045 - `arrival_time` after `departure_time` in `stop_times.txt`
 
 The `departure_time` must not precede the `arrival_time` in `stop_times.txt` if both are given. 
 

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.exporter;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
@@ -309,6 +310,11 @@ public class JsonNoticeExporter implements NoticeExporter {
 
     @Override
     public void export(final ParentStationInvalidLocationTypeNotice toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
+
+    @Override
+    public void export(final StopTimeArrivalTimeAfterDepartureTimeNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }
 }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -17,7 +17,6 @@
 package org.mobilitydata.gtfsvalidator.exporter;
 
 import com.fasterxml.jackson.core.JsonGenerator;
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.exporter;
 
 import org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto;
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
@@ -723,6 +724,23 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .setOtherCsvFileName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE)))
                 .setOtherCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE)))
                 .setAltEntityId(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_THIRD_VALUE)))
+                .build()
+                .writeTo(streamGenerator.getStream());
+    }
+
+    @Override
+    public void export(final StopTimeArrivalTimeAfterDepartureTimeNotice toExport) throws IOException {
+        protoBuilder.clear()
+                .setCsvFileName(toExport.getFilename())
+                .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
+                .setAltValue(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART)))
+                .setCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART)))
+                .setAltEntityName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_THIRD_PART)))
+                .setOtherCsvFileName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE)))
+                .setOtherCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE)))
+                .setAltEntityId(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_THIRD_VALUE)))
+                .setEntityValue(String.valueOf(toExport.getNoticeSpecific(KEY_STOP_TIME_ARRIVAL_TIME)))
+                .setAltEntityValue(String.valueOf(toExport.getNoticeSpecific(KEY_STOP_TIME_DEPARTURE_TIME)))
                 .build()
                 .writeTo(streamGenerator.getStream());
     }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -17,7 +17,6 @@
 package org.mobilitydata.gtfsvalidator.exporter;
 
 import org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto;
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
@@ -735,10 +734,8 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
                 .setAltValue(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART)))
                 .setCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART)))
-                .setAltEntityName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_THIRD_PART)))
                 .setOtherCsvFileName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE)))
                 .setOtherCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE)))
-                .setAltEntityId(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_THIRD_VALUE)))
                 .setEntityValue(String.valueOf(toExport.getNoticeSpecific(KEY_STOP_TIME_ARRIVAL_TIME)))
                 .setAltEntityValue(String.valueOf(toExport.getNoticeSpecific(KEY_STOP_TIME_DEPARTURE_TIME)))
                 .build()

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -797,8 +797,6 @@ class JsonNoticeExporterTest {
                 new StopTimeArrivalTimeAfterDepartureTimeNotice("stop_times.txt",
                         "arrival_time",
                         "departure_time",
-                        "stop_time_trip_id",
-                        "stop_time_stop_sequence",
                         "stop time trip id",
                         "stop time stop sequence");
         underTest.export(toExport);

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -798,7 +798,7 @@ class JsonNoticeExporterTest {
                         "arrival_time",
                         "departure_time",
                         "stop time trip id",
-                        "stop time stop sequence");
+                        514);
         underTest.export(toExport);
 
         verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -18,7 +18,6 @@ package org.mobilitydata.gtfsvalidator.exporter;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.junit.jupiter.api.Test;
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
 import org.mockito.ArgumentMatchers;

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.exporter;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
 import org.mockito.ArgumentMatchers;
@@ -782,6 +783,25 @@ class JsonNoticeExporterTest {
                         "feed publisher name",
                         "feed publisher url",
                         "feed lang");
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
+
+    @Test
+    void exportStopTimeArrivalTimeAfterDepartureTimeNoticeShouldWriteObject() throws IOException {
+        JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        StopTimeArrivalTimeAfterDepartureTimeNotice toExport =
+                new StopTimeArrivalTimeAfterDepartureTimeNotice("stop_times.txt",
+                        "arrival_time",
+                        "departure_time",
+                        "stop_time_trip_id",
+                        "stop_time_stop_sequence",
+                        "stop time trip id",
+                        "stop time stop sequence");
         underTest.export(toExport);
 
         verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -1778,7 +1778,7 @@ class ProtobufNoticeExporterTest {
                         "arrival_time",
                         "departure_time",
                         "stop time trip id",
-                        "stop time stop sequence"));
+                        514));
 
         verify(mockBuilder, times(1)).clear();
         verify(mockBuilder, times(1)).setCsvFileName(
@@ -1792,7 +1792,7 @@ class ProtobufNoticeExporterTest {
         verify(mockBuilder, times(1)).setOtherCsvFileName(
                 ArgumentMatchers.eq("stop time trip id"));
         verify(mockBuilder, times(1)).setOtherCsvKeyName(
-                ArgumentMatchers.eq("stop time stop sequence"));
+                ArgumentMatchers.eq(String.valueOf(514)));
         verify(mockBuilder, times(1)).setEntityValue(
                 ArgumentMatchers.eq("arrival_time"));
         verify(mockBuilder, times(1)).setAltEntityValue(

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -1777,8 +1777,6 @@ class ProtobufNoticeExporterTest {
                 new StopTimeArrivalTimeAfterDepartureTimeNotice("stop_times.txt",
                         "arrival_time",
                         "departure_time",
-                        "stop_time_trip_id",
-                        "stop_time_stop_sequence",
                         "stop time trip id",
                         "stop time stop sequence"));
 
@@ -1788,9 +1786,9 @@ class ProtobufNoticeExporterTest {
         verify(mockBuilder, times(1)).setSeverity(
                 ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
         verify(mockBuilder, times(1)).setAltValue(
-                ArgumentMatchers.eq("stop_time_trip_id"));
+                ArgumentMatchers.eq("tripId"));
         verify(mockBuilder, times(1)).setCsvKeyName(
-                ArgumentMatchers.eq("stop_time_stop_sequence"));
+                ArgumentMatchers.eq("stopSequence"));
         verify(mockBuilder, times(1)).setOtherCsvFileName(
                 ArgumentMatchers.eq("stop time trip id"));
         verify(mockBuilder, times(1)).setOtherCsvKeyName(

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.exporter;
 
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto;
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
 import org.mockito.ArgumentMatchers;
@@ -27,7 +28,6 @@ import java.io.OutputStream;
 import java.net.URL;
 import java.time.LocalDate;
 
-import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_ROUTE_ID;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_SERVICE_ID;
 import static org.mockito.Mockito.*;
 
@@ -1754,6 +1754,53 @@ class ProtobufNoticeExporterTest {
                 ArgumentMatchers.eq("feed publisher url"));
         verify(mockBuilder, times(1)).setAltEntityId(
                 ArgumentMatchers.eq("feed lang"));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
+
+    @Test
+    void exportStopTimeArrivalTimeAfterDepartureTimeNoticeShouldMapToCsvProblemAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        underTest.export(
+                new StopTimeArrivalTimeAfterDepartureTimeNotice("stop_times.txt",
+                        "arrival_time",
+                        "departure_time",
+                        "stop_time_trip_id",
+                        "stop_time_stop_sequence",
+                        "stop time trip id",
+                        "stop time stop sequence"));
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(
+                ArgumentMatchers.eq("stop_times.txt"));
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
+        verify(mockBuilder, times(1)).setAltValue(
+                ArgumentMatchers.eq("stop_time_trip_id"));
+        verify(mockBuilder, times(1)).setCsvKeyName(
+                ArgumentMatchers.eq("stop_time_stop_sequence"));
+        verify(mockBuilder, times(1)).setOtherCsvFileName(
+                ArgumentMatchers.eq("stop time trip id"));
+        verify(mockBuilder, times(1)).setOtherCsvKeyName(
+                ArgumentMatchers.eq("stop time stop sequence"));
+        verify(mockBuilder, times(1)).setEntityValue(
+                ArgumentMatchers.eq("arrival_time"));
+        verify(mockBuilder, times(1)).setAltEntityValue(
+                ArgumentMatchers.eq("departure_time"));
+
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -18,7 +18,6 @@ package org.mobilitydata.gtfsvalidator.exporter;
 
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto;
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
 import org.mockito.ArgumentMatchers;

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -196,6 +196,8 @@ public class Main {
                 config.validateFeedCoversTheNext7ServiceDays().execute();
                 config.validateFeedCoversTheNext30ServiceDays().execute();
                 config.validateFeedInfoFeedEndDateIsPresent().execute();
+                config.validateFeedInfoFeedStartDateIsPresent().execute();
+                config.validateStopTimeDepartureTimeAfterArrivalTime().execute();
 
                 config.cleanOrCreatePath().execute(ExecParamRepository.OUTPUT_KEY);
 

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -329,6 +329,10 @@ public class DefaultConfig {
                 new ValidateStopTimeTripId());
     }
 
+    public ValidateStopTimeDepartureTimeAfterArrivalTime validateStopTimeDepartureTimeAfterArrivalTime() {
+        return new ValidateStopTimeDepartureTimeAfterArrivalTime(gtfsDataRepository, resultRepo, timeUtils, logger);
+    }
+
     public ShapeBasedCrossValidator shapeBasedCrossValidator() {
         return new ShapeBasedCrossValidator(gtfsDataRepository, resultRepo, logger, new ValidateShapeUsage());
     }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/StopTimeArrivalTimeAfterDepartureTimeNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/StopTimeArrivalTimeAfterDepartureTimeNotice.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020. MobilityData IO.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.domain.entity;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+
+import java.io.IOException;
+
+public class StopTimeArrivalTimeAfterDepartureTimeNotice extends ErrorNotice {
+    public StopTimeArrivalTimeAfterDepartureTimeNotice(final String filename,
+                                                       final String arrivalTimeAsString,
+                                                       final String departureTimeAsString,
+                                                       final String compositeKeyFirstPart,
+                                                       final String compositeKeySecondPart,
+                                                       final String compositeKeyFirstValue,
+                                                       final String compositeKeySecondValue) {
+        super("stop_times.txt",
+                E_043,
+                "Fields `arrival_time` and `departure_time` out of order",
+                "`departure_time`: `" + departureTimeAsString + "` precedes `arrival_time`: `" +
+                        arrivalTimeAsString + "` in file `" + filename +
+                        "` for entity with composite id:" +
+                        "`" + compositeKeyFirstPart + "`: `" + compositeKeyFirstValue + "` -- " +
+                        "`" + compositeKeySecondPart + "`: `" + compositeKeySecondValue + "`.",
+                null);
+
+        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART, compositeKeyFirstPart);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART, compositeKeySecondPart);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE, compositeKeyFirstValue);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE, compositeKeySecondValue);
+        putNoticeSpecific(KEY_STOP_TIME_ARRIVAL_TIME, arrivalTimeAsString);
+        putNoticeSpecific(KEY_STOP_TIME_DEPARTURE_TIME, departureTimeAsString);
+    }
+
+    @Override
+    public void export(final NoticeExporter exporter) throws IOException {
+        exporter.export(this);
+    }
+}

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -1,5 +1,6 @@
 package org.mobilitydata.gtfsvalidator.domain.entity.notice;
 
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
 
@@ -116,5 +117,8 @@ public interface NoticeExporter {
     void export(final StationWithParentStationNotice stationWithParentStationNotice) throws IOException;
 
     void export(final ParentStationInvalidLocationTypeNotice parentStationInvalidLocationTypeNotice)
+            throws IOException;
+
+    void export(final StopTimeArrivalTimeAfterDepartureTimeNotice StopTimeArrivalTimeAfterDepartureTimeNotice)
             throws IOException;
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -1,6 +1,5 @@
 package org.mobilitydata.gtfsvalidator.domain.entity.notice;
 
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.*;
 

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -61,6 +61,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_040 = 40;
     protected static final int E_041 = 41;
     protected static final int E_042 = 42;
+    protected static final int E_043 = 43;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -62,6 +62,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_041 = 41;
     protected static final int E_042 = 42;
     protected static final int E_043 = 43;
+    protected static final int E_045 = 45;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
@@ -68,6 +68,8 @@ public abstract class Notice {
     public static final String KEY_PARENT_ID = "parentId";
     public static final String KEY_EXPECTED_PARENT_LOCATION_TYPE = "expectedParentLocationType";
     public static final String KEY_ACTUAL_PARENT_LOCATION_TYPE = "actualParentLocationType";
+    public static final String KEY_STOP_TIME_ARRIVAL_TIME = "stopTimeArrivalTime";
+    public static final String KEY_STOP_TIME_DEPARTURE_TIME = "stopTimeDepartureTime";
 
     private final String filename;
     private final int code;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/StopTimeArrivalTimeAfterDepartureTimeNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/StopTimeArrivalTimeAfterDepartureTimeNotice.java
@@ -28,7 +28,7 @@ public class StopTimeArrivalTimeAfterDepartureTimeNotice extends ErrorNotice {
                                                        final String tripId,
                                                        final Integer stopSequence) {
         super("stop_times.txt",
-                E_043,
+                E_045,
                 "Fields `arrival_time` and `departure_time` out of order",
                 "`departure_time`: `" + departureTimeAsString + "` precedes `arrival_time`: `" +
                         arrivalTimeAsString + "` in file `" + filename +

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/StopTimeArrivalTimeAfterDepartureTimeNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/StopTimeArrivalTimeAfterDepartureTimeNotice.java
@@ -26,7 +26,7 @@ public class StopTimeArrivalTimeAfterDepartureTimeNotice extends ErrorNotice {
                                                        final String arrivalTimeAsString,
                                                        final String departureTimeAsString,
                                                        final String tripId,
-                                                       final String stopSequence) {
+                                                       final Integer stopSequence) {
         super("stop_times.txt",
                 E_043,
                 "Fields `arrival_time` and `departure_time` out of order",

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/StopTimeArrivalTimeAfterDepartureTimeNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/StopTimeArrivalTimeAfterDepartureTimeNotice.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package org.mobilitydata.gtfsvalidator.domain.entity;
+package org.mobilitydata.gtfsvalidator.domain.entity.notice.error;
 
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
@@ -25,24 +25,22 @@ public class StopTimeArrivalTimeAfterDepartureTimeNotice extends ErrorNotice {
     public StopTimeArrivalTimeAfterDepartureTimeNotice(final String filename,
                                                        final String arrivalTimeAsString,
                                                        final String departureTimeAsString,
-                                                       final String compositeKeyFirstPart,
-                                                       final String compositeKeySecondPart,
-                                                       final String compositeKeyFirstValue,
-                                                       final String compositeKeySecondValue) {
+                                                       final String tripId,
+                                                       final String stopSequence) {
         super("stop_times.txt",
                 E_043,
                 "Fields `arrival_time` and `departure_time` out of order",
                 "`departure_time`: `" + departureTimeAsString + "` precedes `arrival_time`: `" +
                         arrivalTimeAsString + "` in file `" + filename +
                         "` for entity with composite id:" +
-                        "`" + compositeKeyFirstPart + "`: `" + compositeKeyFirstValue + "` -- " +
-                        "`" + compositeKeySecondPart + "`: `" + compositeKeySecondValue + "`.",
+                        "`tripId`: `" + tripId + "` -- " +
+                        "`stopSequence`: `" + stopSequence + "`.",
                 null);
 
-        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART, compositeKeyFirstPart);
-        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART, compositeKeySecondPart);
-        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE, compositeKeyFirstValue);
-        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE, compositeKeySecondValue);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_PART, "tripId");
+        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_PART, "stopSequence");
+        putNoticeSpecific(KEY_COMPOSITE_KEY_FIRST_VALUE, tripId);
+        putNoticeSpecific(KEY_COMPOSITE_KEY_SECOND_VALUE, stopSequence);
         putNoticeSpecific(KEY_STOP_TIME_ARRIVAL_TIME, arrivalTimeAsString);
         putNoticeSpecific(KEY_STOP_TIME_DEPARTURE_TIME, departureTimeAsString);
     }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
@@ -58,7 +58,7 @@ public class ValidateStopTimeDepartureTimeAfterArrivalTime {
      * `arrival_time`.
      */
     public void execute() {
-        logger.info("Validating rule 'E043 - `departure_time` and `arrival_time` out of order");
+        logger.info("Validating rule 'E045 - `departure_time` and `arrival_time` out of order");
         dataRepo.getStopTimeAll().forEach((tripId, tripStopTimes) -> tripStopTimes.forEach((stopSequence, stopTime) -> {
             final Integer stopTimeArrivalTime = stopTime.getArrivalTime();
             final Integer stopTimeDepartureTime = stopTime.getDepartureTime();

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
@@ -17,8 +17,8 @@
 package org.mobilitydata.gtfsvalidator.usecase;
 
 import org.apache.logging.log4j.Logger;
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 import org.mobilitydata.gtfsvalidator.usecase.utils.TimeUtils;

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
@@ -73,8 +73,6 @@ public class ValidateStopTimeDepartureTimeAfterArrivalTime {
                                         "stop_times.txt",
                                         timeUtils.convertIntegerToHMMSS(stopTimeArrivalTime),
                                         timeUtils.convertIntegerToHMMSS(stopTimeDepartureTime),
-                                        "stop_time_trip_id",
-                                        "stop_time_stop_sequence",
                                         tripId,
                                         stopSequence.toString())
                         );

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
@@ -18,7 +18,6 @@ package org.mobilitydata.gtfsvalidator.usecase;
 
 import org.apache.logging.log4j.Logger;
 import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
@@ -53,12 +52,12 @@ public class ValidateStopTimeDepartureTimeAfterArrivalTime {
     }
 
     /**
-     * Use case execution method: checks if for each {@code FeedInfo} contained in {@link GtfsDataRepository} that
-     * `feed_end_date` date does not precede the `feed_start_date`. If this requirement is not met, a
-     * {@code FeedInfoStartDateAfterEndDateNotice} is added to the {@code ValidationResultRepo} provided in the
+     * Use case execution method: checks if for each {@code StopTime} contained in {@link GtfsDataRepository} that
+     * `departure_time` date does not precede the `arrival_time`. If this requirement is not met, a
+     * {@code StopTimeArrivalTimeAfterDepartureTimeNotice} is added to the {@code ValidationResultRepo} provided in the
      * constructor.
-     * This verification is executed if {@link FeedInfo} has non-null value for both fields `feed_end_date` and
-     * `feed_start_date`.
+     * This verification is executed if {@link StopTime} has non-null value for both fields `departure_time` and
+     * `arrival_time`.
      */
     public void execute() {
         logger.info("Validating rule 'E043 - `departure_time` and `arrival_time` out of order");
@@ -67,7 +66,6 @@ public class ValidateStopTimeDepartureTimeAfterArrivalTime {
             tripStopTimes.forEach((stopSequence, stopTime) -> {
                 final Integer stopTimeArrivalTime = stopTime.getArrivalTime();
                 final Integer stopTimeDepartureTime = stopTime.getDepartureTime();
-
                 if (stopTimeDepartureTime != null && stopTimeArrivalTime != null) {
                     if (stopTimeDepartureTime < stopTimeArrivalTime) {
                         resultRepo.addNotice(

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+import org.mobilitydata.gtfsvalidator.usecase.utils.TimeUtils;
+
+import java.util.Map;
+
+/**
+ * Use case to validate that `departure_time` does not precede the `arrival_time` date if both are fields are
+ * provided. This use case is triggered after completing the {@code GtfsDataRepository} provided in the constructor with
+ * {@code StopTime} entities.
+ */
+public class ValidateStopTimeDepartureTimeAfterArrivalTime {
+    private final GtfsDataRepository dataRepo;
+    private final ValidationResultRepository resultRepo;
+    private final TimeUtils timeUtils;
+    private final Logger logger;
+
+    /**
+     * @param dataRepo   a repository storing the data of a GTFS dataset
+     * @param resultRepo a repository storing information about the validation process
+     * @param logger     a logger used to log information about the validation process
+     */
+    public ValidateStopTimeDepartureTimeAfterArrivalTime(final GtfsDataRepository dataRepo,
+                                                         final ValidationResultRepository resultRepo,
+                                                         final TimeUtils timeUtils,
+                                                         final Logger logger) {
+        this.dataRepo = dataRepo;
+        this.resultRepo = resultRepo;
+        this.timeUtils = timeUtils;
+        this.logger = logger;
+    }
+
+    /**
+     * Use case execution method: checks if for each {@code FeedInfo} contained in {@link GtfsDataRepository} that
+     * `feed_end_date` date does not precede the `feed_start_date`. If this requirement is not met, a
+     * {@code FeedInfoStartDateAfterEndDateNotice} is added to the {@code ValidationResultRepo} provided in the
+     * constructor.
+     * This verification is executed if {@link FeedInfo} has non-null value for both fields `feed_end_date` and
+     * `feed_start_date`.
+     */
+    public void execute() {
+        logger.info("Validating rule 'E043 - `departure_time` and `arrival_time` out of order");
+        dataRepo.getStopTimeAll().forEach((tripId, innerMap) -> {
+            final Map<Integer, StopTime> tripStopTimes = innerMap;
+            tripStopTimes.forEach((stopSequence, stopTime) -> {
+                final Integer stopTimeArrivalTime = stopTime.getArrivalTime();
+                final Integer stopTimeDepartureTime = stopTime.getDepartureTime();
+
+                if (stopTimeDepartureTime != null && stopTimeArrivalTime != null) {
+                    if (stopTimeDepartureTime < stopTimeArrivalTime) {
+                        resultRepo.addNotice(
+                                new StopTimeArrivalTimeAfterDepartureTimeNotice(
+                                        "stop_times.txt",
+                                        timeUtils.convertIntegerToHMMSS(stopTimeArrivalTime),
+                                        timeUtils.convertIntegerToHMMSS(stopTimeDepartureTime),
+                                        "stop_time_trip_id",
+                                        "stop_time_stop_sequence",
+                                        tripId,
+                                        stopSequence.toString())
+                        );
+                    }
+                }
+            });
+        });
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTime.java
@@ -23,8 +23,6 @@ import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 import org.mobilitydata.gtfsvalidator.usecase.utils.TimeUtils;
 
-import java.util.Map;
-
 /**
  * Use case to validate that `departure_time` does not precede the `arrival_time` date if both are fields are
  * provided. This use case is triggered after completing the {@code GtfsDataRepository} provided in the constructor with
@@ -61,24 +59,21 @@ public class ValidateStopTimeDepartureTimeAfterArrivalTime {
      */
     public void execute() {
         logger.info("Validating rule 'E043 - `departure_time` and `arrival_time` out of order");
-        dataRepo.getStopTimeAll().forEach((tripId, innerMap) -> {
-            final Map<Integer, StopTime> tripStopTimes = innerMap;
-            tripStopTimes.forEach((stopSequence, stopTime) -> {
-                final Integer stopTimeArrivalTime = stopTime.getArrivalTime();
-                final Integer stopTimeDepartureTime = stopTime.getDepartureTime();
-                if (stopTimeDepartureTime != null && stopTimeArrivalTime != null) {
-                    if (stopTimeDepartureTime < stopTimeArrivalTime) {
-                        resultRepo.addNotice(
-                                new StopTimeArrivalTimeAfterDepartureTimeNotice(
-                                        "stop_times.txt",
-                                        timeUtils.convertIntegerToHMMSS(stopTimeArrivalTime),
-                                        timeUtils.convertIntegerToHMMSS(stopTimeDepartureTime),
-                                        tripId,
-                                        stopSequence.toString())
-                        );
-                    }
+        dataRepo.getStopTimeAll().forEach((tripId, tripStopTimes) -> tripStopTimes.forEach((stopSequence, stopTime) -> {
+            final Integer stopTimeArrivalTime = stopTime.getArrivalTime();
+            final Integer stopTimeDepartureTime = stopTime.getDepartureTime();
+            if (stopTimeDepartureTime != null && stopTimeArrivalTime != null) {
+                if (stopTimeDepartureTime < stopTimeArrivalTime) {
+                    resultRepo.addNotice(
+                            new StopTimeArrivalTimeAfterDepartureTimeNotice(
+                                    "stop_times.txt",
+                                    timeUtils.convertIntegerToHMMSS(stopTimeArrivalTime),
+                                    timeUtils.convertIntegerToHMMSS(stopTimeDepartureTime),
+                                    tripId,
+                                    stopSequence)
+                    );
                 }
-            });
-        });
+            }
+        }));
     }
 }

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
@@ -126,9 +126,9 @@ class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
         assertEquals("arrival_time", noticeList.get(0).getNoticeSpecific(Notice.KEY_STOP_TIME_ARRIVAL_TIME));
         assertEquals("departure_time", noticeList.get(0)
                 .getNoticeSpecific(Notice.KEY_STOP_TIME_DEPARTURE_TIME));
-        assertEquals("stop_time_trip_id", noticeList.get(0)
+        assertEquals("tripId", noticeList.get(0)
                 .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_FIRST_PART));
-        assertEquals("stop_time_stop_sequence", noticeList.get(0)
+        assertEquals("stopSequence", noticeList.get(0)
                 .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_SECOND_PART));
         assertEquals("trip_id", noticeList.get(0)
                 .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_FIRST_VALUE));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+import org.mobilitydata.gtfsvalidator.usecase.utils.TimeUtils;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
+
+    // suppressed warning regarding ignored result of method since it is not necessary here
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void stopTimeArrivalTimeBeforeDepartureTimeShouldNotGenerateNotice() {
+        final StopTime mockStopTime = mock(StopTime.class);
+        final Integer arrivalTime = 0;
+        final Integer departureTime = 60;
+        when(mockStopTime.getArrivalTime()).thenReturn(arrivalTime);
+        when(mockStopTime.getDepartureTime()).thenReturn(departureTime);
+
+        final Map<String, TreeMap<Integer, StopTime>> mockStopTimeCollection = new HashMap<>();
+        final TreeMap<Integer, StopTime> mockStopTimeEntry = new TreeMap<>();
+        final Integer stopSequence = 0;
+        mockStopTimeEntry.put(stopSequence, mockStopTime);
+        mockStopTimeCollection.put("trip_id", mockStopTimeEntry);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getStopTimeAll()).thenReturn(mockStopTimeCollection);
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+        final TimeUtils mockTimeUtil = mock(TimeUtils.class);
+
+        final ValidateStopTimeDepartureTimeAfterArrivalTime underTest =
+                new ValidateStopTimeDepartureTimeAfterArrivalTime(mockDataRepo, mockResultRepo,
+                        mockTimeUtil, mockLogger);
+
+        underTest.execute();
+        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+                "`arrival_time` out of order");
+
+        verify(mockDataRepo, times(1)).getStopTimeAll();
+
+        verify(mockStopTime, times(1)).getArrivalTime();
+        verify(mockStopTime, times(1)).getDepartureTime();
+
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockStopTime, mockTimeUtil);
+    }
+
+    // suppressed warning regarding ignored result of method since it is not necessary here
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void stopTimeArrivalTimeAfterDepartureTimeShouldGenerateNotice() {
+        final StopTime mockStopTime = mock(StopTime.class);
+        final Integer arrivalTime = 60;
+        final Integer departureTime = 0;
+        when(mockStopTime.getArrivalTime()).thenReturn(arrivalTime);
+        when(mockStopTime.getDepartureTime()).thenReturn(departureTime);
+
+        final Map<String, TreeMap<Integer, StopTime>> mockStopTimeCollection = new HashMap<>();
+        final TreeMap<Integer, StopTime> mockStopTimeEntry = new TreeMap<>();
+        final Integer stopSequence = 0;
+        mockStopTimeEntry.put(stopSequence, mockStopTime);
+        mockStopTimeCollection.put("trip_id", mockStopTimeEntry);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getStopTimeAll()).thenReturn(mockStopTimeCollection);
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final TimeUtils mockTimeUtil = mock(TimeUtils.class);
+        when(mockTimeUtil.convertIntegerToHMMSS(arrivalTime)).thenReturn("arrival_time");
+        when(mockTimeUtil.convertIntegerToHMMSS(departureTime)).thenReturn("departure_time");
+
+        final ValidateStopTimeDepartureTimeAfterArrivalTime underTest =
+                new ValidateStopTimeDepartureTimeAfterArrivalTime(mockDataRepo, mockResultRepo,
+                        mockTimeUtil, mockLogger);
+
+        underTest.execute();
+        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+                "`arrival_time` out of order");
+
+        verify(mockDataRepo, times(1)).getStopTimeAll();
+
+        verify(mockStopTime, times(1)).getArrivalTime();
+        verify(mockStopTime, times(1)).getDepartureTime();
+
+        final ArgumentCaptor<StopTimeArrivalTimeAfterDepartureTimeNotice> captor =
+                ArgumentCaptor.forClass(StopTimeArrivalTimeAfterDepartureTimeNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        verify(mockTimeUtil, times(2)).convertIntegerToHMMSS(anyInt());
+
+        final List<StopTimeArrivalTimeAfterDepartureTimeNotice> noticeList = captor.getAllValues();
+
+        assertEquals("stop_times.txt", noticeList.get(0).getFilename());
+        assertEquals("arrival_time", noticeList.get(0).getNoticeSpecific(Notice.KEY_STOP_TIME_ARRIVAL_TIME));
+        assertEquals("departure_time", noticeList.get(0)
+                .getNoticeSpecific(Notice.KEY_STOP_TIME_DEPARTURE_TIME));
+        assertEquals("stop_time_trip_id", noticeList.get(0)
+                .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_FIRST_PART));
+        assertEquals("stop_time_stop_sequence", noticeList.get(0)
+                .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_SECOND_PART));
+        assertEquals("trip_id", noticeList.get(0)
+                .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_FIRST_VALUE));
+        assertEquals("0", noticeList.get(0)
+                .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_SECOND_VALUE));
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockTimeUtil);
+    }
+
+    // suppressed warning regarding ignored result of method since it is not necessary here
+    @Test
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    void stopTimeWithNullArrivalTimeShouldNotGenerateNotice() {
+        final StopTime mockStopTime = mock(StopTime.class);
+        final Integer arrivalTime = null;
+        final Integer departureTime = 60;
+        when(mockStopTime.getArrivalTime()).thenReturn(arrivalTime);
+        when(mockStopTime.getDepartureTime()).thenReturn(departureTime);
+
+        final Map<String, TreeMap<Integer, StopTime>> mockStopTimeCollection = new HashMap<>();
+        final TreeMap<Integer, StopTime> mockStopTimeEntry = new TreeMap<>();
+        final Integer stopSequence = 0;
+        mockStopTimeEntry.put(stopSequence, mockStopTime);
+        mockStopTimeCollection.put("trip_id", mockStopTimeEntry);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getStopTimeAll()).thenReturn(mockStopTimeCollection);
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+        final TimeUtils mockTimeUtil = mock(TimeUtils.class);
+
+        final ValidateStopTimeDepartureTimeAfterArrivalTime underTest =
+                new ValidateStopTimeDepartureTimeAfterArrivalTime(mockDataRepo, mockResultRepo,
+                        mockTimeUtil, mockLogger);
+
+        underTest.execute();
+        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+                "`arrival_time` out of order");
+
+        verify(mockDataRepo, times(1)).getStopTimeAll();
+
+        verify(mockStopTime, times(1)).getArrivalTime();
+        verify(mockStopTime, times(1)).getDepartureTime();
+
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockStopTime, mockTimeUtil);
+    }
+
+    // suppressed warning regarding ignored result of method since it is not necessary here
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void stopTimeWithNullDepartureTimeShouldNotGenerateNotice() {
+        final StopTime mockStopTime = mock(StopTime.class);
+        final Integer arrivalTime = 0;
+        final Integer departureTime = null;
+        when(mockStopTime.getArrivalTime()).thenReturn(arrivalTime);
+        when(mockStopTime.getDepartureTime()).thenReturn(departureTime);
+
+        final Map<String, TreeMap<Integer, StopTime>> mockStopTimeCollection = new HashMap<>();
+        final TreeMap<Integer, StopTime> mockStopTimeEntry = new TreeMap<>();
+        final Integer stopSequence = 0;
+        mockStopTimeEntry.put(stopSequence, mockStopTime);
+        mockStopTimeCollection.put("trip_id", mockStopTimeEntry);
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getStopTimeAll()).thenReturn(mockStopTimeCollection);
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+        final TimeUtils mockTimeUtil = mock(TimeUtils.class);
+
+        final ValidateStopTimeDepartureTimeAfterArrivalTime underTest =
+                new ValidateStopTimeDepartureTimeAfterArrivalTime(mockDataRepo, mockResultRepo,
+                        mockTimeUtil, mockLogger);
+
+        underTest.execute();
+        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+                "`arrival_time` out of order");
+
+        verify(mockDataRepo, times(1)).getStopTimeAll();
+
+        verify(mockStopTime, times(1)).getArrivalTime();
+        verify(mockStopTime, times(1)).getDepartureTime();
+
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockStopTime, mockTimeUtil);
+    }
+}

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
@@ -63,7 +63,7 @@ class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
                         mockTimeUtil, mockLogger);
 
         underTest.execute();
-        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+        verify(mockLogger, times(1)).info("Validating rule 'E045 - `departure_time` and " +
                 "`arrival_time` out of order");
 
         verify(mockDataRepo, times(1)).getStopTimeAll();
@@ -105,7 +105,7 @@ class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
                         mockTimeUtil, mockLogger);
 
         underTest.execute();
-        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+        verify(mockLogger, times(1)).info("Validating rule 'E045 - `departure_time` and " +
                 "`arrival_time` out of order");
 
         verify(mockDataRepo, times(1)).getStopTimeAll();
@@ -164,7 +164,7 @@ class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
                         mockTimeUtil, mockLogger);
 
         underTest.execute();
-        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+        verify(mockLogger, times(1)).info("Validating rule 'E045 - `departure_time` and " +
                 "`arrival_time` out of order");
 
         verify(mockDataRepo, times(1)).getStopTimeAll();
@@ -203,7 +203,7 @@ class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
                         mockTimeUtil, mockLogger);
 
         underTest.execute();
-        verify(mockLogger, times(1)).info("Validating rule 'E043 - `departure_time` and " +
+        verify(mockLogger, times(1)).info("Validating rule 'E045 - `departure_time` and " +
                 "`arrival_time` out of order");
 
         verify(mockDataRepo, times(1)).getStopTimeAll();

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
@@ -132,7 +132,7 @@ class ValidateStopTimeDepartureTimeAfterArrivalTimeTest {
                 .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_SECOND_PART));
         assertEquals("trip_id", noticeList.get(0)
                 .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_FIRST_VALUE));
-        assertEquals("0", noticeList.get(0)
+        assertEquals(0, noticeList.get(0)
                 .getNoticeSpecific(Notice.KEY_COMPOSITE_KEY_SECOND_VALUE));
         verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockTimeUtil);
     }

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateStopTimeDepartureTimeAfterArrivalTimeTest.java
@@ -18,9 +18,9 @@ package org.mobilitydata.gtfsvalidator.usecase;
 
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
-import org.mobilitydata.gtfsvalidator.domain.entity.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.stoptimes.StopTime;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.StopTimeArrivalTimeAfterDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 import org.mobilitydata.gtfsvalidator.usecase.utils.TimeUtils;


### PR DESCRIPTION
**Summary:**

Implement validation use case for Departure Time after Arrival Time for a StopTime record (stop_times.txt)

**Expected behavior:** 

Validates and adds a StopTimeArrivalTimeAfterDepartureTimeNotice if needed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)