### PR TITLE
chore: Increase memory size up to 8 GiB

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'java'
 }
 
+applicationDefaultJvmArgs = [ "-Xmx8G" ]
+
 group 'org.mobilitydata'
 version "${System.getenv("versionTag")}"
 


### PR DESCRIPTION
8 GiB is enough for validation of the largest feeds that contain 25 M stop times.
