### PR TITLE
Collect and persist validation reports artifacts

### DIFF
--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -2,8 +2,8 @@ name: End to end
 
 on:
   push:
-    branches: [ master ]
-    #branches: [ master, your-prbranch ]
+    #branches: [ master ]
+    branches: [ master, validation-report-artifact ]
 
 jobs:
   run-on-data:

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -3,7 +3,7 @@ name: End to end
 on:
   push:
     branches: [ master ]
-    #branches: [ master, validation-report-artifact ]
+    #branches: [ master, your-prbranch ]
 
 jobs:
   run-on-data:

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -2,8 +2,8 @@ name: End to end
 
 on:
   push:
-    #branches: [ master ]
-    branches: [ master, validation-report-artifact ]
+    branches: [ master ]
+    #branches: [ master, validation-report-artifact ]
 
 jobs:
   run-on-data:

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -28,4 +28,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: validation_report_all
-          path: output/*
+          path: output

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -2,8 +2,8 @@ name: End to end
 
 on:
   push:
-    branches: [ master ]
-    #branches: [ master, your-prbranch ]
+    #branches: [ master ]
+    branches: [ master, validation-report-artifact ]
 
 jobs:
   build:

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master, validation-report-artifact ]
 
 jobs:
-  build:
+  run-on-data:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Validate dataset from issue 398 -- Orange County Transportation Authority
         run: java -jar application/cli-app/build/libs/gtfs-validator-v1.3.0-SNAPSHOT_cli.jar -u https://octa.net/current/google_transit.zip -i input.zip -e input -o output
       - name: Persist reports
-          uses: actions/upload-artifact@v2
-          with:
-            name: validation_report_all
-            path: output/
+        uses: actions/upload-artifact@v2
+        with:
+          name: validation_report_all
+          path: output/

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -24,3 +24,8 @@ jobs:
         run: java -jar application/cli-app/build/libs/gtfs-validator-v1.3.0-SNAPSHOT_cli.jar -u http://www.mst.org/google/google_transit.zip -i input.zip -e input -o output
       - name: Validate dataset from issue 398 -- Orange County Transportation Authority
         run: java -jar application/cli-app/build/libs/gtfs-validator-v1.3.0-SNAPSHOT_cli.jar -u https://octa.net/current/google_transit.zip -i input.zip -e input -o output
+      - name: Persist reports
+          uses: actions/upload-artifact@v2
+          with:
+            name: validation_report_all
+            path: output/

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -28,4 +28,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: validation_report_all
-          path: output/
+          path: output/*

--- a/.github/workflows/endtoend.yml
+++ b/.github/workflows/endtoend.yml
@@ -2,8 +2,8 @@ name: End to end
 
 on:
   push:
-    #branches: [ master ]
-    branches: [ master, validation-report-artifact ]
+    branches: [ master ]
+    #branches: [ master, your-prbranch ]
 
 jobs:
   run-on-data:

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryGtfsDataRepository.java
@@ -1027,7 +1027,7 @@ public class InMemoryGtfsDataRepository implements GtfsDataRepository {
      */
     @Override
     public String getFeedPublisherName() {
-        if (feedInfoPerFeedPublisherName.size() == 0) {
+        if (feedInfoPerFeedPublisherName.isEmpty()) {
             return "";
         } else {
             return feedInfoPerFeedPublisherName.keySet().stream().findFirst().get();

--- a/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
+++ b/application/cli-app/src/main/java/org/mobilitydata/gtfsvalidator/Main.java
@@ -53,7 +53,7 @@ public class Main {
                 config.downloadArchiveFromNetwork().execute();
 
                 config.unzipInputArchive(
-                        config.cleanOrCreatePath().execute(ExecParamRepository.EXTRACT_KEY))
+                        config.createPath().execute(ExecParamRepository.EXTRACT_KEY, true))
                         .execute();
 
                 final ArrayList<String> filenameListToExclude = config.generateExclusionFilenameList().execute();
@@ -220,7 +220,7 @@ public class Main {
                 config.validateRouteShortNameAreUnique().execute();
                 config.validateUniqueRouteLongNameRouteShortNameCombination().execute();
 
-                config.cleanOrCreatePath().execute(ExecParamRepository.OUTPUT_KEY);
+                config.createPath().execute(ExecParamRepository.OUTPUT_KEY, false);
 
                 config.exportResultAsFile().execute();
             }
@@ -228,7 +228,7 @@ public class Main {
             logger.error("An exception occurred: " + e);
         } catch (TooManyValidationErrorException e) {
             logger.error("Error detected -- ABORTING");
-            config.cleanOrCreatePath().execute(ExecParamRepository.OUTPUT_KEY);
+            config.createPath().execute(ExecParamRepository.OUTPUT_KEY, false);
 
             try {
                 config.exportResultAsFile().execute();

--- a/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
+++ b/config/src/main/java/org/mobilitydata/gtfsvalidator/config/DefaultConfig.java
@@ -144,8 +144,8 @@ public class DefaultConfig {
         return new DownloadArchiveFromNetwork(resultRepo, execParamRepo, logger);
     }
 
-    public CleanOrCreatePath cleanOrCreatePath() {
-        return new CleanOrCreatePath(execParamRepo);
+    public CreatePath createPath() {
+        return new CreatePath(execParamRepo);
     }
 
     public UnzipInputArchive unzipInputArchive(final Path zipExtractPath) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/CreatePath.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/CreatePath.java
@@ -63,7 +63,7 @@ public class CreatePath {
 
             return toCleanOrCreate;
         }
-        
+
         // Create the directory
         try {
             Files.createDirectory(toCleanOrCreate);
@@ -78,7 +78,6 @@ public class CreatePath {
         } catch (IOException e) {
             e.printStackTrace();
         }
-
 
         return toCleanOrCreate;
     }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/CreatePath.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/CreatePath.java
@@ -60,22 +60,25 @@ public class CreatePath {
                     e.printStackTrace();
                 }
             }
-        } else {
-            // Create the directory
-            try {
-                Files.createDirectory(toCleanOrCreate);
-            } catch (AccessDeniedException e) {
-                // Wait and try again - Windows can initially block creating a directory immediately after a delete when a file lock exists (#112)
-                try {
-                    Thread.sleep(500);
-                    Files.createDirectory(toCleanOrCreate);
-                } catch (IOException | InterruptedException ex) {
-                    ex.printStackTrace();
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
+
+            return toCleanOrCreate;
         }
+        
+        // Create the directory
+        try {
+            Files.createDirectory(toCleanOrCreate);
+        } catch (AccessDeniedException e) {
+            // Wait and try again - Windows can initially block creating a directory immediately after a delete when a file lock exists (#112)
+            try {
+                Thread.sleep(500);
+                Files.createDirectory(toCleanOrCreate);
+            } catch (IOException | InterruptedException ex) {
+                ex.printStackTrace();
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
 
         return toCleanOrCreate;
     }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -58,7 +58,7 @@ public class ExportResultAsFile {
                 (execParamRepo.getExecParamValue(execParamRepo.OUTPUT_KEY) +
                         File.separator + reportName + "__" +
                         timestamp
-                ).replaceAll("\\s", "_");
+                ).replaceAll("\\s", "_").replaceAll(":", "/");
         final boolean asProto = Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.PROTO_KEY));
 
         if (Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.PROTO_KEY))) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -50,7 +50,7 @@ public class ExportResultAsFile {
 
         String reportName = gtfsDataRepo.getFeedPublisherName();
 
-        if (reportName.isEmpty() || reportName.isBlank() && gtfsDataRepo.getAgencyCount() > 0) {
+        if ((reportName.isEmpty() || reportName.isBlank()) && gtfsDataRepo.getAgencyCount() > 0) {
             reportName = gtfsDataRepo.getAgencyAll().values().iterator().next().getAgencyName();
         }
 

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -48,9 +48,15 @@ public class ExportResultAsFile {
 
     public void execute() throws IOException {
 
+        String reportName = gtfsDataRepo.getFeedPublisherName();
+
+        if (reportName.isEmpty() || reportName.isBlank() && gtfsDataRepo.getAgencyCount() > 0) {
+            reportName = gtfsDataRepo.getAgencyAll().values().iterator().next().getAgencyName();
+        }
+
         final String finalPath =
                 (execParamRepo.getExecParamValue(execParamRepo.OUTPUT_KEY) +
-                        File.separator + gtfsDataRepo.getFeedPublisherName() + "__" +
+                        File.separator + reportName + "__" +
                         timestamp
                 ).replaceAll("\\s", "_");
         final boolean asProto = Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.PROTO_KEY));

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -58,7 +58,7 @@ public class ExportResultAsFile {
                 (execParamRepo.getExecParamValue(execParamRepo.OUTPUT_KEY) +
                         File.separator + reportName + "__" +
                         timestamp
-                ).replaceAll("\\s", "_").replaceAll(":", "/");
+                ).replaceAll("\\s", "_").replaceAll(":", "-");
         final boolean asProto = Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.PROTO_KEY));
 
         if (Boolean.parseBoolean(execParamRepo.getExecParamValue(execParamRepo.PROTO_KEY))) {

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/GenerateFilenameListToProcess.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/GenerateFilenameListToProcess.java
@@ -19,11 +19,14 @@ package org.mobilitydata.gtfsvalidator.usecase;
 import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Use case to generate the list of filename to validate
  */
 public class GenerateFilenameListToProcess {
+    public static final String FEED_INFO_TXT = "feed_info.txt";
+    public static final String AGENCY_TXT = "agency.txt";
     private final Logger logger;
 
     public GenerateFilenameListToProcess(final Logger logger) {
@@ -36,11 +39,20 @@ public class GenerateFilenameListToProcess {
      *
      * @param toExclude the list of filename to exclude from the validation process
      * @param toProcess the list of files (required and optional) contained in the GTFS archive
-     * @return the list of filename to validate
+     * @return the list of filename to validate. `feed_info.txt` is placed in front if present,
+     * otherwise `agency.txt` if present
      */
     public ArrayList<String> execute(final ArrayList<String> toExclude, final ArrayList<String> toProcess) {
         logger.info("List of filenames to exclude is: " + toExclude);
         toProcess.removeAll(toExclude);
+
+        // We need to place those files in front to have the best chance of having a significant validation report name
+        if (toProcess.contains(FEED_INFO_TXT)) {
+            Collections.swap(toProcess, 0, toProcess.indexOf(FEED_INFO_TXT));
+        } else if (toProcess.contains(AGENCY_TXT)) {
+            Collections.swap(toProcess, 0, toProcess.indexOf(AGENCY_TXT));
+        }
+
         logger.info("Will execute validation on the following subset of files: " + toProcess);
         return toProcess;
     }

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFileTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFileTest.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.usecase;
 
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Test;
+import org.mobilitydata.gtfsvalidator.domain.entity.gtfs.Agency;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.NoticeExporter;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.CannotUnzipInputArchiveNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.MissingHeaderNotice;
@@ -31,6 +32,7 @@ import org.mockito.Mockito;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.*;
 
@@ -155,6 +157,75 @@ class ExportResultAsFileTest {
         verify(mockNotice1, times(1)).export(mockExporter);
         verify(mockResultRepo, times(3)).getAll();
         verify(mockExecParamRepo, times(2)).getExecParamValue(mockExecParamRepo.PROTO_KEY);
+
+        verify(mockExporter, times(1)).exportEnd();
+        verifyNoMoreInteractions(mockExporter, mockResultRepo, mockExecParamRepo, mockLogger);
+    }
+
+    @Test
+    void agencyNameIfFeedPublisherNameIsNotAvailable() throws IOException {
+        final NoticeExporter mockExporter =
+                mock(NoticeExporter.class);
+        final ValidationResultRepository mockResultRepo = mock(ValidationResultRepository.class);
+        final ExecParamRepository mockExecParamRepo = mock(ExecParamRepository.class);
+        final GtfsDataRepository mockGtfsDataRepo = mock(GtfsDataRepository.class);
+        final MissingHeaderNotice mockNotice0 = mock(MissingHeaderNotice.class);
+        final CannotUnzipInputArchiveNotice mockNotice1 = mock(CannotUnzipInputArchiveNotice.class);
+        final Timestamp mockTimestamp = mock(Timestamp.class);
+        final Agency mockAgency = mock(Agency.class);
+        when(mockAgency.getAgencyName()).thenReturn("Agency Name");
+
+        when(mockResultRepo.getExporter(ArgumentMatchers.eq(false), ArgumentMatchers.anyString()))
+                .thenReturn(mockExporter);
+        when(mockResultRepo.getAll()).thenReturn(List.of(mockNotice0, mockNotice1));
+
+        when(mockExecParamRepo.getExecParamValue(mockExecParamRepo.OUTPUT_KEY))
+                .thenReturn(mockExecParamRepo.OUTPUT_KEY);
+        when(mockExecParamRepo.getExecParamValue(mockExecParamRepo.PROTO_KEY)).thenReturn("false");
+        when(mockExecParamRepo.hasExecParamValue(mockExecParamRepo.PROTO_KEY)).thenReturn(false);
+        when(mockGtfsDataRepo.getFeedPublisherName()).thenReturn("");
+        when(mockGtfsDataRepo.getAgencyCount()).thenReturn(1);
+        when(mockGtfsDataRepo.getAgencyAll()).thenReturn(Map.of("0", mockAgency));
+
+        Logger mockLogger = mock(Logger.class);
+
+        final ExportResultAsFile underTest =
+                new ExportResultAsFile(mockResultRepo, mockExecParamRepo, mockGtfsDataRepo, mockTimestamp, mockLogger);
+
+        underTest.execute();
+
+        verify(mockExecParamRepo, times(2)).getExecParamValue(mockExecParamRepo.PROTO_KEY);
+
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.eq("Results are exported as JSON by default"));
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.contains(
+                        "Computed relative path for report file: output/Agency_Name__Mock_for_Timestamp"
+                ));
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.eq("Exporting validation repo content:" + mockResultRepo.getAll()));
+
+        verify(mockNotice0, times(1)).export(ArgumentMatchers.eq(mockExporter));
+        verify(mockNotice1, times(1)).export(ArgumentMatchers.eq(mockExporter));
+
+        verify(mockExecParamRepo, times(1))
+                .getExecParamValue(ArgumentMatchers.eq(mockExecParamRepo.OUTPUT_KEY));
+
+        verify(mockExecParamRepo, times(2))
+                .getExecParamValue(ArgumentMatchers.eq(mockExecParamRepo.PROTO_KEY));
+
+
+        final InOrder inOrder = Mockito.inOrder(mockExporter, mockResultRepo, mockGtfsDataRepo);
+        inOrder.verify(mockGtfsDataRepo, times(1)).getFeedPublisherName();
+        inOrder.verify(mockResultRepo, times(1)).getExporter(ArgumentMatchers.eq(false),
+                ArgumentMatchers.anyString());
+        inOrder.verify(mockExporter, times(1)).exportBegin();
+        inOrder.verify(mockResultRepo, times(1)).getAll();
+
+        verify(mockNotice0, times(1)).export(mockExporter);
+        verify(mockNotice1, times(1)).export(mockExporter);
+
+        verify(mockResultRepo, times(3)).getAll();
 
         verify(mockExporter, times(1)).exportEnd();
         verifyNoMoreInteractions(mockExporter, mockResultRepo, mockExecParamRepo, mockLogger);

--- a/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/GenerateFilenameListToProcessTest.java
+++ b/usecase/src/test/java/org/mobilitydata/gtfsvalidator/usecase/GenerateFilenameListToProcessTest.java
@@ -24,6 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mobilitydata.gtfsvalidator.usecase.GenerateFilenameListToProcess.AGENCY_TXT;
+import static org.mobilitydata.gtfsvalidator.usecase.GenerateFilenameListToProcess.FEED_INFO_TXT;
 import static org.mockito.Mockito.*;
 
 class GenerateFilenameListToProcessTest {
@@ -87,6 +89,40 @@ class GenerateFilenameListToProcessTest {
 
         final GenerateFilenameListToProcess underTest = new GenerateFilenameListToProcess(mockLogger);
         assertEquals(List.of("file0", "file1", "file2"), underTest.execute(toExclude, toProcess));
+
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.eq("List of filenames to exclude is: " + toExclude));
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.eq("Will execute validation on the following subset of files: "
+                        + toProcess));
+        verifyNoMoreInteractions(mockLogger);
+    }
+
+    @Test
+    void feedInfoFirstIfPresent() {
+        final ArrayList<String> toProcess = new ArrayList<>(List.of(AGENCY_TXT, FEED_INFO_TXT, "file2"));
+        final ArrayList<String> toExclude = new ArrayList<>();
+        final Logger mockLogger = mock(Logger.class);
+
+        final GenerateFilenameListToProcess underTest = new GenerateFilenameListToProcess(mockLogger);
+        assertEquals(List.of(FEED_INFO_TXT, AGENCY_TXT, "file2"), underTest.execute(toExclude, toProcess));
+
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.eq("List of filenames to exclude is: " + toExclude));
+        verify(mockLogger, times(1))
+                .info(ArgumentMatchers.eq("Will execute validation on the following subset of files: "
+                        + toProcess));
+        verifyNoMoreInteractions(mockLogger);
+    }
+
+    @Test
+    void agencyFirstIfNoFeedInfo() {
+        final ArrayList<String> toProcess = new ArrayList<>(List.of("file0", "file1", AGENCY_TXT));
+        final ArrayList<String> toExclude = new ArrayList<>();
+        final Logger mockLogger = mock(Logger.class);
+
+        final GenerateFilenameListToProcess underTest = new GenerateFilenameListToProcess(mockLogger);
+        assertEquals(List.of(AGENCY_TXT, "file1", "file0"), underTest.execute(toExclude, toProcess));
 
         verify(mockLogger, times(1))
                 .info(ArgumentMatchers.eq("List of filenames to exclude is: " + toExclude));


### PR DESCRIPTION
closes #436 

**Summary:**

This PR aims at making end to end workflow executions persist our validation reports from each dataset tested.
It contains additional code to ensure the validation process attempts to read the data relevant to the report generation as early as possible in the process in the case it aborts

**Expected behavior:** 

We should see the artifacts in the end to end GitHub Action workflow runs.
https://github.com/MobilityData/gtfs-validator/actions?query=workflow%3A%22End+to+end%22

![image](https://user-images.githubusercontent.com/55884852/96641271-7a68b480-12f2-11eb-8344-50a9cb0405b1.png)

![image](https://user-images.githubusercontent.com/55884852/96641345-94a29280-12f2-11eb-884d-480c840283e6.png)



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)