### PR TITLE
Implement #408 - Build and collect js test coverage reports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
           path: js-tests-v1.3.0-SNAPSHOT.tar
           destination: js-tests-v1.3.0-SNAPSHOT.tar
       - store_artifacts:
-          path: js-tests-v1.3.0-SNAPSHOT.tar
+          path: js-tests-coverage-v1.3.0-SNAPSHOT.tar
           destination: js-tests-coverage-v1.3.0-SNAPSHOT.tar
   doc:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,12 +41,19 @@ jobs:
           name: Compress JS test report
           command: |
             tar -C application/web-app/react-client/test-reports/ -cvf js-tests-v1.3.0-SNAPSHOT.tar .
+      - run:
+          name: Compress JS test coverage report
+          command: |
+            tar -C application/web-app/react-client/build/coverage -cvf js-tests-coverage-v1.3.0-SNAPSHOT.tar .
       - store_artifacts:
           path: java-tests-v1.3.0-SNAPSHOT.tar
           destination: java-tests-v1.3.0-SNAPSHOT.tar
       - store_artifacts:
           path: js-tests-v1.3.0-SNAPSHOT.tar
           destination: js-tests-v1.3.0-SNAPSHOT.tar
+      - store_artifacts:
+          path: js-tests-v1.3.0-SNAPSHOT.tar
+          destination: js-tests-coverage-v1.3.0-SNAPSHOT.tar
   doc:
     docker:
       - image: circleci/openjdk:11

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -71,12 +71,19 @@ jobs:
           versionTag: ${{ steps.prep.outputs.versionTag }}
         with:
           arguments: uiTest
+      - name: Build JS test coverage report
+        run: cd application/web-app/react-client jest--collect-coverage
       - name: Persist JS tests report
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
           name: Test report - JavaScript -- ${{ steps.prep.outputs.versionTag }}
           path: application/web-app/react-client/test-reports/
+      - name: Persist JS tests coverage report
+        uses: actions/upload-artifact@v2
+        with:
+          name: Test coverage report - JavaScript -- ${{ steps.prep.outputs.versionTag }}
+          path: application/web-app/react-client/coverage/
 
   pack:
     needs: [test]

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -71,8 +71,6 @@ jobs:
           versionTag: ${{ steps.prep.outputs.versionTag }}
         with:
           arguments: uiTest
-      - name: Build JS test coverage report
-        run: cd application/web-app/react-client && jest--collect-coverage
       - name: Persist JS tests report
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
@@ -83,7 +81,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Test coverage report - JavaScript -- ${{ steps.prep.outputs.versionTag }}
-          path: application/web-app/react-client/coverage/
+          path: application/web-app/react-client/build/coverage
 
   pack:
     needs: [test]

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           arguments: uiTest
       - name: Build JS test coverage report
-        run: cd application/web-app/react-client jest--collect-coverage
+        run: cd application/web-app/react-client && jest--collect-coverage
       - name: Persist JS tests report
         if: ${{ always() }}
         uses: actions/upload-artifact@v2

--- a/application/web-app/react-client/jest.config.js
+++ b/application/web-app/react-client/jest.config.js
@@ -28,13 +28,13 @@ module.exports = {
   clearMocks: true,
 
   // Indicates whether the coverage information should be collected while executing the test
-  // collectCoverage: false,
+  collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
   // collectCoverageFrom: undefined,
 
   // The directory where Jest should output its coverage files
-  coverageDirectory: "coverage",
+  coverageDirectory: "build/coverage",
 
   // An array of regexp pattern strings used to skip coverage collection
   // coveragePathIgnorePatterns: [


### PR DESCRIPTION
closes #408 

**Summary:**

This PR provides support to build and collect js test coverage report using `jest`
- [x] modify github workflow to persist test coverage report
- [x] modify circle ci workflow to persist test coverage report

**Expected behavior:** 

Test coverage report should be built and the resultant artifact should be collected on GitHub and CircleCI

<img width="1273" alt="Capture d’écran, le 2020-10-26 à 12 00 43" src="https://user-images.githubusercontent.com/35747326/97196559-fe072300-1782-11eb-89fb-37906716a253.png">
<img width="1274" alt="Capture d’écran, le 2020-10-26 à 12 00 57" src="https://user-images.githubusercontent.com/35747326/97196560-fe072300-1782-11eb-970d-8f74ef7e3d96.png">

<img width="985" alt="Capture d’écran, le 2020-10-26 à 12 16 19" src="https://user-images.githubusercontent.com/35747326/97198872-b7ff8e80-1785-11eb-9fcb-5ed8a4f648fd.png">
<img width="998" alt="Capture d’écran, le 2020-10-26 à 12 16 58" src="https://user-images.githubusercontent.com/35747326/97198877-b930bb80-1785-11eb-8566-518ee5226a57.png">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)

