### PR TITLE
chore: Make gradle test task verbose

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,3 +21,13 @@ dependencies {
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'org.mockito:mockito-core:1.10.19'
 }
+
+test {
+    // Always run tests, even when nothing changed.
+    dependsOn 'cleanTest'
+
+    // Show test results.
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -51,3 +51,14 @@ dependencies {
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
 }
+
+test {
+    // Always run tests, even when nothing changed.
+    dependsOn 'cleanTest'
+
+    // Show test results.
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}
+

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -22,3 +22,13 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
 }
+
+test {
+    // Always run tests, even when nothing changed.
+    dependsOn 'cleanTest'
+
+    // Show test results.
+    testLogging {
+        events "passed", "skipped", "failed"
+    }
+}


### PR DESCRIPTION
closes #509 

**Summary:**

This PR provides support to make gradle test task verbose

**Expected behavior:** 

At execution, Gradle test task should display information regarding tests.

<img width="701" alt="Capture d’écran, le 2020-12-03 à 13 20 14" src="https://user-images.githubusercontent.com/35747326/101064352-4841a800-356a-11eb-9f59-b5e2622ea703.png">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- ~[ ] Format the title like "Fix #<issue_number> - <short description of fix and changes>" (for example - "Fix #1111 - Check for null value before using field")~
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
