### PR TITLE
Implement #353 - Avoid building Route entities with both name fields blank/null

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -27,7 +27,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E024](#E024) | Same name and description for route | 
 | [E025](#E025) | Insufficient route color contrast |
 | [E026](#E026) | Invalid route type | 
-| [E027](#E027) | Missing route short name and long name | 
+| [E027](#E027) | Missing route short name or long name | 
 | [E028](#E028) | Route long name equals short name | 
 | [E029](#E029) | Missing field `agency_id` for file `agency.txt` with more than 1 record | 
 | [E030](#E030) | Inconsistent field `agency_timezone` | 
@@ -131,7 +131,7 @@ A Route color and a Route text color should be contrasting. Minimum Contrast Rat
 
 <a name="E027"/>
 
-### E027 - Missing route short name and long name
+### E027 - Missing route short name or long name
 
 <a name="E028"/>
 

--- a/RULES.md
+++ b/RULES.md
@@ -27,7 +27,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E024](#E024) | Same name and description for route | 
 | [E025](#E025) | Insufficient route color contrast |
 | [E026](#E026) | Invalid route type | 
-| [E027](#E027) | Missing route short name or long name | 
+| [E027](#E027) | Missing route short name and long name | 
 | [E028](#E028) | Route long name equals short name | 
 | [E029](#E029) | Missing field `agency_id` for file `agency.txt` with more than 1 record | 
 | [E030](#E030) | Inconsistent field `agency_timezone` | 
@@ -131,7 +131,12 @@ A Route color and a Route text color should be contrasting. Minimum Contrast Rat
 
 <a name="E027"/>
 
-### E027 - Missing route short name or long name
+### E027 - Missing route short name and long name
+
+At least one of short name or long name should be provided - both can't be blank or missing.
+
+#### References:
+* [routes.txt specification](https://gtfs.org/reference/static/#routestxt)
 
 <a name="E028"/>
 

--- a/RULES.md
+++ b/RULES.md
@@ -135,7 +135,7 @@ A Route color and a Route text color should be contrasting. Minimum Contrast Rat
 
 ### E027 - Missing route short name and long name
 
-At least one of short name or long name should be provided - both can't be blank or missing.
+At least one of `routes.route_short_name` or `routes.route_long_name` should be provided - both can't be blank or missing.
 
 #### References:
 * [routes.txt specification](https://gtfs.org/reference/static/#routestxt)

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
@@ -23,6 +23,7 @@ import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.GtfsEntity;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.InvalidAgencyIdNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredValueNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingShortAndLongNameForRouteNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.UnexpectedEnumValueNotice;
 
 import java.util.ArrayList;
@@ -277,7 +278,8 @@ public class Route extends GtfsEntity {
          * are met. Otherwise, method returns an entity representing a list of notices.
          */
         public EntityBuildResult<?> build() throws IllegalArgumentException {
-            if (routeId == null || routeType == null || agencyId.isBlank()) {
+            if (routeId == null || routeType == null || agencyId.isBlank() ||
+                    (!isPresentName(routeLongName) && !isPresentName(routeShortName))) {
                 if (routeId == null) {
                     noticeCollection.add(new MissingRequiredValueNotice("routes.txt", "route_id",
                             routeId));
@@ -294,11 +296,24 @@ public class Route extends GtfsEntity {
                     noticeCollection.add(
                             new InvalidAgencyIdNotice("routes.txt", "agency_id", routeId));
                 }
+                // checks if at least one of name fields is provided
+                if (!isPresentName(routeLongName) && !isPresentName(routeShortName)) {
+                    noticeCollection.add(new MissingShortAndLongNameForRouteNotice("routes.txt", routeId));
+                    ;
+                }
                 return new EntityBuildResult(noticeCollection);
             } else {
                 return new EntityBuildResult(new Route(routeId, agencyId, routeShortName, routeLongName, routeDesc,
                         routeType, routeUrl, routeColor, routeTextColor, routeSortOrder));
             }
+        }
+
+        /**
+         * @param routeName a name of a Route
+         * @return true if this Route name is not missing or empty, false if not.
+         */
+        private boolean isPresentName(final String routeName) {
+            return routeName != null && !routeName.isBlank();
         }
 
         /**

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/routes/Route.java
@@ -299,7 +299,6 @@ public class Route extends GtfsEntity {
                 // checks if at least one of name fields is provided
                 if (!isPresentName(routeLongName) && !isPresentName(routeShortName)) {
                     noticeCollection.add(new MissingShortAndLongNameForRouteNotice("routes.txt", routeId));
-                    ;
                 }
                 return new EntityBuildResult(noticeCollection);
             } else {

--- a/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/RouteTest.java
+++ b/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/RouteTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.InvalidAgencyIdNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredValueNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingShortAndLongNameForRouteNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.UnexpectedEnumValueNotice;
 
 import java.util.List;
@@ -137,6 +138,110 @@ class RouteTest {
         final InvalidAgencyIdNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
         assertEquals("agency_id", notice.getNoticeSpecific(KEY_FIELD_NAME));
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+    }
+
+    @Test
+    void createRouteWithBlankRouteShortNameAndRouteLongNameShouldGenerateNotice() {
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
+
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
+                .agencyId(STRING_TEST_VALUE)
+                .routeShortName(" ")
+                .routeLongName("    ")
+                .routeDesc(STRING_TEST_VALUE)
+                .routeType(1)
+                .routeUrl(STRING_TEST_VALUE)
+                .routeColor(STRING_TEST_VALUE)
+                .routeTextColor(STRING_TEST_VALUE)
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
+
+        assertTrue(entityBuildResult.getData() instanceof List);
+        //noinspection unchecked to avoid lint
+        final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
+                (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
+
+        final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
+        assertEquals("routes.txt", notice.getFilename());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+    }
+
+    @Test
+    void createRouteWithNullRouteShortNameAndRouteLongNameShouldGenerateNotice() {
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
+
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
+                .agencyId(STRING_TEST_VALUE)
+                .routeShortName(null)
+                .routeLongName(null)
+                .routeDesc(STRING_TEST_VALUE)
+                .routeType(1)
+                .routeUrl(STRING_TEST_VALUE)
+                .routeColor(STRING_TEST_VALUE)
+                .routeTextColor(STRING_TEST_VALUE)
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
+
+        assertTrue(entityBuildResult.getData() instanceof List);
+        //noinspection unchecked to avoid lint
+        final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
+                (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
+
+        final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
+        assertEquals("routes.txt", notice.getFilename());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+    }
+
+    @Test
+    void createRouteWithNullRouteShortNameAndBlankRouteLongNameShouldGenerateNotice() {
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
+
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
+                .agencyId(STRING_TEST_VALUE)
+                .routeShortName(null)
+                .routeLongName(" ")
+                .routeDesc(STRING_TEST_VALUE)
+                .routeType(1)
+                .routeUrl(STRING_TEST_VALUE)
+                .routeColor(STRING_TEST_VALUE)
+                .routeTextColor(STRING_TEST_VALUE)
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
+
+        assertTrue(entityBuildResult.getData() instanceof List);
+        //noinspection unchecked to avoid lint
+        final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
+                (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
+
+        final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
+        assertEquals("routes.txt", notice.getFilename());
+        assertEquals(STRING_TEST_VALUE, notice.getEntityId());
+    }
+
+    @Test
+    void createRouteWithBlankRouteShortNameAndNullRouteLongNameShouldGenerateNotice() {
+        final Route.RouteBuilder underTest = new Route.RouteBuilder();
+
+        final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
+                .agencyId(STRING_TEST_VALUE)
+                .routeShortName(null)
+                .routeLongName(" ")
+                .routeDesc(STRING_TEST_VALUE)
+                .routeType(1)
+                .routeUrl(STRING_TEST_VALUE)
+                .routeColor(STRING_TEST_VALUE)
+                .routeTextColor(STRING_TEST_VALUE)
+                .routeSortOrder(INT_TEST_VALUE)
+                .build();
+
+        assertTrue(entityBuildResult.getData() instanceof List);
+        //noinspection unchecked to avoid lint
+        final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
+                (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
+
+        final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
+        assertEquals("routes.txt", notice.getFilename());
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
     }
 }

--- a/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/RouteTest.java
+++ b/domain/src/test/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/RouteTest.java
@@ -58,9 +58,12 @@ class RouteTest {
         final List<MissingRequiredValueNotice> noticeCollection =
                 (List<MissingRequiredValueNotice>) entityBuildResult.getData();
 
-        final MissingRequiredValueNotice notice = noticeCollection.get(0);
+        assertEquals(1, noticeCollection.size());
 
+        final MissingRequiredValueNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(15, notice.getCode());
         assertEquals("route_id", notice.getNoticeSpecific(KEY_FIELD_NAME));
         assertEquals("no id", notice.getEntityId());
         assertEquals(1, noticeCollection.size());
@@ -87,8 +90,11 @@ class RouteTest {
         final List<UnexpectedEnumValueNotice> noticeCollection =
                 (List<UnexpectedEnumValueNotice>) entityBuildResult.getData();
 
+        assertEquals(1, noticeCollection.size());
         final UnexpectedEnumValueNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(21, notice.getCode());
         assertEquals("route_type", notice.getNoticeSpecific(KEY_FIELD_NAME));
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
         assertEquals(15, notice.getNoticeSpecific(KEY_ENUM_VALUE));
@@ -135,8 +141,11 @@ class RouteTest {
         final List<InvalidAgencyIdNotice> noticeCollection =
                 (List<InvalidAgencyIdNotice>) entityBuildResult.getData();
 
+        assertEquals(1, noticeCollection.size());
         final InvalidAgencyIdNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(31, notice.getCode());
         assertEquals("agency_id", notice.getNoticeSpecific(KEY_FIELD_NAME));
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
     }
@@ -162,8 +171,11 @@ class RouteTest {
         final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
                 (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
 
+        assertEquals(1, noticeCollection.size());
         final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(27, notice.getCode());
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
     }
 
@@ -188,8 +200,11 @@ class RouteTest {
         final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
                 (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
 
+        assertEquals(1, noticeCollection.size());
         final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(27, notice.getCode());
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
     }
 
@@ -214,8 +229,11 @@ class RouteTest {
         final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
                 (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
 
+        assertEquals(1, noticeCollection.size());
         final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(27, notice.getCode());
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
     }
 
@@ -225,8 +243,8 @@ class RouteTest {
 
         final EntityBuildResult<?> entityBuildResult = underTest.routeId(STRING_TEST_VALUE)
                 .agencyId(STRING_TEST_VALUE)
-                .routeShortName(null)
-                .routeLongName(" ")
+                .routeShortName(" ")
+                .routeLongName(null)
                 .routeDesc(STRING_TEST_VALUE)
                 .routeType(1)
                 .routeUrl(STRING_TEST_VALUE)
@@ -240,8 +258,11 @@ class RouteTest {
         final List<MissingShortAndLongNameForRouteNotice> noticeCollection =
                 (List<MissingShortAndLongNameForRouteNotice>) entityBuildResult.getData();
 
+        assertEquals(1, noticeCollection.size());
         final MissingShortAndLongNameForRouteNotice notice = noticeCollection.get(0);
         assertEquals("routes.txt", notice.getFilename());
+        assertEquals("ERROR", notice.getLevel());
+        assertEquals(27, notice.getCode());
         assertEquals(STRING_TEST_VALUE, notice.getEntityId());
     }
 }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateShortAndLongNameForRoutePresence.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateShortAndLongNameForRoutePresence.java
@@ -17,7 +17,6 @@
 package org.mobilitydata.gtfsvalidator.usecase;
 
 import org.apache.logging.log4j.Logger;
-import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingShortAndLongNameForRouteNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.MissingRouteLongNameNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.MissingRouteShortNameNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
@@ -45,18 +44,16 @@ public class ValidateShortAndLongNameForRoutePresence {
 
     /**
      * Use case execution method: checks if Route short name and long name are missing
-     * for every Routes in a {@link GtfsDataRepository}. If both are missing, a new error notice is generated.
-     * If only one is missing, a warning error notice is generated. This notice is then added
-     * to the {@link ValidationResultRepository} provided in the constructor.
+     * for every Routes in a {@link GtfsDataRepository}. If one of the fields is missing, a warning error notice is
+     * generated. This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
+     * Note that no record from `routes.txt` can have both fields null or blank.
      */
     public void execute() {
         logger.info("Validating rule 'E027 - Missing route short name and long name'");
         dataRepo.getRouteAll().values().stream()
                 .filter(route -> !(isPresentName(route.getRouteLongName()) && isPresentName(route.getRouteShortName())))
                 .forEach(route -> {
-                    if (!isPresentName(route.getRouteLongName()) && !isPresentName(route.getRouteShortName())) {
-                        resultRepo.addNotice(new MissingShortAndLongNameForRouteNotice("routes.txt", route.getRouteId()));
-                    } else if (!isPresentName(route.getRouteLongName())) {
+                    if (!isPresentName(route.getRouteLongName())) {
                         resultRepo.addNotice(new MissingRouteLongNameNotice("routes.txt", route.getRouteId()));
                     } else {
                         resultRepo.addNotice(new MissingRouteShortNameNotice("routes.txt", route.getRouteId()));

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateShortAndLongNameForRoutePresenceTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateShortAndLongNameForRoutePresenceTest.java
@@ -19,7 +19,6 @@ package org.mobilitydata.gtfsvalidator.usecase;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.routes.Route;
-import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingShortAndLongNameForRouteNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.MissingRouteLongNameNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.warning.MissingRouteShortNameNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsDataRepository;
@@ -68,41 +67,6 @@ public class ValidateShortAndLongNameForRoutePresenceTest {
     }
 
     @Test
-    void blankShortNameAndNullLongNameShouldGenerateNotice() {
-
-        Route mockRoute = mock(Route.class);
-        when(mockRoute.getRouteShortName()).thenReturn("");
-        when(mockRoute.getRouteLongName()).thenReturn(null);
-
-        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
-        Map<String, Route> mockRouteCollection = new HashMap<>();
-        mockRouteCollection.put("route id", mockRoute);
-        when(mockDataRepo.getRouteAll()).thenReturn(mockRouteCollection);
-
-        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
-
-        Logger mockLogger = mock(Logger.class);
-
-        ValidateShortAndLongNameForRoutePresence underTest = new ValidateShortAndLongNameForRoutePresence(
-                mockDataRepo,
-                mockResultRepo,
-                mockLogger
-        );
-
-        underTest.execute();
-
-        verify(mockDataRepo, times(1)).getRouteAll();
-        verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(2)).getRouteLongName();
-        verify(mockRoute, times(1)).getRouteId();
-
-        verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +
-                "and long name'");
-        verify(mockResultRepo, times(1)).addNotice(any(MissingShortAndLongNameForRouteNotice.class));
-        verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo, mockLogger);
-    }
-
-    @Test
     void presentShortNameAndNullLongNameShouldGenerateNotice() {
 
         Route mockRoute = mock(Route.class);
@@ -127,8 +91,7 @@ public class ValidateShortAndLongNameForRoutePresenceTest {
         underTest.execute();
 
         verify(mockDataRepo, times(1)).getRouteAll();
-        verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(3)).getRouteLongName();
+        verify(mockRoute, times(2)).getRouteLongName();
         verify(mockRoute, times(1)).getRouteId();
 
         verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +
@@ -162,8 +125,7 @@ public class ValidateShortAndLongNameForRoutePresenceTest {
         underTest.execute();
 
         verify(mockDataRepo, times(1)).getRouteAll();
-        verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(3)).getRouteLongName();
+        verify(mockRoute, times(2)).getRouteLongName();
         verify(mockRoute, times(1)).getRouteId();
         verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +
                 "and long name'");
@@ -197,7 +159,7 @@ public class ValidateShortAndLongNameForRoutePresenceTest {
 
         verify(mockDataRepo, times(1)).getRouteAll();
         verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(3)).getRouteLongName();
+        verify(mockRoute, times(2)).getRouteLongName();
         verify(mockRoute, times(1)).getRouteId();
 
         verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +
@@ -232,7 +194,7 @@ public class ValidateShortAndLongNameForRoutePresenceTest {
 
         verify(mockDataRepo, times(1)).getRouteAll();
         verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(3)).getRouteLongName();
+        verify(mockRoute, times(2)).getRouteLongName();
         verify(mockRoute, times(1)).getRouteId();
 
         verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateShortAndLongNameForRoutePresenceTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateShortAndLongNameForRoutePresenceTest.java
@@ -68,81 +68,11 @@ public class ValidateShortAndLongNameForRoutePresenceTest {
     }
 
     @Test
-    void nullShortNameAndNullLongNameShouldGenerateNotice() {
-
-        Route mockRoute = mock(Route.class);
-        when(mockRoute.getRouteShortName()).thenReturn(null);
-        when(mockRoute.getRouteLongName()).thenReturn(null);
-
-        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
-        Map<String, Route> mockRouteCollection = new HashMap<>();
-        mockRouteCollection.put("route id", mockRoute);
-        when(mockDataRepo.getRouteAll()).thenReturn(mockRouteCollection);
-
-        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
-
-        Logger mockLogger = mock(Logger.class);
-
-        ValidateShortAndLongNameForRoutePresence underTest = new ValidateShortAndLongNameForRoutePresence(
-                mockDataRepo,
-                mockResultRepo,
-                mockLogger
-        );
-
-        underTest.execute();
-
-        verify(mockDataRepo, times(1)).getRouteAll();
-        verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(2)).getRouteLongName();
-        verify(mockRoute, times(1)).getRouteId();
-
-        verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +
-                "and long name'");
-        verify(mockResultRepo, times(1)).addNotice(any(MissingShortAndLongNameForRouteNotice.class));
-        verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo, mockLogger);
-    }
-
-    @Test
     void blankShortNameAndNullLongNameShouldGenerateNotice() {
 
         Route mockRoute = mock(Route.class);
         when(mockRoute.getRouteShortName()).thenReturn("");
         when(mockRoute.getRouteLongName()).thenReturn(null);
-
-        GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
-        Map<String, Route> mockRouteCollection = new HashMap<>();
-        mockRouteCollection.put("route id", mockRoute);
-        when(mockDataRepo.getRouteAll()).thenReturn(mockRouteCollection);
-
-        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
-
-        Logger mockLogger = mock(Logger.class);
-
-        ValidateShortAndLongNameForRoutePresence underTest = new ValidateShortAndLongNameForRoutePresence(
-                mockDataRepo,
-                mockResultRepo,
-                mockLogger
-        );
-
-        underTest.execute();
-
-        verify(mockDataRepo, times(1)).getRouteAll();
-        verify(mockRoute, times(1)).getRouteShortName();
-        verify(mockRoute, times(2)).getRouteLongName();
-        verify(mockRoute, times(1)).getRouteId();
-
-        verify(mockLogger, times(1)).info("Validating rule 'E027 - Missing route short name " +
-                "and long name'");
-        verify(mockResultRepo, times(1)).addNotice(any(MissingShortAndLongNameForRouteNotice.class));
-        verifyNoMoreInteractions(mockRoute, mockDataRepo, mockResultRepo, mockLogger);
-    }
-
-    @Test
-    void nullShortNameAndBlankLongNameShouldGenerateNotice() {
-
-        Route mockRoute = mock(Route.class);
-        when(mockRoute.getRouteShortName()).thenReturn(null);
-        when(mockRoute.getRouteLongName()).thenReturn("");
 
         GtfsDataRepository mockDataRepo = mock(GtfsDataRepository.class);
         Map<String, Route> mockRouteCollection = new HashMap<>();


### PR DESCRIPTION
**Summary:**

This PR provides support to prevent building `Route` entities with both `route_short_name` and `route_long_name` null or blank.

**Expected behavior:** 

A notice should be generated at the building stage of such entities, and these should not be added to the gtfs data repository.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)