### PR TITLE
Fix #347 - Time conversion of AM times 

### DIFF
--- a/adapter/utils/src/main/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImpl.java
+++ b/adapter/utils/src/main/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImpl.java
@@ -89,29 +89,32 @@ public class TimeUtilsImpl implements TimeUtils {
     public String convertIntegerToHMMSS(final Integer elapsedDurationSinceNoon) {
         if (elapsedDurationSinceNoon != null) {
             // Determine number of hours elapsed
-            int hourValue = (int) (TimeUnit.SECONDS.toHours(elapsedDurationSinceNoon) + 12);
+            int hourValue;
             int minuteValue;
             int secondValue;
             // elapsedDurationSinceNoon > 0 for times after noon, e.g 14:00PM is represented a +2*3600s=+7200s
             // elapsedDurationSinceNoon < 0 for times before noon, e.g 11:00AM is represented as -1*3600s=-3600s
-            if (elapsedDurationSinceNoon > 0) {
+            if (elapsedDurationSinceNoon >= 0) {
+                hourValue = (int) (TimeUnit.SECONDS.toHours(elapsedDurationSinceNoon) + 12);
                 // Determine number of minutes and seconds elapsed
                 minuteValue = (int) (TimeUnit.SECONDS.toMinutes(elapsedDurationSinceNoon) -
                         TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(elapsedDurationSinceNoon)));
                 secondValue = (int) (TimeUnit.SECONDS.toSeconds(elapsedDurationSinceNoon) -
                         TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(elapsedDurationSinceNoon)));
             } else {
+                hourValue = (int) (TimeUnit.SECONDS.toHours(elapsedDurationSinceNoon + 12 * 3600));
                 // Determine number of minutes elapsed minus the number of hours elapsed
                 minuteValue = ((int) (TimeUnit.SECONDS.toMinutes(elapsedDurationSinceNoon) -
                         TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(elapsedDurationSinceNoon)))) % 60;
                 if (minuteValue < 0) {
-                    hourValue = hourValue - 1;
-                    minuteValue = 1 + ((int) -(TimeUnit.SECONDS.toMinutes(elapsedDurationSinceNoon) -
-                            TimeUnit.HOURS.toMinutes(TimeUnit.SECONDS.toHours(elapsedDurationSinceNoon))));
+                    minuteValue = 60 + minuteValue;
                 }
                 // Determine number of seconds elapsed minus the number of hours and minutes elapsed
                 secondValue = (int) (TimeUnit.SECONDS.toSeconds(elapsedDurationSinceNoon) -
                         TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(elapsedDurationSinceNoon)));
+                if (secondValue < 0) {
+                    minuteValue = minuteValue - 1;
+                }
                 if ((int) (TimeUnit.SECONDS.toSeconds(elapsedDurationSinceNoon) -
                         TimeUnit.MINUTES.toSeconds(TimeUnit.SECONDS.toMinutes(elapsedDurationSinceNoon))) < 0) {
                     secondValue = 60 + secondValue;

--- a/adapter/utils/src/main/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImpl.java
+++ b/adapter/utils/src/main/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImpl.java
@@ -93,30 +93,29 @@ public class TimeUtilsImpl implements TimeUtils {
             IllegalArgumentException {
         if (elapsedDurationSinceNoonInSeconds == null) {
             throw new IllegalArgumentException("elapsedDurationSinceNoonInSeconds cannot be null");
-        } else {
-            final LocalTime noon = LocalTime.NOON;
-            // elapsedDurationSinceNoonInSeconds > 0 for times after noon, e.g 14:00PM is represented a +2*3600s=+7200s
-            // elapsedDurationSinceNoonInSeconds < 0 for times before noon, e.g 11:00AM is represented as -1*3600s=-3600s
-            final boolean isTimeGreaterThan24hours =
-                    elapsedDurationSinceNoonInSeconds >= TimeUnit.HOURS.toSeconds(12);
+        }
+        final LocalTime noon = LocalTime.NOON;
+        // elapsedDurationSinceNoonInSeconds > 0 for times after noon, e.g 14:00PM is represented a +2*3600s=+7200s
+        // elapsedDurationSinceNoonInSeconds < 0 for times before noon, e.g 11:00AM is represented as -1*3600s=-3600s
+        final boolean isTimeGreaterThan24hours =
+                elapsedDurationSinceNoonInSeconds >= TimeUnit.HOURS.toSeconds(12);
 
-            if (!isTimeGreaterThan24hours) {
-                return String.format("%02d:%02d:%02d", noon.plusSeconds(elapsedDurationSinceNoonInSeconds).getHour(),
-                        noon.plusSeconds(elapsedDurationSinceNoonInSeconds).getMinute(),
-                        noon.plusSeconds(elapsedDurationSinceNoonInSeconds).getSecond());
-            } else {
-                // This wraps around midnight
-                LocalTime timeAfterMidnight = noon.plusSeconds(elapsedDurationSinceNoonInSeconds);
-                // Get the number of hours, minutes, and seconds between midnight and timeAfterMidnight, which is the
-                // time to add to 24:00:00
-                long hoursAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.HOURS);
-                long minutesAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.MINUTES) % 60;
-                long secondsAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.SECONDS) % 60;
-                return String.format("%02d:%02d:%02d",
-                        24 + hoursAfterMidnight,
-                        minutesAfterMidnight,
-                        secondsAfterMidnight);
-            }
+        if (!isTimeGreaterThan24hours) {
+            return String.format("%02d:%02d:%02d", noon.plusSeconds(elapsedDurationSinceNoonInSeconds).getHour(),
+                    noon.plusSeconds(elapsedDurationSinceNoonInSeconds).getMinute(),
+                    noon.plusSeconds(elapsedDurationSinceNoonInSeconds).getSecond());
+        } else {
+            // This wraps around midnight
+            LocalTime timeAfterMidnight = noon.plusSeconds(elapsedDurationSinceNoonInSeconds);
+            // Get the number of hours, minutes, and seconds between midnight and timeAfterMidnight, which is the
+            // time to add to 24:00:00
+            long hoursAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.HOURS);
+            long minutesAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.MINUTES) % 60;
+            long secondsAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.SECONDS) % 60;
+            return String.format("%02d:%02d:%02d",
+                    24 + hoursAfterMidnight,
+                    minutesAfterMidnight,
+                    secondsAfterMidnight);
         }
     }
 }

