### PR TITLE
Rework report name to include both feed_publisher_name and agency_name when available

### DIFF
--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -26,7 +26,7 @@ import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
-// TODO: implement #475
+
 public class ExportResultAsFile {
     private final ValidationResultRepository resultRepo;
     private final ExecParamRepository execParamRepo;

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -26,7 +26,7 @@ import org.mobilitydata.gtfsvalidator.usecase.port.ValidationResultRepository;
 import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
-
+// TODO: implement #475
 public class ExportResultAsFile {
     private final ValidationResultRepository resultRepo;
     private final ExecParamRepository execParamRepo;

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ExportResultAsFile.java
@@ -49,8 +49,12 @@ public class ExportResultAsFile {
     public void execute() throws IOException {
         String reportName = gtfsDataRepo.getFeedPublisherName();
 
-        if ((reportName.isEmpty() || reportName.isBlank()) && gtfsDataRepo.getAgencyCount() > 0) {
-            reportName = gtfsDataRepo.getAgencyAll().values().iterator().next().getAgencyName();
+        if (gtfsDataRepo.getAgencyCount() > 0) {
+            if ((reportName.isEmpty() || reportName.isBlank())) {
+                reportName = gtfsDataRepo.getAgencyAll().values().iterator().next().getAgencyName();
+            } else {
+                reportName = reportName + "__" + gtfsDataRepo.getAgencyAll().values().iterator().next().getAgencyName();
+            }
         }
 
         final String finalPath =


### PR DESCRIPTION
closes #475 

**Summary:**
This PR provides support to include both `feed_info.feed_publisher_name` and `agency.agency_name` in the validation report name.

**Expected behavior:** 

reports should be named as follows:

`agency.agency_name--feed_info.feed_publisher__timestamp.json`

sample usages:

- [x] `feed_info.txt` and `agency.txt` are provided:
`feed_info.feed_publisher_name__agency.agency_name + timestamp.json`

- [x] `feed_info.txt` is not provided and `agency.txt` has at least 1 row:
 `agency.agency_name__timestamp.json`

- [x] `feed_info.txt` is not provided and `agency.txt` counts 0 rows:
`__timestamp.json`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
