### PR TITLE
feat: Validate long and short names for a single route

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteBothShortAndLongNameMissingNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteBothShortAndLongNameMissingNotice.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Both short_name and long_name are missing for a route.
+ */
+public class RouteBothShortAndLongNameMissingNotice extends Notice {
+    public RouteBothShortAndLongNameMissingNotice(String routeId,
+                                                  long csvRowNumber) {
+        super(ImmutableMap.of(
+                "routeId", routeId,
+                "csvRowNumber", csvRowNumber));
+    }
+
+    @Override
+    public String getCode() {
+        return "route_both_short_and_long_name_missing";
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteShortAndLongNameEqualNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteShortAndLongNameEqualNotice.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Short and long name are equal for a route.
+ */
+public class RouteShortAndLongNameEqualNotice extends Notice {
+    public RouteShortAndLongNameEqualNotice(String routeId,
+                                            long csvRowNumber, String routeShortName, String routeLongName) {
+        super(ImmutableMap.of(
+                "routeId", routeId,
+                "csvRowNumber", csvRowNumber,
+                "routeShortName", routeShortName,
+                "routeLongName", routeLongName));
+    }
+
+    @Override
+    public String getCode() {
+        return "route_short_and_long_name_equal";
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteShortNameTooLongNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteShortNameTooLongNotice.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Short name of a route is too long (more than 6 characters).
+ */
+public class RouteShortNameTooLongNotice extends Notice {
+    public RouteShortNameTooLongNotice(String routeId,
+                                       long csvRowNumber, String routeShortName) {
+        super(ImmutableMap.of(
+                "routeId", routeId,
+                "csvRowNumber", csvRowNumber,
+                "routeShortName", routeShortName));
+    }
+
+    @Override
+    public String getCode() {
+        return "route_short_name_too_long";
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteShortNameTooLongNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteShortNameTooLongNotice.java
@@ -19,7 +19,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Short name of a route is too long (more than 6 characters).
+ * Short name of a route is too long (more than 12 characters, https://gtfs.org/best-practices/#routestxt).
  */
 public class RouteShortNameTooLongNotice extends Notice {
     public RouteShortNameTooLongNotice(String routeId,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -33,7 +33,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
  */
 @GtfsValidator
 public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
-    private static final int MAX_SHORT_NAME_LENGTH = 6;
+    private static final int MAX_SHORT_NAME_LENGTH = 12;
 
     @Override
     public void validate(GtfsRoute entity, NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+
+/**
+ * Validates short and long name for a single route.
+ * <p>
+ * Generated notices:
+ * * RouteBothShortAndLongNameMissingNotice
+ * * RouteShortAndLongNameEqualNotice
+ * * RouteShortNameTooLongNotice
+ */
+@GtfsValidator
+public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
+    private static final int MAX_SHORT_NAME_LENGTH = 6;
+
+    @Override
+    public void validate(GtfsRoute entity, NoticeContainer noticeContainer) {
+        final boolean hasLongName = entity.hasRouteLongName();
+        final boolean hasShortName = entity.hasRouteShortName();
+
+        if (!hasLongName && !hasShortName) {
+          noticeContainer.addNotice(new RouteBothShortAndLongNameMissingNotice(
+              entity.routeId(), entity.csvRowNumber()));
+        }
+
+        if (hasShortName && hasLongName &&
+            entity.routeShortName().equalsIgnoreCase(entity.routeLongName())) {
+          noticeContainer.addNotice(new RouteShortAndLongNameEqualNotice(
+              entity.routeId(), entity.csvRowNumber(), entity.routeShortName(),
+              entity.routeLongName()));
+        }
+
+        if (hasShortName && entity.routeShortName().length() > MAX_SHORT_NAME_LENGTH) {
+          noticeContainer.addNotice(new RouteShortNameTooLongNotice(
+              entity.routeId(), entity.csvRowNumber(),
+              entity.routeShortName()));
+        }
+    }
+}
+
+

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.*;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class RouteNameValidatorTest {
+    private List<Notice> validateRoute(GtfsRoute route) {
+        NoticeContainer container = new NoticeContainer();
+        RouteNameValidator validator = new RouteNameValidator();
+        validator.validate(route, container);
+        return container.getNotices();
+    }
+
+    private GtfsRoute createRoute(String shortName, String longName) {
+        return new GtfsRoute.Builder()
+                .setRouteId("r1")
+                .setCsvRowNumber(1)
+                .setRouteShortName(shortName)
+                .setRouteLongName(longName)
+                .build();
+    }
+
+    @Test
+    public void routeBothShortAndLongNameMissing() {
+        assertThat(validateRoute(createRoute(null, null)))
+                .containsExactly(new RouteBothShortAndLongNameMissingNotice("r1", 1));
+        assertThat(validateRoute(createRoute("S", null))).isEmpty();
+        assertThat(validateRoute(createRoute(null, "Long"))).isEmpty();
+        assertThat(validateRoute(createRoute("S", "Long"))).isEmpty();
+    }
+
+    @Test
+    public void routeShortAndLongNameEqual() {
+        assertThat(validateRoute(createRoute("S", "S")))
+                .containsExactly(
+                        new RouteShortAndLongNameEqualNotice("r1", 1, "S", "S"));
+        // Compare case-insensitive.
+        assertThat(validateRoute(createRoute("SA", "Sa")))
+                .containsExactly(
+                        new RouteShortAndLongNameEqualNotice("r1", 1, "SA", "Sa"));
+
+        assertThat(validateRoute(createRoute("S", "Long"))).isEmpty();
+    }
+
+    @Test
+    public void routeShortNameTooLong() {
+        assertThat(validateRoute(createRoute("THISISMYSHORTNAME", null)))
+                .containsExactly(
+                        new RouteShortNameTooLongNotice("r1", 1, "THISISMYSHORTNAME"));
+    }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
@@ -19,7 +19,11 @@ package org.mobilitydata.gtfsvalidator.validator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mobilitydata.gtfsvalidator.notice.*;
+import org.mobilitydata.gtfsvalidator.notice.Notice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
 import java.util.List;
@@ -71,5 +75,7 @@ public class RouteNameValidatorTest {
         assertThat(validateRoute(createRoute("THISISMYSHORTNAME", null)))
                 .containsExactly(
                         new RouteShortNameTooLongNotice("r1", 1, "THISISMYSHORTNAME"));
+
+        assertThat(validateRoute(createRoute("SH", null))).isEmpty();
     }
 }


### PR DESCRIPTION
* RouteBothShortAndLongNameMissingNotice - Both short_name and long_name are missing for a route.
* RouteShortAndLongNameEqualNotice - Short and long name are equal for a route.
* RouteShortNameTooLongNotice - Short name of a route is too long (more than 6 characters).
