### PR TITLE
Implement #131 - Check agency.agency_lang and feed_info.feed_lang match

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -314,6 +314,16 @@ A trip must visit more than one stop in `stop_times.txt` to be usable by passeng
 ### E055 - Mismatching feed and agency language fields
 
 Files `agency.txt` and `feed_info.txt` must define matching `agency.agency_lang` and `feed_info.feed_lang`.
+The default language may be multilingual for datasets with the original text in multiple languages. In such cases, the feed_lang field should contain the language code mul defined by 
+the norm ISO 639-2.
+* If `feed_lang` is not `mul` and does not match with `agency_lang`, that's an error
+* If there is more than one `agency_lang` and `feed_lang` isn't `mul`, that's an error
+* If `feed_lang` is `mul` and there isn't more than one `agency_lang`, that's an error
+
+
+#### References:
+* [feed_info.txt specification](http://gtfs.org/reference/static/#feed_infotxt)
+* [agency.txt specification](http://gtfs.org/reference/static/#agencytxt)
 
 <a name="E056"/>
 

--- a/RULES.md
+++ b/RULES.md
@@ -332,8 +332,8 @@ the norm ISO 639-2.
 * If `feed_lang` is `mul` and there isn't more than one `agency_lang`, that's an error
 
 #### References:
-* [feed_info.txt specification](http://gtfs.org/reference/static/#feed_infotxt)
-* [agency.txt specification](http://gtfs.org/reference/static/#agencytxt)
+* [GTFS feed_info.txt specification](http://gtfs.org/reference/static/#feed_infotxt)
+* [GTFS agency.txt specification](http://gtfs.org/reference/static/#agencytxt)
 
 <a name="E056"/>
 

--- a/RULES.md
+++ b/RULES.md
@@ -309,7 +309,6 @@ Trips must be referred to at least once in `stop_times.txt`.
 
 A trip must visit more than one stop in `stop_times.txt` to be usable by passengers for boarding and alighting.
 
-
 <a name="E055"/>
 
 ### E055 - Mismatching feed and agency language fields

--- a/RULES.md
+++ b/RULES.md
@@ -330,8 +330,7 @@ Trip frequencies must not overlap in time
 ### E055 - Mismatching feed and agency language fields
 
 Files `agency.txt` and `feed_info.txt` must define matching `agency.agency_lang` and `feed_info.feed_lang`.
-The default language may be multilingual for datasets with the original text in multiple languages. In such cases, the feed_lang field should contain the language code mul defined by 
-the norm ISO 639-2.
+The default language may be multilingual for datasets with the original text in multiple languages. In such cases, the feed_lang field should contain the language code mul defined by the norm ISO 639-2.
 * If `feed_lang` is not `mul` and does not match with `agency_lang`, that's an error
 * If there is more than one `agency_lang` and `feed_lang` isn't `mul`, that's an error
 * If `feed_lang` is `mul` and there isn't more than one `agency_lang`, that's an error

--- a/RULES.md
+++ b/RULES.md
@@ -52,6 +52,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E049](#E049) | Backwards time travel between stops in `stop_times.txt` |
 | [E050](#E050) | Trips must be used in `stop_times.txt` |
 | [E051](#E051) | Trips must have more than one stop to be usable |
+| [E055](#E055) | Mismatching feed and agency language fields |
 
 ### Table of Warnings
 
@@ -306,6 +307,13 @@ Trips must be referred to at least once in `stop_times.txt`.
 ### E051 - Trips must have more than one stop to be usable
 
 A trip must visit more than one stop in `stop_times.txt` to be usable by passengers for boarding and alighting.
+
+
+<a name="E055"/>
+
+### E055 - Mismatching feed and agency language fields
+
+Files `agency.txt` and `feed_info.txt` must define matching `agency.agency_lang` and `feed_info.feed_lang`.
 
 # Warnings
 

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -356,4 +356,9 @@ public class JsonNoticeExporter implements NoticeExporter {
     public void export(final UnusableTripNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }
+
+    @Override
+    public void export(final FeedInfoLangAgencyLangMismatchNotice toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
 }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -745,7 +745,7 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .setEntityId(toExport.getEntityId())
                 .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
                 .setType(TYPE_AGENCY_LANG_AND_FEED_LANG_MISMATCH)
-                .setAltValue(String.valueOf(toExport.getNoticeSpecific(KEY_AGENCY_AGENCY_NAME)))
+                .setAltValue(String.valueOf(toExport.getNoticeSpecific(KEY_AGENCY_NAME)))
                 .setCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_AGENCY_AGENCY_LANG)))
                 .setOtherCsvFileName(String.valueOf(toExport.getNoticeSpecific(KEY_FEED_INFO_FEED_LANG)))
                 .build()

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -29,8 +29,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_BAD_NUMBER_OF_ROWS;
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_USABLE_STOPS;
+import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.*;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.*;
 
 public class ProtobufNoticeExporter implements NoticeExporter {
@@ -735,6 +734,20 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .setAltEntityId(String.valueOf(toExport.getNoticeSpecific(KEY_COMPOSITE_KEY_THIRD_VALUE)))
                 .setEntityValue(String.valueOf(toExport.getNoticeSpecific(KEY_CURRENT_DATE)))
                 .setAltEntityValue(String.valueOf(toExport.getNoticeSpecific(KEY_FEED_INFO_END_DATE)))
+                .build()
+                .writeTo(streamGenerator.getStream());
+    }
+
+    @Override
+    public void export(final FeedInfoLangAgencyLangMismatchNotice toExport) throws IOException {
+        protoBuilder.clear()
+                .setCsvFileName(toExport.getFilename())
+                .setEntityId(toExport.getEntityId())
+                .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
+                .setType(TYPE_AGENCY_LANG_AND_FEED_LANG_MISMATCH)
+                .setAltValue(String.valueOf(toExport.getNoticeSpecific(KEY_AGENCY_AGENCY_NAME)))
+                .setCsvKeyName(String.valueOf(toExport.getNoticeSpecific(KEY_AGENCY_AGENCY_LANG)))
+                .setOtherCsvFileName(String.valueOf(toExport.getNoticeSpecific(KEY_FEED_INFO_FEED_LANG)))
                 .build()
                 .writeTo(streamGenerator.getStream());
     }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -921,4 +921,18 @@ class JsonNoticeExporterTest {
         verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
         verifyNoMoreInteractions(mockGenerator);
     }
+
+    @Test
+    void exportFeedInfoLangAgencyLangMismatchNoticeShouldWriteObject() throws IOException {
+        JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        FeedInfoLangAgencyLangMismatchNotice toExport =
+                new FeedInfoLangAgencyLangMismatchNotice("agency id value", "agency name value"
+                        , "agency lang value", "feed info lang value");
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
 }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -28,8 +28,7 @@ import java.net.URL;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_BAD_NUMBER_OF_ROWS;
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_USABLE_STOPS;
+import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.*;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_SERVICE_ID;
 import static org.mockito.Mockito.*;
 
@@ -2129,6 +2128,47 @@ class ProtobufNoticeExporterTest {
                 .setEntityId(ArgumentMatchers.eq("trip_id"));
         verify(mockBuilder, times(1))
                 .setType(ArgumentMatchers.eq(TYPE_TRIP_WITH_NO_USABLE_STOPS));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
+
+    @Test
+    void exportFeedInfoLangAgencyLangMismatchNoticeShouldMapToCsvProblemAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        underTest.export(
+                new FeedInfoLangAgencyLangMismatchNotice(
+                        "agency id value",
+                        "agency name value",
+                        "agency lang value",
+                        "feed info lang value"));
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(ArgumentMatchers.eq("feed_info.txt"));
+        verify(mockBuilder, times(1))
+                .setEntityId(ArgumentMatchers.eq("agency id value"));
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
+        verify(mockBuilder, times(1)).setType(
+                ArgumentMatchers.eq(TYPE_AGENCY_LANG_AND_FEED_LANG_MISMATCH));
+        verify(mockBuilder, times(1))
+                .setAltValue(ArgumentMatchers.eq("agency name value"));
+        verify(mockBuilder, times(1))
+                .setCsvKeyName(ArgumentMatchers.eq("agency lang value"));
+        verify(mockBuilder, times(1))
+                .setOtherCsvFileName(ArgumentMatchers.eq("feed info lang value"));
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
@@ -489,6 +489,7 @@ public class InMemoryGtfsDataRepository implements GtfsDataRepository {
      * @return the entity added to the repository if the uniqueness constraint of route based on feed_publisher_name is
      * respected, if this requirement is not met returns null.
      */
+    // todo: take into account that feed info is a single-line file! We can not add more than 1 feed_info
     @Override
     public FeedInfo addFeedInfo(final FeedInfo newFeedInfo) throws IllegalArgumentException {
         if (newFeedInfo != null) {

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
@@ -489,7 +489,6 @@ public class InMemoryGtfsDataRepository implements GtfsDataRepository {
      * @return the entity added to the repository if the uniqueness constraint of route based on feed_publisher_name is
      * respected, if this requirement is not met returns null.
      */
-    // todo: take into account that feed info is a single-line file! We can not add more than 1 feed_info
     @Override
     public FeedInfo addFeedInfo(final FeedInfo newFeedInfo) throws IllegalArgumentException {
         if (newFeedInfo != null) {

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -211,6 +211,7 @@ public class Main {
                 config.validateTripUsage().execute();
                 config.validateTripNumberOfStops().execute();
                 config.validateFrequencyStartTimeBeforeEndTime().execute();
+                config.validateAgencyLangAndFeedInfoFeedLangMatch().execute();
 
                 config.cleanOrCreatePath().execute(ExecParamRepository.OUTPUT_KEY);
 

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -244,6 +244,10 @@ public class DefaultConfig {
         return new ValidateFeedInfoFeedStartDateIsPresent(gtfsDataRepository, resultRepo, logger);
     }
 
+    public ValidateAgencyLangAndFeedInfoFeedLangMatch validateAgencyLangAndFeedInfoFeedLangMatch() {
+        return new ValidateAgencyLangAndFeedInfoFeedLangMatch(gtfsDataRepository, resultRepo, logger);
+    }
+
     public ExportResultAsFile exportResultAsFile() {
         return new ExportResultAsFile(resultRepo, execParamRepo, logger);
     }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -136,4 +136,6 @@ public interface NoticeExporter {
     void export(final TripNotUsedNotice tripNotUsedNotice) throws IOException;
 
     void export(final UnusableTripNotice unusableTripNotice) throws IOException;
+
+    void export(final FeedInfoLangAgencyLangMismatchNotice feedInfoLangAgencyLangMismatchNotice) throws IOException;
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -70,6 +70,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_049 = 49;
     protected static final int E_050 = 50;
     protected static final int E_051 = 51;
+    protected static final int E_055 = 55;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
@@ -74,6 +74,9 @@ public abstract class Notice {
     public static final String KEY_STOP_TIME_STOP_SEQUENCE_LIST = "stopTimeStopSequenceList";
     public static final String KEY_STOP_TIME_STOP_SEQUENCE = "stopTimeStopSequence";
     public static final String KEY_STOP_TIME_TRIP_ID = "stopTimeTripId";
+    public static final String KEY_AGENCY_AGENCY_NAME = "agencyAgencyName";
+    public static final String KEY_AGENCY_AGENCY_LANG = "agencyAgencyLang";
+    public static final String KEY_FEED_INFO_FEED_LANG = "feedInfoFeedLang";
 
     private final String filename;
     private final int code;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
@@ -81,6 +81,7 @@ public abstract class Notice {
     public static final String KEY_FREQUENCY_END_TIME = "frequencyEndTime";
     public static final String KEY_AGENCY_AGENCY_NAME = "agencyAgencyName";
     public static final String KEY_AGENCY_AGENCY_LANG = "agencyAgencyLang";
+    public static final String KEY_AGENCY_AGENCY_LANG_COLLECTION = "agencyAgencyLangCollection";
     public static final String KEY_FEED_INFO_FEED_LANG = "feedInfoFeedLang";
 
     private final String filename;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
@@ -87,7 +87,6 @@ public abstract class Notice {
     public static final String KEY_PREVIOUS_TRIP_FIRST_TIME = "previousTripFirstTime";
     public static final String KEY_PREVIOUS_TRIP_LAST_TIME = "previousTripLastTime";
     public static final String KEY_CONFLICTING_DATE_LIST = "conflictingDateList";
-    public static final String KEY_AGENCY_AGENCY_NAME = "agencyAgencyName";
     public static final String KEY_AGENCY_AGENCY_LANG = "agencyAgencyLang";
     public static final String KEY_AGENCY_AGENCY_LANG_COLLECTION = "agencyAgencyLangCollection";
     public static final String KEY_FEED_INFO_FEED_LANG = "feedInfoFeedLang";

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
@@ -20,6 +20,7 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
 
 import java.io.IOException;
+import java.util.Set;
 
 public class FeedInfoLangAgencyLangMismatchNotice extends ErrorNotice {
 
@@ -40,6 +41,29 @@ public class FeedInfoLangAgencyLangMismatchNotice extends ErrorNotice {
         putNoticeSpecific(KEY_AGENCY_AGENCY_NAME, agencyName);
         putNoticeSpecific(KEY_AGENCY_AGENCY_LANG, agencyLang);
         putNoticeSpecific(KEY_FEED_INFO_FEED_LANG, feedInfoFeedLang);
+    }
+
+    public FeedInfoLangAgencyLangMismatchNotice(final Set<String> agencyLangCollection, final String feedInfoFeedLang) {
+        super("feed_info.txt",
+                E_055,
+                "Mismatching feed and agency language fields",
+                String.format("`feed_info.feed_lang` is `%s` but `agency.txt` defines more than one " +
+                                "`agency.agency_lang`: `%s`",
+                        feedInfoFeedLang, agencyLangCollection),
+                null);
+        putNoticeSpecific(KEY_FEED_INFO_FEED_LANG, feedInfoFeedLang);
+        putNoticeSpecific(KEY_AGENCY_AGENCY_LANG_COLLECTION, agencyLangCollection);
+    }
+
+    public FeedInfoLangAgencyLangMismatchNotice(final Set<String> agencyLangCollection) {
+        super("feed_info.txt",
+                E_055,
+                "Mismatching feed and agency language fields",
+                String.format("`feed_info.feed_lang` is `mul` but `agency.txt` only defines: `%s` as agency_lang.",
+                        agencyLangCollection),
+                null);
+        putNoticeSpecific(KEY_AGENCY_AGENCY_LANG_COLLECTION, agencyLangCollection);
+        putNoticeSpecific(KEY_FEED_INFO_FEED_LANG, "mul");
     }
 
     @Override

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
@@ -30,7 +30,7 @@ public class FeedInfoLangAgencyLangMismatchNotice extends ErrorNotice {
         super("feed_info.txt",
                 E_055,
                 "Mismatching feed and agency language fields",
-                String.format("Agency with `agency_name`: `%s` have mismatching `agency.agency_lang`: `%s` and" +
+                String.format("Agency `agency_name`: `%s` has mismatching `agency.agency_lang`: `%s` and" +
                                 " feed_info.feed_lang`: `%s`.",
                         agencyName,
                         agencyLang,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
@@ -29,7 +29,7 @@ public class FeedInfoLangAgencyLangMismatchNotice extends ErrorNotice {
                                                 final String feedInfoFeedLang) {
         super("feed_info.txt",
                 E_055,
-                "Conflicting field values",
+                "Mismatching feed and agency language fields",
                 String.format("Agency with `agency_name`: `%s` have mismatching `agency.agency_lang`: `%s` and" +
                                 " feed_info.feed_lang`: `%s`.",
                         agencyName,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
@@ -38,7 +38,7 @@ public class FeedInfoLangAgencyLangMismatchNotice extends ErrorNotice {
                         feedInfoFeedLang),
                 agencyId
         );
-        putNoticeSpecific(KEY_AGENCY_AGENCY_NAME, agencyName);
+        putNoticeSpecific(KEY_AGENCY_NAME, agencyName);
         putNoticeSpecific(KEY_AGENCY_AGENCY_LANG, agencyLang);
         putNoticeSpecific(KEY_FEED_INFO_FEED_LANG, feedInfoFeedLang);
     }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/FeedInfoLangAgencyLangMismatchNotice.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.domain.entity.notice.error;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+
+import java.io.IOException;
+
+public class FeedInfoLangAgencyLangMismatchNotice extends ErrorNotice {
+
+    public FeedInfoLangAgencyLangMismatchNotice(final String agencyId,
+                                                final String agencyName,
+                                                final String agencyLang,
+                                                final String feedInfoFeedLang) {
+        super("feed_info.txt",
+                E_055,
+                "Conflicting field values",
+                String.format("Agency with `agency_name`: `%s` have mismatching `agency.agency_lang`: `%s` and" +
+                                " feed_info.feed_lang`: `%s`.",
+                        agencyName,
+                        agencyLang,
+                        feedInfoFeedLang),
+                agencyId
+        );
+        putNoticeSpecific(KEY_AGENCY_AGENCY_NAME, agencyName);
+        putNoticeSpecific(KEY_AGENCY_AGENCY_LANG, agencyLang);
+        putNoticeSpecific(KEY_FEED_INFO_FEED_LANG, feedInfoFeedLang);
+    }
+
+    @Override
+    public void export(final NoticeExporter exporter) throws IOException {
+        exporter.export(this);
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
@@ -65,40 +65,30 @@ public class ValidateAgencyLangAndFeedInfoFeedLangMatch {
                 dataRepo.getFeedInfoAll().values().stream().findFirst().get().getFeedLang();
         final Set<String> agencyLangCollection = new HashSet<>();
         dataRepo.getAgencyAll().forEach((agencyId, agency) -> agencyLangCollection.add(agency.getAgencyLang()));
+        if (feedInfoFeedLang.equals(MUL)) {
+            // If feed_lang is mul and there isn't more than one agency_lang, that's an error
+            if (agencyLangCollection.size() <= 1) {
+                resultRepo.addNotice(new FeedInfoLangAgencyLangMismatchNotice(agencyLangCollection));
+                return;
+            }
+            return;
+        }
+        // If there is more than one agency_lang and feed_lang isn't mul, that's an error
+        // check if feed_lang is `mul` here is redundant but is provided for future software maintenance
+        if (!feedInfoFeedLang.equals(MUL) && agencyLangCollection.size() > 1 && !agencyLangCollection.contains(feedInfoFeedLang)) {
+            resultRepo.addNotice(new FeedInfoLangAgencyLangMismatchNotice(agencyLangCollection, feedInfoFeedLang));
+            return;
+        }
 
         dataRepo.getAgencyAll().forEach((agencyId, agency) -> {
-            if (!feedInfoFeedLang.equals(MUL)) {
-                // If feed_lang is not mul and differs from agency_lang, that's an error
-                if (!feedInfoFeedLang.equals(agency.getAgencyLang())) {
-                    resultRepo.addNotice(
-                            new FeedInfoLangAgencyLangMismatchNotice(
-                                    agencyId,
-                                    agency.getAgencyName(),
-                                    agency.getAgencyLang(),
-                                    feedInfoFeedLang));
-                    return;
-                }
-                // If there is more than one agency_lang and feed_lang isn't mul, that's an error
-                if (agencyLangCollection.size() > 1 && !feedInfoFeedLang.equals(agency.getAgencyLang())) {
-                    resultRepo.addNotice(
-                            new FeedInfoLangAgencyLangMismatchNotice(
-                                    agencyId,
-                                    agency.getAgencyName(),
-                                    agency.getAgencyLang(),
-                                    feedInfoFeedLang));
-                    return;
-                }
-            } else {
-                // If feed_lang is mul and there isn't more than one agency_lang, that's an error
-                if (agencyLangCollection.size() <= 1) {
-                    resultRepo.addNotice(
-                            new FeedInfoLangAgencyLangMismatchNotice(
-                                    agencyId,
-                                    agency.getAgencyName(),
-                                    agency.getAgencyLang(),
-                                    feedInfoFeedLang));
-                    return;
-                }
+            // If feed_lang is not mul and differs from agency_lang, that's an error
+            if (!feedInfoFeedLang.equals(agency.getAgencyLang())) {
+                resultRepo.addNotice(
+                        new FeedInfoLangAgencyLangMismatchNotice(
+                                agencyId,
+                                agency.getAgencyName(),
+                                agency.getAgencyLang(),
+                                feedInfoFeedLang));
             }
         });
     }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
@@ -74,8 +74,7 @@ public class ValidateAgencyLangAndFeedInfoFeedLangMatch {
             return;
         }
         // If there is more than one agency_lang and feed_lang isn't mul, that's an error
-        // check if feed_lang is `mul` here is redundant but is provided for future software maintenance
-        if (!feedInfoFeedLang.equals(MUL) && agencyLangCollection.size() > 1 && !agencyLangCollection.contains(feedInfoFeedLang)) {
+        if (agencyLangCollection.size() > 1 && !agencyLangCollection.contains(feedInfoFeedLang)) {
             resultRepo.addNotice(new FeedInfoLangAgencyLangMismatchNotice(agencyLangCollection, feedInfoFeedLang));
             return;
         }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
@@ -74,7 +74,7 @@ public class ValidateAgencyLangAndFeedInfoFeedLangMatch {
             return;
         }
         // If there is more than one agency_lang and feed_lang isn't mul, that's an error
-        if (agencyLangCollection.size() > 1 && !agencyLangCollection.contains(feedInfoFeedLang)) {
+        if (agencyLangCollection.size() > 1) {
             resultRepo.addNotice(new FeedInfoLangAgencyLangMismatchNotice(agencyLangCollection, feedInfoFeedLang));
             return;
         }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.apache.logging.log4j.Logger;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.FeedInfoLangAgencyLangMismatchNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+
+public class ValidateAgencyLangAndFeedInfoFeedLangMatch {
+    private final GtfsDataRepository dataRepo;
+    private final ValidationResultRepository resultRepo;
+    private final Logger logger;
+
+    public ValidateAgencyLangAndFeedInfoFeedLangMatch(final GtfsDataRepository dataRepo,
+                                                      final ValidationResultRepository resultRepo,
+                                                      final Logger logger) {
+        this.dataRepo = dataRepo;
+        this.resultRepo = resultRepo;
+        this.logger = logger;
+    }
+
+    public void execute() {
+        logger.info("Validating rule 'E055 - Mismatching feed and agency language fields'");
+        final String feedInfoFeedLang = dataRepo.getFeedInfoAll().size() > 1 ?
+                dataRepo.getFeedInfoAll().values().stream().findFirst().get().getFeedLang() :
+                null;
+        if (feedInfoFeedLang != null) {
+            dataRepo.getAgencyAll().forEach((agencyId, agency) -> {
+                if (agencyId != null) {
+                    if (!feedInfoFeedLang.equals("mul"))
+                        if (!agency.getAgencyLang().equals(feedInfoFeedLang)) {
+                            resultRepo.addNotice(
+                                    new FeedInfoLangAgencyLangMismatchNotice(
+                                            agencyId,
+                                            agency.getAgencyName(),
+                                            agency.getAgencyName(),
+                                            feedInfoFeedLang)
+                            );
+                        }
+                }
+            });
+        }
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatch.java
@@ -21,11 +21,20 @@ import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.FeedInfoLangAge
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 
+/**
+ * Use case to validate that `agency.agency_lang` and `feed_info.feed_lang` match. This use case is triggered after
+ * completing the {@code GtfsDataRepository} provided in the constructor with {@code StopTime} entities.
+ */
 public class ValidateAgencyLangAndFeedInfoFeedLangMatch {
     private final GtfsDataRepository dataRepo;
     private final ValidationResultRepository resultRepo;
     private final Logger logger;
 
+    /**
+     * @param dataRepo   a repository storing the data of a GTFS dataset
+     * @param resultRepo a repository storing information about the validation process
+     * @param logger     a logger to log information about the validation process
+     */
     public ValidateAgencyLangAndFeedInfoFeedLangMatch(final GtfsDataRepository dataRepo,
                                                       final ValidationResultRepository resultRepo,
                                                       final Logger logger) {
@@ -34,6 +43,12 @@ public class ValidateAgencyLangAndFeedInfoFeedLangMatch {
         this.logger = logger;
     }
 
+    /**
+     * Use case execution method: checks if for each {@code Agency} defines a value for `agency.agency_lang` that
+     * matches the value contained in `feed_info.feed_lang` if `feed_info.txt` is provided. If this requirement is not
+     * met, a {@code StopTimeArrivalTimeAfterDepartureTimeNotice} is added to the {@code ValidationResultRepo} provided
+     * in the constructor.
+     */
     public void execute() {
         logger.info("Validating rule 'E055 - Mismatching feed and agency language fields'");
         final String feedInfoFeedLang = dataRepo.getFeedInfoAll().size() > 1 ?

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatchTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatchTest.java
@@ -28,6 +28,7 @@ import org.mockito.ArgumentCaptor;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.*;
@@ -96,44 +97,6 @@ class ValidateAgencyLangAndFeedInfoFeedLangMatchTest {
     // suppressed warning regarding ignored result of method, since the method is called in assertions
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
-    void mulMatchesWithAnyAgencyLangAndShouldNotGenerateNotice() {
-        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
-        when(mockFeedInfo.getFeedLang()).thenReturn("mul");
-
-        final Agency mockAgency0 = mock(Agency.class);
-        when(mockAgency0.getAgencyLang()).thenReturn("french");
-        final Agency mockAgency1 = mock(Agency.class);
-        when(mockAgency1.getAgencyLang()).thenReturn("english");
-
-        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
-        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
-        when(mockDataRepo.getAgencyAll()).thenReturn(new HashMap<>(Map.of("agency id 0", mockAgency0,
-                "agency id 1", mockAgency1)));
-        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
-        final Logger mockLogger = mock(Logger.class);
-
-        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
-                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
-
-        underTest.execute();
-
-        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
-                "agency language fields'");
-
-        verify(mockDataRepo, times(2)).getFeedInfoAll();
-        verify(mockDataRepo, times(2)).getAgencyAll();
-
-        verify(mockFeedInfo, times(1)).getFeedLang();
-
-        verify(mockAgency0, times(1)).getAgencyLang();
-        verify(mockAgency1, times(1)).getAgencyLang();
-
-        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
-    }
-
-    // suppressed warning regarding ignored result of method, since the method is called in assertions
-    @SuppressWarnings("ResultOfMethodCallIgnored")
-    @Test
     void nonMatchingFeedInfoFeedLangShouldGenerateNotice() {
         final FeedInfo mockFeedInfo = mock(FeedInfo.class);
         when(mockFeedInfo.getFeedLang()).thenReturn("default language");
@@ -168,7 +131,7 @@ class ValidateAgencyLangAndFeedInfoFeedLangMatchTest {
         verify(mockAgency0, times(3)).getAgencyLang();
         verify(mockAgency0, times(1)).getAgencyName();
 
-        verify(mockAgency1, times(3)).getAgencyLang();
+        verify(mockAgency1, times(2)).getAgencyLang();
 
         final ArgumentCaptor<FeedInfoLangAgencyLangMismatchNotice> captor =
                 ArgumentCaptor.forClass(FeedInfoLangAgencyLangMismatchNotice.class);
@@ -218,39 +181,121 @@ class ValidateAgencyLangAndFeedInfoFeedLangMatchTest {
                 "agency language fields'");
 
         verify(mockDataRepo, times(2)).getFeedInfoAll();
-        verify(mockDataRepo, times(2)).getAgencyAll();
+        verify(mockDataRepo, times(1)).getAgencyAll();
 
         verify(mockFeedInfo, times(1)).getFeedLang();
 
-        verify(mockAgency0, times(3)).getAgencyLang();
-        verify(mockAgency0, times(1)).getAgencyName();
-
-        verify(mockAgency1, times(1)).getAgencyName();
-        verify(mockAgency1, times(3)).getAgencyLang();
+        verify(mockAgency0, times(1)).getAgencyLang();
+        verify(mockAgency1, times(1)).getAgencyLang();
 
         final ArgumentCaptor<FeedInfoLangAgencyLangMismatchNotice> captor =
                 ArgumentCaptor.forClass(FeedInfoLangAgencyLangMismatchNotice.class);
 
-        verify(mockResultRepo, times(2)).addNotice(captor.capture());
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
 
         final List<FeedInfoLangAgencyLangMismatchNotice> noticeList = captor.getAllValues();
-        assertEquals(2, noticeList.size());
+        assertEquals(1, noticeList.size());
 
         assertEquals("feed_info.txt", noticeList.get(0).getFilename());
         assertEquals("ERROR", noticeList.get(0).getLevel());
         assertEquals(55, noticeList.get(0).getCode());
-        assertEquals("agency name", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_NAME));
-        assertEquals("non matching language", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG));
+        assertEquals(Set.of("non matching language", "other non matching language"),
+                noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG_COLLECTION));
         assertEquals("default language", noticeList.get(0).getNoticeSpecific(KEY_FEED_INFO_FEED_LANG));
-        assertEquals("agency id 0", noticeList.get(0).getEntityId());
 
-        assertEquals("feed_info.txt", noticeList.get(1).getFilename());
-        assertEquals("ERROR", noticeList.get(1).getLevel());
-        assertEquals(55, noticeList.get(1).getCode());
-        assertEquals("agency name", noticeList.get(1).getNoticeSpecific(KEY_AGENCY_AGENCY_NAME));
-        assertEquals("other non matching language", noticeList.get(1).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG));
-        assertEquals("default language", noticeList.get(1).getNoticeSpecific(KEY_FEED_INFO_FEED_LANG));
-        assertEquals("agency id 1", noticeList.get(1).getEntityId());
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
+    }
+
+    @Test
+    void feedLangNotMulAndOnlyThanOneMatchingAgencyLangShouldNotGenerateNotice() {
+        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
+        when(mockFeedInfo.getFeedLang()).thenReturn("default language");
+
+        final Agency mockAgency0 = mock(Agency.class);
+        when(mockAgency0.getAgencyLang()).thenReturn("default language");
+        when(mockAgency0.getAgencyName()).thenReturn("agency name");
+
+        final Agency mockAgency1 = mock(Agency.class);
+        when(mockAgency1.getAgencyName()).thenReturn("agency name");
+        when(mockAgency1.getAgencyLang()).thenReturn("default language");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
+        when(mockDataRepo.getAgencyAll()).thenReturn(
+                new HashMap<>(Map.of("agency id 0", mockAgency0, "agency id 1", mockAgency1)));
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(2)).getFeedInfoAll();
+        verify(mockDataRepo, times(2)).getAgencyAll();
+
+        verify(mockFeedInfo, times(1)).getFeedLang();
+        verify(mockAgency0, times(2)).getAgencyLang();
+        verify(mockAgency1, times(2)).getAgencyLang();
+
+        verifyNoMoreInteractions(mockDataRepo, mockResultRepo, mockLogger, mockResultRepo, mockFeedInfo,
+                mockAgency0, mockAgency1);
+    }
+
+    @Test
+    void feedLangNotMulAndOnlyOneMismatchingAgencyLangShouldGenerateNotice() {
+        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
+        when(mockFeedInfo.getFeedLang()).thenReturn("default language");
+
+        final Agency mockAgency0 = mock(Agency.class);
+        when(mockAgency0.getAgencyLang()).thenReturn("default language");
+        when(mockAgency0.getAgencyName()).thenReturn("agency name");
+
+        final Agency mockAgency1 = mock(Agency.class);
+        when(mockAgency1.getAgencyName()).thenReturn("agency name");
+        when(mockAgency1.getAgencyLang()).thenReturn("mismatching language");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
+        when(mockDataRepo.getAgencyAll()).thenReturn(
+                new HashMap<>(Map.of("agency id 0", mockAgency0, "agency id 1", mockAgency1)));
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(2)).getFeedInfoAll();
+        verify(mockDataRepo, times(2)).getAgencyAll();
+
+        verify(mockFeedInfo, times(1)).getFeedLang();
+        verify(mockAgency0, times(2)).getAgencyLang();
+        verify(mockAgency1, times(3)).getAgencyLang();
+        verify(mockAgency1, times(1)).getAgencyName();
+
+        final ArgumentCaptor<FeedInfoLangAgencyLangMismatchNotice> captor =
+                ArgumentCaptor.forClass(FeedInfoLangAgencyLangMismatchNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final List<FeedInfoLangAgencyLangMismatchNotice> noticeList = captor.getAllValues();
+        assertEquals(1, noticeList.size());
+
+        assertEquals("feed_info.txt", noticeList.get(0).getFilename());
+        assertEquals("ERROR", noticeList.get(0).getLevel());
+        assertEquals(55, noticeList.get(0).getCode());
+        assertEquals("agency id 1", noticeList.get(0).getEntityId());
+        assertEquals("agency name", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_NAME));
+        assertEquals("mismatching language", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG));
+        assertEquals("default language", noticeList.get(0).getNoticeSpecific(KEY_FEED_INFO_FEED_LANG));
 
         verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
     }
@@ -284,39 +329,64 @@ class ValidateAgencyLangAndFeedInfoFeedLangMatchTest {
                 "agency language fields'");
 
         verify(mockDataRepo, times(2)).getFeedInfoAll();
-        verify(mockDataRepo, times(2)).getAgencyAll();
+        verify(mockDataRepo, times(1)).getAgencyAll();
 
         verify(mockFeedInfo, times(1)).getFeedLang();
 
-        verify(mockAgency0, times(1)).getAgencyName();
-        verify(mockAgency0, times(2)).getAgencyLang();
-
-        verify(mockAgency1, times(1)).getAgencyName();
-        verify(mockAgency1, times(2)).getAgencyLang();
+        verify(mockAgency0, times(1)).getAgencyLang();
+        verify(mockAgency1, times(1)).getAgencyLang();
 
         final ArgumentCaptor<FeedInfoLangAgencyLangMismatchNotice> captor =
                 ArgumentCaptor.forClass(FeedInfoLangAgencyLangMismatchNotice.class);
 
-        verify(mockResultRepo, times(2)).addNotice(captor.capture());
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
 
         final List<FeedInfoLangAgencyLangMismatchNotice> noticeList = captor.getAllValues();
-        assertEquals(2, noticeList.size());
+        assertEquals(1, noticeList.size());
 
         assertEquals("feed_info.txt", noticeList.get(0).getFilename());
         assertEquals("ERROR", noticeList.get(0).getLevel());
         assertEquals(55, noticeList.get(0).getCode());
-        assertEquals("agency name", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_NAME));
-        assertEquals("some language", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG));
+        assertEquals(Set.of("some language"), noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG_COLLECTION));
         assertEquals("mul", noticeList.get(0).getNoticeSpecific(KEY_FEED_INFO_FEED_LANG));
-        assertEquals("agency id 0", noticeList.get(0).getEntityId());
 
-        assertEquals("feed_info.txt", noticeList.get(1).getFilename());
-        assertEquals("ERROR", noticeList.get(1).getLevel());
-        assertEquals(55, noticeList.get(1).getCode());
-        assertEquals("agency name", noticeList.get(1).getNoticeSpecific(KEY_AGENCY_AGENCY_NAME));
-        assertEquals("some language", noticeList.get(1).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG));
-        assertEquals("mul", noticeList.get(1).getNoticeSpecific(KEY_FEED_INFO_FEED_LANG));
-        assertEquals("agency id 1", noticeList.get(1).getEntityId());
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
+    }
+
+    // suppressed warning regarding ignored result of method, since the method is called in assertions
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Test
+    void mulFeedLandAnMoreThanOneAgencyShouldNotGenerateNotice() {
+        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
+        when(mockFeedInfo.getFeedLang()).thenReturn("mul");
+
+        final Agency mockAgency0 = mock(Agency.class);
+        when(mockAgency0.getAgencyLang()).thenReturn("french");
+        final Agency mockAgency1 = mock(Agency.class);
+        when(mockAgency1.getAgencyLang()).thenReturn("english");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
+        when(mockDataRepo.getAgencyAll()).thenReturn(new HashMap<>(Map.of("agency id 0", mockAgency0,
+                "agency id 1", mockAgency1)));
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(2)).getFeedInfoAll();
+        verify(mockDataRepo, times(1)).getAgencyAll();
+
+        verify(mockFeedInfo, times(1)).getFeedLang();
+
+        verify(mockAgency0, times(1)).getAgencyLang();
+        verify(mockAgency1, times(1)).getAgencyLang();
 
         verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
     }

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatchTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatchTest.java
@@ -16,28 +16,168 @@
 
 package org.mobilitydata.gtfsvalidator.usecase;
 
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.FeedInfo;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.FeedInfoLangAgencyLangMismatchNotice;
+import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
+import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.*;
+import static org.mockito.Mockito.*;
 
 class ValidateAgencyLangAndFeedInfoFeedLangMatchTest {
 
     @Test
-    void notProvidedFeedInfoShouldNotGenerateNotice() {
-        // todo feed_info.feed_lang = null
+    void feedInfoFileNotProvidedShouldNotGenerateNotice() {
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>());
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(1)).getFeedInfoAll();
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockDataRepo, mockLogger);
     }
 
+    // suppressed warning regarding ignored result of method, since the method is called in assertions
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void matchingFeedInfoFeedLangShouldNotGenerateNotice() {
-        // todo, agency.agency_lang = feed_info.feed_lang
+        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
+        when(mockFeedInfo.getFeedLang()).thenReturn("common language");
+
+        final Agency mockAgency0 = mock(Agency.class);
+        when(mockAgency0.getAgencyLang()).thenReturn("common language");
+        final Agency mockAgency1 = mock(Agency.class);
+        when(mockAgency1.getAgencyLang()).thenReturn("common language");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
+        when(mockDataRepo.getAgencyAll()).thenReturn(new HashMap<>(Map.of("agency id 0", mockAgency0,
+                "agency id 1", mockAgency1)));
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(2)).getFeedInfoAll();
+        verify(mockDataRepo, times(1)).getAgencyAll();
+
+        verify(mockFeedInfo, times(1)).getFeedLang();
+
+        verify(mockAgency0, times(1)).getAgencyLang();
+        verify(mockAgency1, times(1)).getAgencyLang();
+
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
     }
 
+    // suppressed warning regarding ignored result of method, since the method is called in assertions
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void mulMatchesWithAnyAgencyLangAndShouldNotGenerateNotice() {
-        // todo, feed_info.feed_lang = null and agency.agency_lang = whatever
+        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
+        when(mockFeedInfo.getFeedLang()).thenReturn("mul");
 
+        final Agency mockAgency0 = mock(Agency.class);
+        when(mockAgency0.getAgencyLang()).thenReturn("french");
+        final Agency mockAgency1 = mock(Agency.class);
+        when(mockAgency1.getAgencyLang()).thenReturn("english");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
+        when(mockDataRepo.getAgencyAll()).thenReturn(new HashMap<>(Map.of("agency id 0", mockAgency0,
+                "agency id 1", mockAgency1)));
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(2)).getFeedInfoAll();
+        verify(mockDataRepo, times(1)).getAgencyAll();
+
+        verify(mockFeedInfo, times(1)).getFeedLang();
+
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
     }
 
+    // suppressed warning regarding ignored result of method, since the method is called in assertions
+    @SuppressWarnings("ResultOfMethodCallIgnored")
     @Test
     void nonMatchingFeedInfoFeedLangShouldGenerateNotice() {
-        // todo: feed_info.feed_lang != agency.agency_lang
+        final FeedInfo mockFeedInfo = mock(FeedInfo.class);
+        when(mockFeedInfo.getFeedLang()).thenReturn("default language");
+
+        final Agency mockAgency0 = mock(Agency.class);
+        when(mockAgency0.getAgencyLang()).thenReturn("non matching language");
+        when(mockAgency0.getAgencyName()).thenReturn("agency name");
+        final Agency mockAgency1 = mock(Agency.class);
+        when(mockAgency1.getAgencyLang()).thenReturn("default language");
+
+        final GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
+        when(mockDataRepo.getFeedInfoAll()).thenReturn(new HashMap<>(Map.of("feed publisher name", mockFeedInfo)));
+        when(mockDataRepo.getAgencyAll()).thenReturn(
+                new HashMap<>(Map.of("agency id 0", mockAgency0, "agency id 1", mockAgency1)));
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final Logger mockLogger = mock(Logger.class);
+
+        final ValidateAgencyLangAndFeedInfoFeedLangMatch underTest =
+                new ValidateAgencyLangAndFeedInfoFeedLangMatch(mockDataRepo, mockResultRepo, mockLogger);
+
+        underTest.execute();
+
+        verify(mockLogger, times(1)).info("Validating rule 'E055 - Mismatching feed and " +
+                "agency language fields'");
+
+        verify(mockDataRepo, times(2)).getFeedInfoAll();
+        verify(mockDataRepo, times(1)).getAgencyAll();
+
+        verify(mockFeedInfo, times(1)).getFeedLang();
+
+        verify(mockAgency0, times(2)).getAgencyLang();
+        verify(mockAgency0, times(1)).getAgencyName();
+        verify(mockAgency1, times(1)).getAgencyLang();
+
+        final ArgumentCaptor<FeedInfoLangAgencyLangMismatchNotice> captor =
+                ArgumentCaptor.forClass(FeedInfoLangAgencyLangMismatchNotice.class);
+
+        verify(mockResultRepo, times(1)).addNotice(captor.capture());
+
+        final List<FeedInfoLangAgencyLangMismatchNotice> noticeList = captor.getAllValues();
+
+        assertEquals("feed_info.txt", noticeList.get(0).getFilename());
+        assertEquals("agency name", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_NAME));
+        assertEquals("non matching language", noticeList.get(0).getNoticeSpecific(KEY_AGENCY_AGENCY_LANG));
+        assertEquals("default language", noticeList.get(0).getNoticeSpecific(KEY_FEED_INFO_FEED_LANG));
+        assertEquals("agency id 0", noticeList.get(0).getEntityId());
+
+        verifyNoMoreInteractions(mockDataRepo, mockLogger, mockResultRepo, mockFeedInfo, mockAgency0, mockAgency1);
     }
 }

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatchTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAgencyLangAndFeedInfoFeedLangMatchTest.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.usecase;
+
+import org.junit.jupiter.api.Test;
+
+class ValidateAgencyLangAndFeedInfoFeedLangMatchTest {
+
+    @Test
+    void notProvidedFeedInfoShouldNotGenerateNotice() {
+        // todo feed_info.feed_lang = null
+    }
+
+    @Test
+    void matchingFeedInfoFeedLangShouldNotGenerateNotice() {
+        // todo, agency.agency_lang = feed_info.feed_lang
+    }
+
+    @Test
+    void mulMatchesWithAnyAgencyLangAndShouldNotGenerateNotice() {
+        // todo, feed_info.feed_lang = null and agency.agency_lang = whatever
+
+    }
+
+    @Test
+    void nonMatchingFeedInfoFeedLangShouldGenerateNotice() {
+        // todo: feed_info.feed_lang != agency.agency_lang
+    }
+}


### PR DESCRIPTION
**Summary:**

This PR provides support to check that `agency.agency_lang` and `feed_info.feed_lang` match.

**Expected behavior:** 

- [x] Write rule logic
- [x] Unit tests
- [x] Update documentation  

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)