### PR TITLE
 Implement solution to prevent worker from stopping on OutOfMemoryError

### DIFF
--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,7 +2,7 @@ name: End to end
 
 on:
   push:
-    branches: [ master, transport-agency-name] #<-- replace transport-agency-name by the name of the agency/publisher
+    branches: [ master, prevent-worker-from-stoppping-on-error] #<-- replace transport-agency-name by the name of the agency/publisher
 # todo: implement #474
 jobs:
   run-on-data:
@@ -42,38 +42,28 @@ jobs:
           arguments: shadowJar
 
       #- name: Validate dataset from -- ACRONYM #<-- uncomment this line, replace ACRONYM by the name of the agency/publisher acronym
-        #if: ${{ always() }} # we still want job to be executed in case of previous failure
       #  run: java -jar application/cli-app/build/libs/*.jar -u DATASET_PUBLIC_URL -i [[[ACRONYM]]].zip -e input -o output #<-- uncomment this line,
 #replace ACRONYM and [[[ACRONYM]]] by the agency/publisher acronym. Also replace DATASET_PUBLIC_URL by a public link to a GTFS Schedule zip archive
       - name: Validate dataset from -- SMART
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/sonoma-marin-area-rail-transit/1050/20200930/download -i smart.zip -e input -o output -a false
       - name: Validate dataset from -- STM
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u https://openmobilitydata.org/p/societe-de-transport-de-montreal/39/latest/download -i stm.zip -e input -o output
       - name: Validate dataset from -- MBTA
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u https://cdn.mbta.com/MBTA_GTFS.zip -i mbta.zip -e input -o output
       - name: Validate dataset from issue 379 -- Bay Area Rapid Transit
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://www.bart.gov/dev/schedules/google_transit.zip -i bart.zip -e input -o output
       - name: Validate dataset from issue 399 -- Monterey-Salinas Transit
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://www.mst.org/google/google_transit.zip -i mst.zip -e input -o output
       - name: Validate dataset from issue 398 -- Orange County Transportation Authority
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u https://octa.net/current/google_transit.zip -i octa.zip -e input -o output
       - name: Validate dataset from issue 400 -- Siskiyou Transit and General Express
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/siskiyou-transit-and-general-express/492/latest/download -i stge.zip -e input -o output
       - name: Persist datasets
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         uses: actions/upload-artifact@v2
         with:
           name: dataset_all
           path: ./*.zip
       - name: Persist reports
-        if: ${{ always() }} # we still want job to be executed in case of previous failure
         uses: actions/upload-artifact@v2
         with:
           name: validation_report_all

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,7 +2,7 @@ name: End to end
 
 on:
   push:
-    branches: [ master,  transport-agency-name] #<-- replace transport-agency-name by the name of the agency/publisher
+    branches: [ master,  prevent-worker-from-stopping-on-error] #<-- replace transport-agency-name by the name of the agency/publisher
 # todo: implement #474
 jobs:
   run-on-data:
@@ -45,26 +45,35 @@ jobs:
       #  run: java -jar application/cli-app/build/libs/*.jar -u DATASET_PUBLIC_URL -i [[[ACRONYM]]].zip -e input -o output #<-- uncomment this line,
 #replace ACRONYM and [[[ACRONYM]]] by the agency/publisher acronym. Also replace DATASET_PUBLIC_URL by a public link to a GTFS Schedule zip archive
       - name: Validate dataset from -- SMART
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/sonoma-marin-area-rail-transit/1050/20200930/download -i smart.zip -e input -o output -a false
       # STM out until #474 is closed
-      #- name: Validate dataset from -- STM
-      #  run: java -jar application/cli-app/build/libs/*.jar -u https://openmobilitydata.org/p/societe-de-transport-de-montreal/39/latest/download -i stm.zip -e input -o output
+      - name: Validate dataset from -- STM
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
+        run: java -jar application/cli-app/build/libs/*.jar -u https://openmobilitydata.org/p/societe-de-transport-de-montreal/39/latest/download -i stm.zip -e input -o output
       - name: Validate dataset from -- MBTA
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u https://cdn.mbta.com/MBTA_GTFS.zip -i mbta.zip -e input -o output
       - name: Validate dataset from issue 379 -- Bay Area Rapid Transit
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://www.bart.gov/dev/schedules/google_transit.zip -i bart.zip -e input -o output
       - name: Validate dataset from issue 399 -- Monterey-Salinas Transit
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://www.mst.org/google/google_transit.zip -i mst.zip -e input -o output
       - name: Validate dataset from issue 398 -- Orange County Transportation Authority
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u https://octa.net/current/google_transit.zip -i octa.zip -e input -o output
       - name: Validate dataset from issue 400 -- Siskiyou Transit and General Express
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/siskiyou-transit-and-general-express/492/latest/download -i stge.zip -e input -o output
       - name: Persist datasets
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         uses: actions/upload-artifact@v2
         with:
           name: dataset_all
           path: ./*.zip
       - name: Persist reports
+        if: ${{ always() }} # we still want job to be executed in case of previous failure
         uses: actions/upload-artifact@v2
         with:
           name: validation_report_all

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,7 +2,7 @@ name: End to end
 
 on:
   push:
-    branches: [ master,  prevent-worker-from-stopping-on-error] #<-- replace transport-agency-name by the name of the agency/publisher
+    branches: [ master, transport-agency-name] #<-- replace transport-agency-name by the name of the agency/publisher
 # todo: implement #474
 jobs:
   run-on-data:
@@ -47,7 +47,6 @@ jobs:
       - name: Validate dataset from -- SMART
         if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u http://transitfeeds.com/p/sonoma-marin-area-rail-transit/1050/20200930/download -i smart.zip -e input -o output -a false
-      # STM out until #474 is closed
       - name: Validate dataset from -- STM
         if: ${{ always() }} # we still want job to be executed in case of previous failure
         run: java -jar application/cli-app/build/libs/*.jar -u https://openmobilitydata.org/p/societe-de-transport-de-montreal/39/latest/download -i stm.zip -e input -o output

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -42,6 +42,7 @@ jobs:
           arguments: shadowJar
 
       #- name: Validate dataset from -- ACRONYM #<-- uncomment this line, replace ACRONYM by the name of the agency/publisher acronym
+        #if: ${{ always() }} # we still want job to be executed in case of previous failure
       #  run: java -jar application/cli-app/build/libs/*.jar -u DATASET_PUBLIC_URL -i [[[ACRONYM]]].zip -e input -o output #<-- uncomment this line,
 #replace ACRONYM and [[[ACRONYM]]] by the agency/publisher acronym. Also replace DATASET_PUBLIC_URL by a public link to a GTFS Schedule zip archive
       - name: Validate dataset from -- SMART

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -2,7 +2,7 @@ name: End to end
 
 on:
   push:
-    branches: [ master, prevent-worker-from-stoppping-on-error] #<-- replace transport-agency-name by the name of the agency/publisher
+    branches: [ master, prevent-worker-from-stopping-on-error] #<-- replace transport-agency-name by the name of the agency/publisher
 # todo: implement #474
 jobs:
   run-on-data:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -3,7 +3,7 @@ name: End to end
 on:
   push:
     branches: [ master,  transport-agency-name] #<-- replace transport-agency-name by the name of the agency/publisher
-
+# todo: implement #474
 jobs:
   run-on-data:
     runs-on: ubuntu-latest

--- a/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryValidationResultRepository.java
+++ b/adapter/repository/in-memory-simple/src/main/java/org/mobilitydata/gtfsvalidator/db/InMemoryValidationResultRepository.java
@@ -114,4 +114,11 @@ public class InMemoryValidationResultRepository implements ValidationResultRepos
     public int getErrorNoticeCount() {
         return errorNoticeList.size();
     }
+
+    @Override
+    public void flushRepo() {
+        errorNoticeList.clear();
+        warningNoticeList.clear();
+        infoNoticeList.clear();
+    }
 }

--- a/adapter/repository/in-memory-simple/src/test/java/org/mobilitydata/gtfsvalidator/db/InMemoryValidationResultRepositoryTest.java
+++ b/adapter/repository/in-memory-simple/src/test/java/org/mobilitydata/gtfsvalidator/db/InMemoryValidationResultRepositoryTest.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.db;
 
 import org.junit.jupiter.api.Test;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.ErrorNotice;
+import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.InfoNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.Notice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.base.WarningNotice;
 import org.mobilitydata.gtfsvalidator.domain.entity.notice.error.CannotUnzipInputArchiveNotice;
@@ -29,6 +30,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
 
 class InMemoryValidationResultRepositoryTest {
 
@@ -74,5 +76,22 @@ class InMemoryValidationResultRepositoryTest {
 
         assertThrows(TooManyValidationErrorException.class, () ->
                 underTest.addNotice(errorNotice));
+    }
+
+    @Test
+    void flushRepoShouldEmptyAllNoticeCollection() {
+        WarningNotice mockWarningNotice = mock(WarningNotice.class);
+        InfoNotice mockInfoNotice = mock(InfoNotice.class);
+
+        ValidationResultRepository underTest = new InMemoryValidationResultRepository(true);
+
+        underTest.addNotice(mockWarningNotice);
+        underTest.addNotice(mockInfoNotice);
+
+        assertEquals(2, underTest.getAll().size());
+
+        underTest.flushRepo();
+
+        assertEquals(0, underTest.getAll().size());
     }
 }

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedStopTime.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/ProcessParsedStopTime.java
@@ -58,6 +58,7 @@ public class ProcessParsedStopTime {
      * @param validatedParsedStopTime entity to be processed and added to the GTFS data repository
      */
     public void execute(final ParsedEntity validatedParsedStopTime) {
+        System.gc();
         final String tripId = (String) validatedParsedStopTime.get("trip_id");
         final Integer arrivalTime = timeUtils.convertHHMMSSToIntFromNoonOfDayOfService(
                 (String) validatedParsedStopTime.get("arrival_time"));

--- a/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ValidationResultRepository.java
+++ b/usecase/src/main/java/org/mobilitydata/gtfsvalidator/usecase/port/ValidationResultRepository.java
@@ -37,4 +37,6 @@ public interface ValidationResultRepository {
     int getWarningNoticeCount();
 
     int getErrorNoticeCount();
+
+    void flushRepo();
 }


### PR DESCRIPTION
closes #474

**Summary:**

This PR provides support to prevent worker from stop in end_to_end workflow when encountering OutOfMemoryException

**Expected behavior:**

Worker should skip task and continue to next job

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with gradle test to make sure you didn't break anything
- ~[ ] Format the title like "Fix #<issue_number> - " (for example - "Fix #1111 - Check for null value before using field")~
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)