### PR TITLE
Add TheBus Honolulu dataset to End to End workflow

### DIFF
--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           arguments: shadowJar
       - name: Validate dataset from -- THB #<-- uncomment this line, replace ACRONYM by the name of the agency/publisher acronym
-        run: java -jar application/cli-app/build/libs/*.jar -u https://openmobilitydata.org/p/thebus-honolulu -i THB.zip -e input -o output #<-- uncomment this line, 
+        run: java -jar application/cli-app/build/libs/*.jar -u http://webapps.thebus.org/transitdata/Production/google_transit.zip -i THB.zip -e input -o output #<-- uncomment this line, 
 #replace ACRONYM and [[[ACRONYM]]] by the agency/publisher acronym. Also replace DATASET_PUBLIC_URL by a public link to a GTFS Schedule zip archive
       - name: Validate dataset from -- MBTA
         run: java -jar application/cli-app/build/libs/*.jar -u https://cdn.mbta.com/MBTA_GTFS.zip -i mbta.zip -e input -o output

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -40,9 +40,8 @@ jobs:
           versionTag: ${{ steps.prep.outputs.versionTag }}
         with:
           arguments: shadowJar
-      - name: Validate dataset from -- THB #<-- uncomment this line, replace ACRONYM by the name of the agency/publisher acronym
-        run: java -jar application/cli-app/build/libs/*.jar -u http://webapps.thebus.org/transitdata/Production/google_transit.zip -i THB.zip -e input -o output #<-- uncomment this line, 
-#replace ACRONYM and [[[ACRONYM]]] by the agency/publisher acronym. Also replace DATASET_PUBLIC_URL by a public link to a GTFS Schedule zip archive
+      - name: Validate dataset from -- THB
+        run: java -jar application/cli-app/build/libs/*.jar -u http://webapps.thebus.org/transitdata/Production/google_transit.zip -i THB.zip -e input -o output
       - name: Validate dataset from -- MBTA
         run: java -jar application/cli-app/build/libs/*.jar -u https://cdn.mbta.com/MBTA_GTFS.zip -i mbta.zip -e input -o output
       - name: Validate dataset from issue 399 -- Monterey-Salinas Transit

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,7 +2,7 @@ name: End to end
 
 on:
   push:
-    branches: [ master,  the-honolulu-bus] #<-- replace transport-agency-name by the name of the agency/publisher
+    branches: [ master,  the-honolulu-bus]
 
 jobs:
   run-on-data:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,7 +2,7 @@ name: End to end
 
 on:
   push:
-    branches: [ master,  transport-agency-name] #<-- replace transport-agency-name by the name of the agency/publisher
+    branches: [ master,  the-honolulu-bus] #<-- replace transport-agency-name by the name of the agency/publisher
 
 jobs:
   run-on-data:
@@ -40,8 +40,8 @@ jobs:
           versionTag: ${{ steps.prep.outputs.versionTag }}
         with:
           arguments: shadowJar
-      #- name: Validate dataset from -- ACRONYM #<-- uncomment this line, replace ACRONYM by the name of the agency/publisher acronym
-      #  run: java -jar application/cli-app/build/libs/*.jar -u DATASET_PUBLIC_URL -i [[[ACRONYM]]].zip -e input -o output #<-- uncomment this line, 
+      - name: Validate dataset from -- THB #<-- uncomment this line, replace ACRONYM by the name of the agency/publisher acronym
+        run: java -jar application/cli-app/build/libs/*.jar -u https://openmobilitydata.org/p/thebus-honolulu -i THB.zip -e input -o output #<-- uncomment this line, 
 #replace ACRONYM and [[[ACRONYM]]] by the agency/publisher acronym. Also replace DATASET_PUBLIC_URL by a public link to a GTFS Schedule zip archive
       - name: Validate dataset from -- MBTA
         run: java -jar application/cli-app/build/libs/*.jar -u https://cdn.mbta.com/MBTA_GTFS.zip -i mbta.zip -e input -o output


### PR DESCRIPTION
Please create the PR and a member of the Mobility Data team will take it from here - thanks!

- [x] This PR only touches `end_to_end.ym` in `.github/workflows
- [x] `-abort_on_error to `false`
- [ ] Null Pointer Exception --> add bug and NPE tag
- [ ] Attach the dataset and report from the workflow run to this PR

***
***

**Summary:**

This PR provides support to add dataset from [`The Honolulu Bus`](https://openmobilitydata.org/p/thebus-honolulu) to the end to end workflow
**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
