### PR TITLE
Implement #341 -- Enforce presence of at least 1 out of 2 files `calendar.txt` and `calendar_dates.txt`

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -52,6 +52,7 @@ Rules are declared in the [`Notice` module](https://github.com/MobilityData/gtfs
 | [E049](#E049) | Backwards time travel between stops in `stop_times.txt` |
 | [E050](#E050) | Trips must be used in `stop_times.txt` |
 | [E051](#E051) | Trips must have more than one stop to be usable |
+| [E056](#E056) | Missing `calendar_dates.txt` and `calendar.txt` files |
 
 ### Table of Warnings
 
@@ -307,6 +308,12 @@ Trips must be referred to at least once in `stop_times.txt`.
 
 A trip must visit more than one stop in `stop_times.txt` to be usable by passengers for boarding and alighting.
 
+<a name="E056"/>
+
+### E056 - Missing both `calendar_dates.txt` and `calendar.txt` files
+
+Both files `calendar.dates.txt` and `calendar_dates.txt` are missing from the GTFS archive. At least one of both files must be provided.
+                        
 # Warnings
 
 <a name="W002"/>

--- a/RULES.md
+++ b/RULES.md
@@ -312,7 +312,7 @@ A trip must visit more than one stop in `stop_times.txt` to be usable by passeng
 
 ### E056 - Missing both `calendar_dates.txt` and `calendar.txt` files
 
-Both files `calendar.dates.txt` and `calendar_dates.txt` are missing from the GTFS archive. At least one of both files must be provided.
+Both files `calendar_dates.txt` and `calendar.txt` are missing from the GTFS archive. At least one of the files must be provided.
                         
 # Warnings
 

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporter.java
@@ -356,4 +356,9 @@ public class JsonNoticeExporter implements NoticeExporter {
     public void export(final UnusableTripNotice toExport) throws IOException {
         jsonGenerator.writeObject(toExport);
     }
+
+    @Override
+    public void export(final MissingCalendarAndCalendarDateFilesNotice toExport) throws IOException {
+        jsonGenerator.writeObject(toExport);
+    }
 }

--- a/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
+++ b/adapter/exporter/src/main/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporter.java
@@ -29,8 +29,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_BAD_NUMBER_OF_ROWS;
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_USABLE_STOPS;
+import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.*;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.*;
 
 public class ProtobufNoticeExporter implements NoticeExporter {
@@ -262,7 +261,7 @@ public class ProtobufNoticeExporter implements NoticeExporter {
     public void export(MissingRequiredFileNotice toExport) throws IOException {
         protoBuilder.clear()
                 .setCsvFileName(toExport.getFilename())
-                .setType(GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_MISSING_TABLE)
+                .setType(TYPE_CSV_MISSING_TABLE)
                 .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
                 .setAltEntityId(toExport.getFilename())
                 .build()
@@ -850,6 +849,17 @@ public class ProtobufNoticeExporter implements NoticeExporter {
                 .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
                 .setEntityId(String.valueOf(toExport.getEntityId()))
                 .setType(TYPE_TRIP_WITH_NO_USABLE_STOPS)
+                .build()
+                .writeTo(streamGenerator.getStream());
+    }
+
+    @Override
+    public void export(final MissingCalendarAndCalendarDateFilesNotice toExport) throws IOException {
+        protoBuilder.clear()
+                .setCsvFileName(toExport.getFilename())
+                .setSeverity(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR)
+                .setType(TYPE_CSV_MISSING_TABLE)
+                .setAltEntityId(String.valueOf(toExport.getNoticeSpecific(KEY_OTHER_MISSING_FILENAME)))
                 .build()
                 .writeTo(streamGenerator.getStream());
     }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/JsonNoticeExporterTest.java
@@ -921,4 +921,17 @@ class JsonNoticeExporterTest {
         verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
         verifyNoMoreInteractions(mockGenerator);
     }
+
+    @Test
+    void exportMissingCalendarAndCalendarDateFilesNoticeShouldWriteObject() throws IOException {
+        JsonGenerator mockGenerator = mock(JsonGenerator.class);
+
+        JsonNoticeExporter underTest = new JsonNoticeExporter(mockGenerator);
+        MissingCalendarAndCalendarDateFilesNotice toExport =
+                new MissingCalendarAndCalendarDateFilesNotice();
+        underTest.export(toExport);
+
+        verify(mockGenerator, times(1)).writeObject(ArgumentMatchers.eq(toExport));
+        verifyNoMoreInteractions(mockGenerator);
+    }
 }

--- a/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
+++ b/adapter/exporter/src/test/java/org/mobilitydata/gtfsvalidator/exporter/ProtobufNoticeExporterTest.java
@@ -28,8 +28,7 @@ import java.net.URL;
 import java.time.LocalDate;
 import java.util.List;
 
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_CSV_BAD_NUMBER_OF_ROWS;
-import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.TYPE_TRIP_WITH_NO_USABLE_STOPS;
+import static org.mobilitydata.gtfsvalidator.adapter.protos.GtfsValidationOutputProto.GtfsProblem.Type.*;
 import static org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice.KEY_UNKNOWN_SERVICE_ID;
 import static org.mockito.Mockito.*;
 
@@ -2129,6 +2128,36 @@ class ProtobufNoticeExporterTest {
                 .setEntityId(ArgumentMatchers.eq("trip_id"));
         verify(mockBuilder, times(1))
                 .setType(ArgumentMatchers.eq(TYPE_TRIP_WITH_NO_USABLE_STOPS));
+        verify(mockBuilder, times(1)).build();
+        verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
+    }
+
+    @Test
+    void exportMissingCalendarAndCalendarDateFilesNoticeShouldMapToCsvProblemAndWriteToStream() throws IOException {
+        GtfsValidationOutputProto.GtfsProblem.Builder mockBuilder =
+                mock(GtfsValidationOutputProto.GtfsProblem.Builder.class, RETURNS_SELF);
+
+        GtfsValidationOutputProto.GtfsProblem mockProblem = mock(GtfsValidationOutputProto.GtfsProblem.class);
+
+        when(mockBuilder.build()).thenReturn(mockProblem);
+
+        OutputStream mockStream = mock(OutputStream.class);
+
+        ProtobufNoticeExporter.ProtobufOutputStreamGenerator mockStreamGenerator =
+                mock(ProtobufNoticeExporter.ProtobufOutputStreamGenerator.class);
+        when(mockStreamGenerator.getStream()).thenReturn(mockStream);
+
+        ProtobufNoticeExporter underTest = new ProtobufNoticeExporter(mockBuilder, mockStreamGenerator);
+        underTest.export(new MissingCalendarAndCalendarDateFilesNotice());
+
+        verify(mockBuilder, times(1)).clear();
+        verify(mockBuilder, times(1)).setCsvFileName(ArgumentMatchers.eq("calendar.txt"));
+        verify(mockBuilder, times(1)).setSeverity(
+                ArgumentMatchers.eq(GtfsValidationOutputProto.GtfsProblem.Severity.ERROR));
+        verify(mockBuilder, times(1))
+                .setType(ArgumentMatchers.eq(TYPE_CSV_MISSING_TABLE));
+        verify(mockBuilder, times(1))
+                .setAltEntityId(ArgumentMatchers.eq("calendar_dates.txt"));
         verify(mockBuilder, times(1)).build();
         verify(mockProblem, times(1)).writeTo(ArgumentMatchers.eq(mockStream));
     }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/NoticeExporter.java
@@ -136,4 +136,6 @@ public interface NoticeExporter {
     void export(final TripNotUsedNotice tripNotUsedNotice) throws IOException;
 
     void export(final UnusableTripNotice unusableTripNotice) throws IOException;
+
+    void export(final MissingCalendarAndCalendarDateFilesNotice missingCalendarAndCalendarDateFilesNotice) throws IOException;
 }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/ErrorNotice.java
@@ -70,6 +70,7 @@ public abstract class ErrorNotice extends Notice {
     protected static final int E_049 = 49;
     protected static final int E_050 = 50;
     protected static final int E_051 = 51;
+    protected static final int E_056 = 56;
 
     public ErrorNotice(final String filename,
                        final int code,

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/base/Notice.java
@@ -74,6 +74,7 @@ public abstract class Notice {
     public static final String KEY_STOP_TIME_STOP_SEQUENCE_LIST = "stopTimeStopSequenceList";
     public static final String KEY_STOP_TIME_STOP_SEQUENCE = "stopTimeStopSequence";
     public static final String KEY_STOP_TIME_TRIP_ID = "stopTimeTripId";
+    public static final String KEY_OTHER_MISSING_FILENAME = "otherMissingFilename";
 
     private final String filename;
     private final int code;

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingCalendarAndCalendarDateFilesNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingCalendarAndCalendarDateFilesNotice.java
@@ -25,8 +25,8 @@ public class MissingCalendarAndCalendarDateFilesNotice extends ErrorNotice {
     public MissingCalendarAndCalendarDateFilesNotice() {
         super("calendar.txt", E_056,
                 "Missing both `calendar_dates.txt` and `calendar.txt` files",
-                "Both files `calendar.dates.txt` and `calendar_dates.txt` are missing from the GTFS " +
-                        "archive. At least one of both files must be provided",
+                "Both files `calendar_dates.txt` and `calendar.txt` are missing from the GTFS " +
+                        "archive. At least one of the files must be provided",
                 null);
         putNoticeSpecific(KEY_OTHER_MISSING_FILENAME, "calendar_dates.txt");
     }

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingCalendarAndCalendarDateFilesNotice.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/notice/error/MissingCalendarAndCalendarDateFilesNotice.java
@@ -1,0 +1,38 @@
+/*
+ *  Copyright (c) 2020. MobilityData IO.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.domain.entity.notice.error;
+
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+
+import java.io.IOException;
+
+public class MissingCalendarAndCalendarDateFilesNotice extends ErrorNotice {
+    public MissingCalendarAndCalendarDateFilesNotice() {
+        super("calendar.txt", E_056,
+                "Missing both `calendar_dates.txt` and `calendar.txt` files",
+                "Both files `calendar.dates.txt` and `calendar_dates.txt` are missing from the GTFS " +
+                        "archive. At least one of both files must be provided",
+                null);
+        putNoticeSpecific(KEY_OTHER_MISSING_FILENAME, "calendar_dates.txt");
+    }
+
+    @Override
+    public void export(final NoticeExporter exporter) throws IOException {
+        exporter.export(this);
+    }
+}

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRequiredFilePresence.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRequiredFilePresence.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.usecase;
 
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingCalendarAndCalendarDateFilesNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsSpecRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.RawFileRepository;
@@ -49,12 +50,20 @@ public class ValidateAllRequiredFilePresence {
      * Use case execution method: checks the presence of all required files in a {@link RawFileRepository} instance
      * A new notice is generated each time a file marked as "required" is missing from a {@link RawFileRepository}
      * instance. This notice is then added to the {@link ValidationResultRepository} provided in the constructor.
+     * This method also checks the presence of files `calendar.txt` and `calendar_dates.txt` which are marked as
+     * `optional` in the schema, but are actually conditionally required.
      */
     public void execute() {
         if (!rawFileRepo.getFilenameAll().containsAll(specRepo.getRequiredFilenameList())) {
             specRepo.getRequiredFilenameList().stream()
                     .filter(requiredFile -> !rawFileRepo.getFilenameAll().contains(requiredFile))
                     .forEach(missingFile -> resultRepo.addNotice(new MissingRequiredFileNotice(missingFile)));
+        }
+        // special case for files `calendar.txt` and `calendar_dates.txt` whose presence is conditionally required by
+        // the absence of one another
+        if (!rawFileRepo.getFilenameAll().contains("calendar.txt") &&
+                !rawFileRepo.getFilenameAll().contains("calendar_dates.txt")) {
+            resultRepo.addNotice(new MissingCalendarAndCalendarDateFilesNotice());
         }
     }
 }

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRequiredFilePresenceTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ValidateAllRequiredFilePresenceTest.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.usecase;
 
 import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingCalendarAndCalendarDateFilesNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.usecase.port.GtfsSpecRepository;
 import org.mobilitydata.gtfsvalidator.usecase.port.RawFileRepository;
@@ -38,7 +39,7 @@ class ValidateAllRequiredFilePresenceTest {
         Set<String> testSet = Set.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req",
                 "req5.req", "req6.req", "req7.req", "req8.req", "req9.req",
                 "opt0.opt", "opt1.opt", "opt2.opt", "opt3.opt", "opt4.opt",
-                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt");
+                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt", "calendar_dates.txt", "calendar.txt");
         when(mockFileRepo.getFilenameAll()).thenReturn(testSet);
 
         GtfsSpecRepository mockSpecRepo = mock(GtfsSpecRepository.class);
@@ -60,6 +61,7 @@ class ValidateAllRequiredFilePresenceTest {
 
         inOrder.verify(mockFileRepo, times(1)).getFilenameAll();
         inOrder.verify(mockSpecRepo, times(1)).getRequiredFilenameList();
+        inOrder.verify(mockFileRepo, times(1)).getFilenameAll();
         verifyNoInteractions(mockResultRepo);
         verifyNoMoreInteractions(mockFileRepo, mockSpecRepo, mockResultRepo);
     }
@@ -71,7 +73,7 @@ class ValidateAllRequiredFilePresenceTest {
         Set<String> testSet = Set.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req",
                 "req5.req", "req6.req", "req7.req", "req8.req", "req9.req",
                 "opt0.opt", "opt1.opt", "opt2.opt", "opt3.opt", "opt4.opt",
-                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt");
+                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt", "calendar_dates.txt", "calendar.txt");
         when(mockFileRepo.getFilenameAll()).thenReturn(testSet);
 
         GtfsSpecRepository mockSpecRepo = mock(GtfsSpecRepository.class);
@@ -94,8 +96,102 @@ class ValidateAllRequiredFilePresenceTest {
 
         inOrder.verify(mockFileRepo, times(1)).getFilenameAll();
         inOrder.verify(mockSpecRepo, times(2)).getRequiredFilenameList();
-        inOrder.verify(mockFileRepo, times(15)).getFilenameAll();
+        inOrder.verify(mockFileRepo, times(16)).getFilenameAll();
         verify(mockResultRepo, times(5)).addNotice(any(MissingRequiredFileNotice.class));
+        verifyNoMoreInteractions(mockFileRepo, mockSpecRepo, mockResultRepo);
+    }
+
+    @Test
+    void missingCalendarFileWhenCalendarDateIsPresentShouldNotGenerateNotice() {
+
+        RawFileRepository mockFileRepo = mock(RawFileRepository.class);
+        Set<String> testSet = Set.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req",
+                "opt0.opt", "opt1.opt", "opt2.opt", "opt3.opt", "opt4.opt",
+                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt", "calendar_dates.txt");
+        when(mockFileRepo.getFilenameAll()).thenReturn(testSet);
+
+        GtfsSpecRepository mockSpecRepo = mock(GtfsSpecRepository.class);
+        List<String> testRequiredList = List.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req");
+        when(mockSpecRepo.getRequiredFilenameList()).thenReturn(testRequiredList);
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateAllRequiredFilePresence underTest = new ValidateAllRequiredFilePresence(
+                mockSpecRepo,
+                mockFileRepo,
+                mockResultRepo
+        );
+
+        underTest.execute();
+
+        InOrder inOrder = Mockito.inOrder(mockFileRepo, mockSpecRepo);
+
+        inOrder.verify(mockFileRepo, times(1)).getFilenameAll();
+        inOrder.verify(mockSpecRepo, times(1)).getRequiredFilenameList();
+        inOrder.verify(mockFileRepo, times(2)).getFilenameAll();
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockFileRepo, mockSpecRepo, mockResultRepo);
+    }
+
+    @Test
+    void missingCalendarDatesFileWhenCalendarIsPresentShouldNotGenerateNotice() {
+
+        RawFileRepository mockFileRepo = mock(RawFileRepository.class);
+        Set<String> testSet = Set.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req",
+                "opt0.opt", "opt1.opt", "opt2.opt", "opt3.opt", "opt4.opt",
+                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt", "calendar.txt");
+        when(mockFileRepo.getFilenameAll()).thenReturn(testSet);
+
+        GtfsSpecRepository mockSpecRepo = mock(GtfsSpecRepository.class);
+        List<String> testRequiredList = List.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req");
+        when(mockSpecRepo.getRequiredFilenameList()).thenReturn(testRequiredList);
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateAllRequiredFilePresence underTest = new ValidateAllRequiredFilePresence(
+                mockSpecRepo,
+                mockFileRepo,
+                mockResultRepo
+        );
+
+        underTest.execute();
+
+        InOrder inOrder = Mockito.inOrder(mockFileRepo, mockSpecRepo);
+
+        inOrder.verify(mockFileRepo, times(1)).getFilenameAll();
+        inOrder.verify(mockSpecRepo, times(1)).getRequiredFilenameList();
+        inOrder.verify(mockFileRepo, times(1)).getFilenameAll();
+        verifyNoInteractions(mockResultRepo);
+        verifyNoMoreInteractions(mockFileRepo, mockSpecRepo, mockResultRepo);
+    }
+
+    @Test
+    void missingCalendarDatesAndCalendarFilesShouldGenerateNotice() {
+
+        RawFileRepository mockFileRepo = mock(RawFileRepository.class);
+        Set<String> testSet = Set.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req",
+                "opt0.opt", "opt1.opt", "opt2.opt", "opt3.opt", "opt4.opt",
+                "opt5.opt", "opt6.opt", "opt7.opt", "opt8.opt", "opt9.opt");
+        when(mockFileRepo.getFilenameAll()).thenReturn(testSet);
+
+        GtfsSpecRepository mockSpecRepo = mock(GtfsSpecRepository.class);
+        List<String> testRequiredList = List.of("req0.req", "req1.req", "req2.req", "req3.req", "req4.req");
+        when(mockSpecRepo.getRequiredFilenameList()).thenReturn(testRequiredList);
+
+        ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+
+        ValidateAllRequiredFilePresence underTest = new ValidateAllRequiredFilePresence(
+                mockSpecRepo,
+                mockFileRepo,
+                mockResultRepo
+        );
+
+        underTest.execute();
+
+        verify(mockFileRepo, times(3)).getFilenameAll();
+        verify(mockSpecRepo, times(1)).getRequiredFilenameList();
+        verify(mockResultRepo, times(1)).addNotice(
+                any(MissingCalendarAndCalendarDateFilesNotice.class));
         verifyNoMoreInteractions(mockFileRepo, mockSpecRepo, mockResultRepo);
     }
 }


### PR DESCRIPTION
**Summary:**

This PR provides support to verify that at least one of the two aforementioned files is present in the GTFS archive to validate.

**Expected behavior:** 

An error notice should be generated when both files are missing.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~