### PR TITLE
Implement #400 - Allow `transfer` to be blank in fare_attributes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Docker image
 
 on:
   push:
-    branches: [ master ]
-    #branches: [ master, pr-branch ]
+#    branches: [ master ]
+    branches: [ master, allow-transfers-to-be-blank-in-fare_attributes ]
   release:
     types: [ prereleased, released ]
 
@@ -124,7 +124,7 @@ jobs:
           file: ./Dockerfile
           push: true
           tags: ${{ steps.prep.outputs.tags }}
-          labels: | 
+          labels: |
             org.opencontainers.image.source=https://github.com/mobilitydata/gtfs-validator.git
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Docker image
 
 on:
   push:
-#    branches: [ master ]
-    branches: [ master, allow-transfers-to-be-blank-in-fare_attributes ]
+    branches: [ master ]
+    #branches: [ master, pr-branch ]
   release:
     types: [ prereleased, released ]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Docker image
 
 on:
   push:
-    branches: [ master ]
-    #branches: [ master, pr-branch ]
+#    branches: [ master ]
+    branches: [ master, allow-transfers-to-be-blank-in-fare_attrbutes ]
   release:
     types: [ prereleased, released ]
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,8 @@ name: Docker image
 
 on:
   push:
-#    branches: [ master ]
-    branches: [ master, allow-transfers-to-be-blank-in-fare_attrbutes ]
+    branches: [ master ]
+    #branches: [ master, pr-branch ]
   release:
     types: [ prereleased, released ]
 

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,8 +2,8 @@ name: End to end
 
 on:
   push:
-    #branches: [ master ] #<-- comment this line
-    branches: [ master, allow-transfers-to-be-blank-in-fare_attrbutes ] #<-- uncomment this line, replace your-prbranch by the name of the agency/publisher
+    branches: [ master ] #<-- comment this line
+    #branches: [ master, your-prbranch ] #<-- uncomment this line, replace your-prbranch by the name of the agency/publisher
 
 jobs:
   run-on-data:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,8 +2,8 @@ name: End to end
 
 on:
   push:
-    branches: [ master ] #<-- comment this line
-    #branches: [ master, your-prbranch ] #<-- uncomment this line, replace your-prbranch by the name of the agency/publisher
+    #branches: [ master ] #<-- comment this line
+    branches: [ master, allow-transfers-to-be-blank-in-fare_attrbutes ] #<-- uncomment this line, replace your-prbranch by the name of the agency/publisher
 
 jobs:
   run-on-data:
@@ -52,6 +52,8 @@ jobs:
         run: java -jar application/cli-app/build/libs/*.jar -u http://www.mst.org/google/google_transit.zip -i mst.zip -e input -o output
       - name: Validate dataset from issue 398 -- Orange County Transportation Authority
         run: java -jar application/cli-app/build/libs/*.jar -u https://octa.net/current/google_transit.zip -i octa.zip -e input -o output
+      - name: Validate dataset from issue 400 -- Siskiyou Transit and General Express
+        run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/siskiyou-transit-and-general-express/492/latest -i stge.zip -e input -o output
       - name: Persist datasets
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Validate dataset from issue 398 -- Orange County Transportation Authority
         run: java -jar application/cli-app/build/libs/*.jar -u https://octa.net/current/google_transit.zip -i octa.zip -e input -o output
       - name: Validate dataset from issue 400 -- Siskiyou Transit and General Express
-        run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/siskiyou-transit-and-general-express/492/latest -i stge.zip -e input -o output
+        run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/siskiyou-transit-and-general-express/492/latest/download -i stge.zip -e input -o output
       - name: Persist datasets
         uses: actions/upload-artifact@v2
         with:

--- a/adapter/repository/in-memory-simple/src/main/resources/gtfs_spec.asciipb
+++ b/adapter/repository/in-memory-simple/src/main/resources/gtfs_spec.asciipb
@@ -1174,6 +1174,7 @@ csvspec: {
     value_required: false
     type: { type: INTEGER }
     intmin: 0
+    intmax: 2
     # The maximum number of transfers (excluding block transfers)
     # that are possible with this fare; unlimited if empty.
     # The public GTFS spec limits this value to at most 2, but there is no

--- a/adapter/repository/in-memory-simple/src/main/resources/gtfs_spec.asciipb
+++ b/adapter/repository/in-memory-simple/src/main/resources/gtfs_spec.asciipb
@@ -1171,7 +1171,7 @@ csvspec: {
     field_number: 7
     name: "transfers"
     required: true
-    value_required: true
+    value_required: false
     type: { type: INTEGER }
     intmin: 0
     # The maximum number of transfers (excluding block transfers)

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
@@ -214,6 +214,7 @@ public class FareAttribute extends GtfsEntity {
          * @return {@link EntityBuildResult} representing a row from fare_attributes.txt if the requirements from the
          * official GTFS specification are met. Otherwise, method returns a collection pf notices specifying the issues.
          */
+        // TODO: implement fix for #400
         public EntityBuildResult<?> build() {
             if (price == null || price < 0 || fareId == null || currencyType == null ||
                     !PaymentMethod.isEnumValueValid(originalPaymentMethodInteger) ||

--- a/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
+++ b/domain/src/main/java/org/mobilitydata/gtfsvalidator/domain/entity/gtfs/fareattributes/FareAttribute.java
@@ -214,7 +214,6 @@ public class FareAttribute extends GtfsEntity {
          * @return {@link EntityBuildResult} representing a row from fare_attributes.txt if the requirements from the
          * official GTFS specification are met. Otherwise, method returns a collection pf notices specifying the issues.
          */
-        // TODO: implement fix for #400
         public EntityBuildResult<?> build() {
             if (price == null || price < 0 || fareId == null || currencyType == null ||
                     !PaymentMethod.isEnumValueValid(originalPaymentMethodInteger) ||


### PR DESCRIPTION
closes #400 

**Summary:**

This PR provides support to prevent the validator from generating a `MissingRequiredValueNotice` when `fare_attributes.transfer` is empty.

This PR:
- modifies `gtfs_spec.asciipb` to match the GTFS specification in the following ways:
  -  [x] allow `fare_attributes.transfers` to be empty
  - [x] specify intmax for `fare_attributes.transfers` to prevent generation of `OutOfRangeIntegerNotice` 

**Expected behavior:** 

No notice should be generated if `fare_attributes.transfers` is empty

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~