### PR TITLE
Implement #333 - Perform external key verification on field agency_id

### DIFF
--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
@@ -561,6 +561,16 @@ public class InMemoryGtfsDataRepository implements GtfsDataRepository {
     }
 
     /**
+     * Returns an unmodifiable  collection of {@link FareAttribute} entities
+     *
+     * @return an unmodifiable  collection of {@link FareAttribute} entities
+     */
+    @Override
+    public Map<String, FareAttribute> getFareAttributeAll() {
+        return Collections.unmodifiableMap(fareAttributePerFareId);
+    }
+
+    /**
      * Add a FareRule representing a row from fare_rules.txt to this {@link GtfsDataRepository}.
      * Return the entity added to the repository if the uniqueness constraint on rows from fare_rules.txt is respected,
      * if this requirement is not met, returns null.

--- a/adapter/repository/in-memory-simple/src/test/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepositoryTest.java
+++ b/adapter/repository/in-memory-simple/src/test/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepositoryTest.java
@@ -17,7 +17,6 @@
 package org.mobilitydata.gtfsvalidator.db;
 
 import org.junit.jupiter.api.Test;
-import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Calendar;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.*;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.CalendarDate;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.calendardates.ExceptionType;
@@ -36,7 +35,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
-import java.util.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -491,6 +489,26 @@ class InMemoryGtfsDataRepositoryTest {
                 underTest.getFareAttributeById("fare attribute id 00"));
         assertEquals(underTest.addFareAttribute(mockFareAttribute01),
                 underTest.getFareAttributeById("fare attribute id 01"));
+    }
+
+    @Test
+    void getFareAttributeAllShouldReturnFareAttributeCollection() {
+        final FareAttribute mockFareAttribute00 = mock(FareAttribute.class);
+        when(mockFareAttribute00.getFareId()).thenReturn("fare id00");
+
+        final FareAttribute mockFareAttribute01 = mock(FareAttribute.class);
+        when(mockFareAttribute00.getFareId()).thenReturn("fare id01");
+
+        final InMemoryGtfsDataRepository underTest = new InMemoryGtfsDataRepository();
+
+        underTest.addFareAttribute(mockFareAttribute00);
+        underTest.addFareAttribute(mockFareAttribute01);
+
+        final Map<String, FareAttribute> toCheck = underTest.getFareAttributeAll();
+
+        assertEquals(2, toCheck.size());
+        assertTrue(toCheck.containsKey(mockFareAttribute00.getFareId()));
+        assertTrue(toCheck.containsKey(mockFareAttribute01.getFareId()));
     }
 
     @Test

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -190,6 +190,7 @@ public class Main {
                 config.validateTripRouteId().execute();
                 config.validateTripServiceId().execute();
                 config.validateRouteAgencyId().execute();
+                config.validateFareAttributeAgencyId().execute();
                 config.stopTimeBasedCrossValidator().execute();
                 config.shapeBasedCrossValidator().execute();
                 config.validateFeedInfoEndDateAfterStartDate().execute();

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -328,6 +328,10 @@ public class DefaultConfig {
         return new ValidateRouteAgencyId(gtfsDataRepository, resultRepo, logger);
     }
 
+    public ValidateFareAttributeAgencyId validateFareAttributeAgencyId() {
+        return new ValidateFareAttributeAgencyId(gtfsDataRepository, resultRepo, logger);
+    }
+
     public StopTimeBasedCrossValidator stopTimeBasedCrossValidator() {
         return new StopTimeBasedCrossValidator(gtfsDataRepository, resultRepo, logger,
                 new ValidateShapeIdReferenceInStopTime(),

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateFareAttributeAgencyId.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateFareAttributeAgencyId.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.AgencyIdNotFoundNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingAgencyIdNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+
+public class ValidateFareAttributeAgencyId {
+    private final GtfsDataRepository dataRepo;
+    private final ValidationResultRepository resultRepo;
+    private final Logger logger;
+
+    public ValidateFareAttributeAgencyId(final GtfsDataRepository dataRepo,
+                                         final ValidationResultRepository resultRepo,
+                                         final Logger logger) {
+        this.dataRepo = dataRepo;
+        this.resultRepo = resultRepo;
+        this.logger = logger;
+    }
+
+    public void execute() {
+        logger.info("Validating rule 'E035 - `agency_id` not found");
+
+        final int agencyCount = dataRepo.getAgencyCount();
+        dataRepo.getFareAttributeAll().values()
+                .forEach(fareAttribute -> {
+                    final String fareId = fareAttribute.getFareId();
+                    final String agencyId = fareAttribute.getAgencyId();
+                    if (agencyCount > 1) {
+                        if (agencyId == null) {
+                            resultRepo.addNotice(new MissingAgencyIdNotice("fare_attributes.txt", fareId));
+                        } else {
+                            if (dataRepo.getAgencyById(agencyId) == null) {
+                                resultRepo.addNotice(new AgencyIdNotFoundNotice("fare_attributes.txt", "agency_id",
+                                        fareId));
+                            }
+                        }
+                    } else {
+                        if (dataRepo.getAgencyById(agencyId) == null) {
+                            resultRepo.addNotice(new AgencyIdNotFoundNotice("fare_attributes.txt",
+                                    "agency_id", fareId));
+                        }
+                    }
+                });
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/GtfsDataRepository.java
@@ -81,6 +81,8 @@ public interface GtfsDataRepository {
 
     FareAttribute getFareAttributeById(final String fareId);
 
+    Map<String, FareAttribute> getFareAttributeAll();
+
     FareRule addFareRule(final FareRule newFareRule) throws IllegalArgumentException;
 
     FareRule getFareRule(final String fareId, final String routeId, final String originId, final String destinationId,

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateFareAttributeAgencyIdTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateFareAttributeAgencyIdTest.java
@@ -1,0 +1,284 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.fareattributes.FareAttribute;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.AgencyIdNotFoundNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingAgencyIdNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatchers;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_FIELD_NAME;
+import static org.mockito.Mockito.*;
+
+class ValidateFareAttributeAgencyIdTest {
+
+    @Test
+    void existingAgencyIdWhenAgencyCountsOneRecordShouldNotGenerateNotice() {
+        final Agency mockAgency = mock(Agency.class);
+
+        final FareAttribute mockFareAttribute = mock(FareAttribute.class);
+        when(mockFareAttribute.getAgencyId()).thenReturn("existing agency id");
+        when(mockFareAttribute.getFareId()).thenReturn("fare id");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getAgencyCount()).thenReturn(1);
+
+        final Map<String, FareAttribute> mockFareAttributeCollection = new HashMap<>();
+        mockFareAttributeCollection.put("fare id", mockFareAttribute);
+        when(mockDataRepo.getFareAttributeAll()).thenReturn(mockFareAttributeCollection);
+        when(mockDataRepo.getAgencyById("existing agency id")).thenReturn(mockAgency);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateFareAttributeAgencyId underTest = new ValidateFareAttributeAgencyId(mockDataRepo, mockResultRepo,
+                mockLogger);
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(
+                ArgumentMatchers.eq("Validating rule 'E035 - `agency_id` not found"));
+
+        verify(mockDataRepo, times(1)).getAgencyCount();
+        verify(mockDataRepo, times(1)).getFareAttributeAll();
+        verify(mockDataRepo, times(1))
+                .getAgencyById(ArgumentMatchers.eq("existing agency id"));
+
+        verify(mockFareAttribute, times(1)).getAgencyId();
+        verify(mockFareAttribute, times(1)).getFareId();
+
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockFareAttribute);
+    }
+
+    @Test
+    void existingAgencyIdWhenAgencyCountsMoreThanOneRecordShouldNotGenerateNotice() {
+        final Agency mockAgency = mock(Agency.class);
+
+        final FareAttribute mockFareAttribute = mock(FareAttribute.class);
+        when(mockFareAttribute.getAgencyId()).thenReturn("existing agency id");
+        when(mockFareAttribute.getFareId()).thenReturn("fare id");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getAgencyCount()).thenReturn(2);
+
+        final Map<String, FareAttribute> mockFareAttributeCollection = new HashMap<>();
+        mockFareAttributeCollection.put("fare id", mockFareAttribute);
+        when(mockDataRepo.getFareAttributeAll()).thenReturn(mockFareAttributeCollection);
+        when(mockDataRepo.getAgencyById("existing agency id")).thenReturn(mockAgency);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateFareAttributeAgencyId underTest = new ValidateFareAttributeAgencyId(mockDataRepo, mockResultRepo,
+                mockLogger);
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(
+                ArgumentMatchers.eq("Validating rule 'E035 - `agency_id` not found"));
+
+        verify(mockDataRepo, times(1)).getAgencyCount();
+        verify(mockDataRepo, times(1)).getFareAttributeAll();
+        verify(mockDataRepo, times(1))
+                .getAgencyById(ArgumentMatchers.eq("existing agency id"));
+
+        verify(mockFareAttribute, times(1)).getAgencyId();
+        verify(mockFareAttribute, times(1)).getFareId();
+
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockFareAttribute);
+    }
+
+    @Test
+    void nullAgencyIdInFareAttributeWhenAgencyHasOneRecordShouldNotGenerateNotice() {
+        final Agency mockAgency = mock(Agency.class);
+
+        final FareAttribute mockFareAttribute = mock(FareAttribute.class);
+        when(mockFareAttribute.getAgencyId()).thenReturn(null);
+        when(mockFareAttribute.getFareId()).thenReturn("fare id");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getAgencyCount()).thenReturn(1);
+        when(mockDataRepo.getAgencyById(null)).thenReturn(mockAgency);
+
+        final Map<String, FareAttribute> mockFareAttributeCollection = new HashMap<>();
+        mockFareAttributeCollection.put("fare id", mockFareAttribute);
+        when(mockDataRepo.getFareAttributeAll()).thenReturn(mockFareAttributeCollection);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateFareAttributeAgencyId underTest = new ValidateFareAttributeAgencyId(mockDataRepo, mockResultRepo,
+                mockLogger);
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(
+                ArgumentMatchers.eq("Validating rule 'E035 - `agency_id` not found"));
+
+        verify(mockDataRepo, times(1)).getAgencyCount();
+        verify(mockDataRepo, times(1)).getFareAttributeAll();
+        verify(mockDataRepo, times(1)).getAgencyById(ArgumentMatchers.eq(null));
+
+        verify(mockFareAttribute, times(1)).getAgencyId();
+        verify(mockFareAttribute, times(1)).getFareId();
+
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockFareAttribute);
+    }
+
+    @Test
+    void nonExistingAgencyIdInFareAttributeWhenAgencyHasOneRecordInAgencyShouldGenerateNotice() {
+        final FareAttribute mockFareAttribute = mock(FareAttribute.class);
+        when(mockFareAttribute.getAgencyId()).thenReturn("non existing agency id");
+        when(mockFareAttribute.getFareId()).thenReturn("fare id");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getAgencyCount()).thenReturn(1);
+
+        final Map<String, FareAttribute> mockFareAttributeCollection = new HashMap<>();
+        mockFareAttributeCollection.put("fare id", mockFareAttribute);
+        when(mockDataRepo.getFareAttributeAll()).thenReturn(mockFareAttributeCollection);
+
+        when(mockDataRepo.getAgencyById("non existing agency id")).thenReturn(null);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateFareAttributeAgencyId underTest = new ValidateFareAttributeAgencyId(mockDataRepo, mockResultRepo, mockLogger);
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(
+                ArgumentMatchers.eq("Validating rule 'E035 - `agency_id` not found"));
+
+        verify(mockDataRepo, times(1)).getAgencyCount();
+        verify(mockDataRepo, times(1)).getFareAttributeAll();
+        verify(mockDataRepo, times(1)).getAgencyById(ArgumentMatchers.eq("non existing " +
+                "agency id"));
+
+        verify(mockFareAttribute, times(1)).getAgencyId();
+        verify(mockFareAttribute, times(1)).getFareId();
+
+        final ArgumentCaptor<AgencyIdNotFoundNotice> captor = ArgumentCaptor.forClass(AgencyIdNotFoundNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final List<AgencyIdNotFoundNotice> noticeList = captor.getAllValues();
+
+        assertEquals("fare_attributes.txt", noticeList.get(0).getFilename());
+        assertEquals("agency_id", noticeList.get(0).getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals("fare id", noticeList.get(0).getEntityId());
+
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFareAttribute);
+    }
+
+    @Test
+    void nonExistingAgencyIdInFareAttributeWhenAgencyHasMoreThanOneRecordShouldGenerateNotice() {
+        final FareAttribute mockFareAttribute = mock(FareAttribute.class);
+        when(mockFareAttribute.getAgencyId()).thenReturn("non existing agency id");
+        when(mockFareAttribute.getFareId()).thenReturn("fare id");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getAgencyCount()).thenReturn(2);
+
+        final Map<String, FareAttribute> mockFareAttributeCollection = new HashMap<>();
+        mockFareAttributeCollection.put("fare id", mockFareAttribute);
+        when(mockDataRepo.getFareAttributeAll()).thenReturn(mockFareAttributeCollection);
+
+        when(mockDataRepo.getAgencyById("non existing agency id")).thenReturn(null);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateFareAttributeAgencyId underTest = new ValidateFareAttributeAgencyId(mockDataRepo, mockResultRepo,
+                mockLogger);
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(
+                ArgumentMatchers.eq("Validating rule 'E035 - `agency_id` not found"));
+
+        verify(mockDataRepo, times(1)).getAgencyCount();
+        verify(mockDataRepo, times(1)).getFareAttributeAll();
+        verify(mockDataRepo, times(1)).getAgencyById(ArgumentMatchers.eq("non existing " +
+                "agency id"));
+
+        verify(mockFareAttribute, times(1)).getAgencyId();
+        verify(mockFareAttribute, times(1)).getFareId();
+
+        final ArgumentCaptor<AgencyIdNotFoundNotice> captor = ArgumentCaptor.forClass(AgencyIdNotFoundNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final List<AgencyIdNotFoundNotice> noticeList = captor.getAllValues();
+
+        assertEquals("fare_attributes.txt", noticeList.get(0).getFilename());
+        assertEquals("agency_id", noticeList.get(0).getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals("fare id", noticeList.get(0).getEntityId());
+
+        verifyNoMoreInteractions(mockDataRepo, mockResultRepo, mockLogger, mockFareAttribute);
+    }
+
+    @Test
+    void nullAgencyIdInFareAttributeWhenAgencyHasMoreThanOneRecordShouldGenerateNotice() {
+        final FareAttribute mockFareAttribute = mock(FareAttribute.class);
+        when(mockFareAttribute.getAgencyId()).thenReturn(null);
+        when(mockFareAttribute.getFareId()).thenReturn("fare id");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getAgencyCount()).thenReturn(2);
+
+        final Map<String, FareAttribute> mockFareAttributeCollection = new HashMap<>();
+        mockFareAttributeCollection.put("fare id", mockFareAttribute);
+        when(mockDataRepo.getFareAttributeAll()).thenReturn(mockFareAttributeCollection);
+
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateFareAttributeAgencyId underTest = new ValidateFareAttributeAgencyId(mockDataRepo, mockResultRepo,
+                mockLogger);
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info(
+                ArgumentMatchers.eq("Validating rule 'E035 - `agency_id` not found"));
+
+        verify(mockDataRepo, times(1)).getAgencyCount();
+        verify(mockDataRepo, times(1)).getFareAttributeAll();
+
+        verify(mockFareAttribute, times(1)).getAgencyId();
+        verify(mockFareAttribute, times(1)).getFareId();
+
+        final ArgumentCaptor<MissingAgencyIdNotice> captor = ArgumentCaptor.forClass(MissingAgencyIdNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final List<MissingAgencyIdNotice> noticeList = captor.getAllValues();
+
+        assertEquals("fare_attributes.txt", noticeList.get(0).getFilename());
+        assertEquals("fare id", noticeList.get(0).getEntityId());
+
+        verifyNoMoreInteractions(mockDataRepo, mockResultRepo, mockLogger, mockFareAttribute);
+    }
+}


### PR DESCRIPTION
**Summary:**

This PR provides support to perform external key verification on field agency_id of files `attributions.txt` and `fare_attributes.txt`.

**Expected behavior:** 

- [x] `fare_attributes.txt`: 
> Identifies the relevant agency for a fare. This field is required for datasets with multiple agencies defined in agency.txt, otherwise it is optional.

- [ ] `attributions.txt`: 

> If one agency_id, route_id, or trip_id attribution is defined, the other ones must be empty. If none of them is specified, the attribution will apply to the whole dataset. 

--


 
Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)