### PR TITLE
fix: Add hashCode() method to classes that implement equals()

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsFeedName.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsFeedName.java
@@ -121,4 +121,9 @@ public class GtfsFeedName {
         }
         return false;
     }
+
+    @Override
+    public int hashCode() {
+        return countryFirstName.hashCode();
+    }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -57,4 +57,14 @@ public abstract class Notice {
     public String toString() {
         return getCode() + " " + Joiner.on(",").withKeyValueSeparator("=").join(context);
     }
+
+    @Override
+    public int hashCode() {
+        int h = 1;
+        h *= 1000003;
+        h ^= getCode().hashCode();
+        h *= 1000003;
+        h ^= getContext().hashCode();
+        return h;
+    }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -20,6 +20,7 @@ import com.google.common.base.Joiner;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Base class for all notices produced by GTFS validator.
@@ -60,11 +61,6 @@ public abstract class Notice {
 
     @Override
     public int hashCode() {
-        int h = 1;
-        h *= 1000003;
-        h ^= getCode().hashCode();
-        h *= 1000003;
-        h ^= getContext().hashCode();
-        return h;
+        return Objects.hash(getCode(), getContext());
     }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsColor.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsColor.java
@@ -57,6 +57,11 @@ public class GtfsColor {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(rgb);
+    }
+
     public String toHtmlColor() {
         return String.format("#%06X", rgb);
     }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsDate.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsDate.java
@@ -91,6 +91,11 @@ public class GtfsDate implements Comparable<GtfsDate> {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return localDate.hashCode();
+    }
+
     public boolean isAfter(GtfsDate other) {
         return localDate.isAfter(other.localDate);
     }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsTime.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsTime.java
@@ -103,6 +103,11 @@ public class GtfsTime implements Comparable<GtfsTime> {
         return false;
     }
 
+    @Override
+    public int hashCode() {
+        return Integer.hashCode(secondsSinceMidnight);
+    }
+
     public boolean isAfter(GtfsTime other) {
         return secondsSinceMidnight > other.secondsSinceMidnight;
     }


### PR DESCRIPTION
The contract for Object.hashCode states that if two objects are equal, then calling the hashCode() method on each of the two objects must produce the same result. Implementing equals() but not hashCode() causes broken behaviour when trying to store the object in a collection.

Affected classes:
* GtfsFeedName
* Notice
* GtfsColor
* GtfsDate
* GtfsTime