--- a/adapter/utils/src/main/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImpl.java
+++ b/adapter/utils/src/main/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImpl.java
@@ -89,8 +89,11 @@ public class TimeUtilsImpl implements TimeUtils {
      * @return the human readable string representation of the number of seconds elapsed since noon of day of service.
      * This string is formatted as follows: HH:MM:SS.
      */
-    public String convertIntegerToHMMSS(final Integer elapsedDurationSinceNoonInSeconds) {
-        if (elapsedDurationSinceNoonInSeconds != null) {
+    public String convertIntegerToHMMSS(final Integer elapsedDurationSinceNoonInSeconds) throws
+            IllegalArgumentException {
+        if (elapsedDurationSinceNoonInSeconds == null) {
+            throw new IllegalArgumentException("elapsedDurationSinceNoonInSeconds cannot be null");
+        } else {
             final LocalTime noon = LocalTime.NOON;
             // elapsedDurationSinceNoonInSeconds > 0 for times after noon, e.g 14:00PM is represented a +2*3600s=+7200s
             // elapsedDurationSinceNoonInSeconds < 0 for times before noon, e.g 11:00AM is represented as -1*3600s=-3600s
@@ -110,12 +113,10 @@ public class TimeUtilsImpl implements TimeUtils {
                 long minutesAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.MINUTES) % 60;
                 long secondsAfterMidnight = LocalTime.MIDNIGHT.until(timeAfterMidnight, ChronoUnit.SECONDS) % 60;
                 return String.format("%02d:%02d:%02d",
-                        hoursAfterMidnight + 24,
+                        24 + hoursAfterMidnight,
                         minutesAfterMidnight,
                         secondsAfterMidnight);
             }
-        } else {
-            return null;
         }
     }
 }

--- a/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
+++ b/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
@@ -223,5 +223,17 @@ public class TimeUtilsImplTest {
         toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(threePm);
         assertEquals(toCheck, TIME_CONVERSION_UTILS.convertIntegerToHMMSS(
                 TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(toCheck)));
+
+        final int twentyFiveThirtyPm40sec = (25 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
+                40 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
+        toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(twentyFiveThirtyPm40sec);
+        assertEquals(toCheck, TIME_CONVERSION_UTILS.convertIntegerToHMMSS(
+                TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(toCheck)));
+
+        final int twentyEightFortySevenPm20sec = (28 * HOUR_TO_SEC_CONVERSION_FACTOR + 47 * MIN_TO_SEC_CONVERSION_FACTOR +
+                20 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
+        toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(twentyEightFortySevenPm20sec);
+        assertEquals(toCheck, TIME_CONVERSION_UTILS.convertIntegerToHMMSS(
+                TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(toCheck)));
     }
 }

--- a/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
+++ b/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
@@ -61,6 +61,11 @@ public class TimeUtilsImplTest {
         assertEquals(((6 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
                 20 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON), toCheck);
 
+        final String sixOneAm = "06:01:00";
+        toCheck = TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(sixOneAm);
+        assertEquals(((6 * HOUR_TO_SEC_CONVERSION_FACTOR + 1 * MIN_TO_SEC_CONVERSION_FACTOR +
+                0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON), toCheck);
+
         final String oneThirtyAm40sec = "25:30:40";
         toCheck = TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(oneThirtyAm40sec);
         assertEquals(((25 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
@@ -124,6 +129,11 @@ public class TimeUtilsImplTest {
                 0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
         toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(sixFortyPm);
         assertEquals("18:40:00", toCheck);
+
+        final int sixAmOne = (6 * HOUR_TO_SEC_CONVERSION_FACTOR + 1 * MIN_TO_SEC_CONVERSION_FACTOR +
+                0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
+        toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(sixAmOne);
+        assertEquals("06:01:00", toCheck);
 
         final int tenAm = (10 * HOUR_TO_SEC_CONVERSION_FACTOR + 0 * MIN_TO_SEC_CONVERSION_FACTOR +
                 0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;

--- a/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
+++ b/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
@@ -16,10 +16,12 @@
 
 package org.mobilitydata.gtfsvalidator.timeutils;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class TimeUtilsImplTest {
     private static final int HOUR_TO_SEC_CONVERSION_FACTOR = 3600;
@@ -167,8 +169,10 @@ public class TimeUtilsImplTest {
     }
 
     @Test
-    void convertIntegerToHMMSSOnNullValueShouldReturnNull() {
-        assertNull(TIME_CONVERSION_UTILS.convertIntegerToHMMSS(null));
+    void convertIntegerToHMMSSOnNullValueShouldThrowException() {
+        final Exception exception = assertThrows(IllegalArgumentException.class,
+                () -> TIME_CONVERSION_UTILS.convertIntegerToHMMSS(null));
+        Assertions.assertEquals("elapsedDurationSinceNoonInSeconds cannot be null", exception.getMessage());
     }
 
     // Remove warning "PointlessArithmeticExpression" since they these expressions are written to ease code

--- a/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
+++ b/adapter/utils/src/test/java/org/mobilitydata/gtfsvalidator/timeutils/TimeUtilsImplTest.java
@@ -56,6 +56,11 @@ public class TimeUtilsImplTest {
         assertEquals(((10 * HOUR_TO_SEC_CONVERSION_FACTOR + 0 * MIN_TO_SEC_CONVERSION_FACTOR +
                 0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON), toCheck);
 
+        final String fiveTenAm34sec = "05:10:34";
+        toCheck = TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(fiveTenAm34sec);
+        assertEquals(((5 * HOUR_TO_SEC_CONVERSION_FACTOR + 10 * MIN_TO_SEC_CONVERSION_FACTOR +
+                34 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON), toCheck);
+
         final String sixThirtyAm20sec = "06:30:20";
         toCheck = TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(sixThirtyAm20sec);
         assertEquals(((6 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
@@ -135,6 +140,11 @@ public class TimeUtilsImplTest {
         toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(sixAmOne);
         assertEquals("06:01:00", toCheck);
 
+        final int fiveTenAm34sec = (5 * HOUR_TO_SEC_CONVERSION_FACTOR + 10 * MIN_TO_SEC_CONVERSION_FACTOR +
+                34 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
+        toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(fiveTenAm34sec);
+        assertEquals("05:10:34", toCheck);
+
         final int tenAm = (10 * HOUR_TO_SEC_CONVERSION_FACTOR + 0 * MIN_TO_SEC_CONVERSION_FACTOR +
                 0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
         toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(tenAm);
@@ -166,8 +176,8 @@ public class TimeUtilsImplTest {
     @SuppressWarnings("PointlessArithmeticExpression")
     @Test
     void convertHHMMSStoIntegerAndIntegerToHHMMSSShouldBeConsistent() {
-        final int oneThirtyAm40sec = (13 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
-                20 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
+        final int oneThirtyAm40sec = (1 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
+                40 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
         String toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(oneThirtyAm40sec);
         assertEquals(toCheck, TIME_CONVERSION_UTILS.convertIntegerToHMMSS(
                 TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(toCheck)));
@@ -175,6 +185,12 @@ public class TimeUtilsImplTest {
         final int sixThirtyAm20sec = (6 * HOUR_TO_SEC_CONVERSION_FACTOR + 30 * MIN_TO_SEC_CONVERSION_FACTOR +
                 20 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
         toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(sixThirtyAm20sec);
+        assertEquals(toCheck, TIME_CONVERSION_UTILS.convertIntegerToHMMSS(
+                TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(toCheck)));
+
+        final int sixAmOne = (6 * HOUR_TO_SEC_CONVERSION_FACTOR + 0 * MIN_TO_SEC_CONVERSION_FACTOR +
+                0 * SEC_TO_SEC_CONVERSION_FACTOR) - NOON;
+        toCheck = TIME_CONVERSION_UTILS.convertIntegerToHMMSS(sixAmOne);
         assertEquals(toCheck, TIME_CONVERSION_UTILS.convertIntegerToHMMSS(
                 TIME_CONVERSION_UTILS.convertHHMMSSToIntFromNoonOfDayOfService(toCheck)));
 


### PR DESCRIPTION
**Summary:**

This PR provides support to solve to avoid wrong conversion of AM time
**Expected behavior:** 

`timeUtils.convertIntegerToHMMSS(timeUtils.convertHHMMSSToIntFromNoonOfDayOfService("06:01:00"))`
returns `06:01:00` instead of `06:60:00`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~