### PR TITLE
feat: Cache certain field values to optimize memory usage

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/CachedField.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/CachedField.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.annotation;
+
+/**
+ * Enables caching of values for a given field to optimize memory usage.
+ * <p>
+ * See {@code FieldCache} for details.
+ * <p>
+ * Note that caching is already automatically enabled for certain field types (ID, date, time, color).
+ * <p>
+ * Example.
+ *
+ * <pre>
+ *   @GtfsTable("stop_times.txt")
+ *   @Required
+ *   public interface GtfsStopTimeSchema extends GtfsEntity {
+ *       @CachedField
+ *       String stopHeadsign();
+ *   }
+ * </pre>
+ */
+public @interface CachedField {
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/CachedField.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/CachedField.java
@@ -21,7 +21,7 @@ package org.mobilitydata.gtfsvalidator.annotation;
  * <p>
  * See {@code FieldCache} for details.
  * <p>
- * Note that caching is already automatically enabled for certain field types (ID, date, time, color).
+ * Note that caching is already automatically enabled for certain field types (ID, date, time, color, language code).
  * <p>
  * Example.
  *

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/FieldCache.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/FieldCache.java
@@ -36,10 +36,13 @@ import java.util.Map;
 public class FieldCache<T> {
     private final Map<T, T> cache = new HashMap<>();
 
-    private int invocationCount = 0;
+    private int lookupCount = 0;
 
     /**
      * Adds the object to the cache if it is absent. Returns a reference to the given object in cache.
+     * <p>
+     * If this function is called for {@code null}, it returns {@code null} but does not add it to the cache.
+     *
      * <p>
      * Note that it is not the same as {@code Map.putIfAbsent()} which returns {@code null} if the the object was not
      * already in the map.
@@ -49,7 +52,7 @@ public class FieldCache<T> {
      */
     public @Nullable
     T addIfAbsent(@Nullable T obj) {
-        ++invocationCount;
+        ++lookupCount;
         if (obj == null) {
             // Do not store null in the cache.
             return null;
@@ -64,12 +67,14 @@ public class FieldCache<T> {
     }
 
     /**
-     * Returns amount of invocations of {@code addIfAbsent}.
+     * Returns amount of lookups using {@code addIfAbsent}.
+     * <p>
+     * This is equal to {@code getCacheHits() + getCacheMisses()}.
      *
-     * @return amount of invocations of {@code addIfAbsent}.
+     * @return amount of cache lookups of {@code addIfAbsent}.
      */
-    public int getInvocationCount() {
-        return invocationCount;
+    public int getLookupCount() {
+        return lookupCount;
     }
 
     /**
@@ -79,5 +84,47 @@ public class FieldCache<T> {
      */
     public int getCacheSize() {
         return cache.size();
+    }
+
+    /**
+     * Returns the amount of cache misses.
+     * <p>
+     * This is the same as the cache size because objects are not removed from cache.
+     *
+     * @return amount of cache misses.
+     */
+    public int getCacheMisses() {
+        return cache.size();
+    }
+
+    /**
+     * Returns the amount of cache hits.
+     *
+     * @return
+     */
+    public int getCacheHits() {
+        return getLookupCount() - getCacheMisses();
+    }
+
+    /**
+     * Returns cache hit ratio from 0.0 to 1.0.
+     * <p>
+     * If there were no lookups, returns 1.0.
+     *
+     * @return hit ratio.
+     */
+    public double getHitRatio() {
+        return lookupCount == 0 ? 1.0 : getCacheHits() * 1.0 / lookupCount;
+    }
+
+    /**
+     * Returns cache miss ratio from 0.0 to 1.0.
+     * <p>
+     * If there were no lookups, returns 0.0.
+     *
+     * @return miss ratio.
+     */
+    public double getMissRatio() {
+        return lookupCount == 0 ? 0.0 : getCacheMisses() * 1.0 / lookupCount;
     }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/FieldCache.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/FieldCache.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.parsing;
+
+import javax.annotation.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Caches field values for a single table.
+ * <p>
+ * There are many fields that repeat for multiple rows of a single table, e.g., stop_headsign for stop_times.txt or
+ * shape_id for shapes.txt. Caching of those values dramatically saves memory for large feeds, e.g., a feed with
+ * 25 M stop times requires 8 GiB without caching and 3 GiB with caching.
+ * <p>
+ * All tables are read in parallel, that's why we create a separate set of caches for each table. It is tempting to use
+ * the same cache for, e.g., trip_id in both trips.txt and stop_times.txt but that would require synchronization that
+ * slows down the reading.
+ *
+ * @param <T> the type of the cached objects. It must be suitable as a key for hash maps.
+ */
+public class FieldCache<T> {
+    private final Map<T, T> cache = new HashMap<>();
+
+    private int invocationCount = 0;
+
+    /**
+     * Adds the object to the cache if it is absent. Returns a reference to the given object in cache.
+     * <p>
+     * Note that it is not the same as {@code Map.putIfAbsent()} which returns {@code null} if the the object was not
+     * already in the map.
+     *
+     * @param obj object to store in cache.
+     * @return reference to the object in cache.
+     */
+    public @Nullable
+    T addIfAbsent(@Nullable T obj) {
+        ++invocationCount;
+        if (obj == null) {
+            // Do not store null in the cache.
+            return null;
+        }
+        // Benchmarks show that computeIfAbsent() is about 20% more expensive than calling get() and put().
+        T inCache = cache.get(obj);
+        if (inCache == null) {
+            inCache = obj;
+            cache.put(inCache, inCache);
+        }
+        return inCache;
+    }
+
+    /**
+     * Returns amount of invocations of {@code addIfAbsent}.
+     *
+     * @return amount of invocations of {@code addIfAbsent}.
+     */
+    public int getInvocationCount() {
+        return invocationCount;
+    }
+
+    /**
+     * Returns cache size.
+     *
+     * @return cache size.
+     */
+    public int getCacheSize() {
+        return cache.size();
+    }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvFileTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvFileTest.java
@@ -122,7 +122,7 @@ public class CsvFileTest {
 
     @Test
     public void emptyValues() throws IOException {
-        Reader reader = new StringReader("col0,col1,col2\n"+
+        Reader reader = new StringReader("col0,col1,col2\n" +
                 "a,,\"\",b\n");
         CsvFile csvFile = new CsvFile(reader, "stops.txt");
 

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/FieldCacheTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/FieldCacheTest.java
@@ -19,12 +19,67 @@ package org.mobilitydata.gtfsvalidator.parsing;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.type.GtfsColor;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+import java.util.Locale;
 
 import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
 public class FieldCacheTest {
+    @Test
+    public void hitsAndMisses() {
+        FieldCache<String> cache = new FieldCache<>();
+
+        // Test an empty cache.
+        assertThat(cache.getLookupCount()).isEqualTo(0);
+        assertThat(cache.getCacheSize()).isEqualTo(0);
+        assertThat(cache.getCacheHits()).isEqualTo(0);
+        assertThat(cache.getCacheMisses()).isEqualTo(0);
+        assertThat(cache.getHitRatio()).isEqualTo(1);
+        assertThat(cache.getMissRatio()).isEqualTo(0);
+
+        // Add two different values.
+        String s1 = "s1";
+        String s2 = "s2";
+        assertThat(cache.addIfAbsent(s1)).isSameInstanceAs(s1);
+        assertThat(cache.addIfAbsent(s2)).isSameInstanceAs(s2);
+
+        assertThat(cache.getLookupCount()).isEqualTo(2);
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.getCacheHits()).isEqualTo(0);
+        assertThat(cache.getCacheMisses()).isEqualTo(2);
+        assertThat(cache.getHitRatio()).isEqualTo(0);
+        assertThat(cache.getMissRatio()).isEqualTo(1);
+
+        // Put the same values again as different objects.
+        assertThat(cache.addIfAbsent("s1")).isSameInstanceAs(s1);
+        assertThat(cache.addIfAbsent("s2")).isSameInstanceAs(s2);
+
+        assertThat(cache.getLookupCount()).isEqualTo(4);
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.getCacheHits()).isEqualTo(2);
+        assertThat(cache.getCacheMisses()).isEqualTo(2);
+        assertThat(cache.getHitRatio()).isEqualTo(0.5);
+        assertThat(cache.getMissRatio()).isEqualTo(0.5);
+    }
+
+    @Test
+    public void lookupNull() {
+        FieldCache<String> cache = new FieldCache<>();
+
+        assertThat(cache.addIfAbsent(null)).isNull();
+
+        assertThat(cache.getLookupCount()).isEqualTo(1);
+        assertThat(cache.getCacheSize()).isEqualTo(0);
+        assertThat(cache.getCacheHits()).isEqualTo(1);
+        assertThat(cache.getCacheMisses()).isEqualTo(0);
+        assertThat(cache.getHitRatio()).isEqualTo(1);
+        assertThat(cache.getMissRatio()).isEqualTo(0);
+    }
+
     @Test
     public void cacheString() {
         FieldCache<String> cache = new FieldCache<>();
@@ -37,7 +92,7 @@ public class FieldCacheTest {
         assertThat(cache.addIfAbsent("s2")).isSameInstanceAs(s2);
         // Check cache size and efficiency.
         assertThat(cache.getCacheSize()).isEqualTo(2);
-        assertThat(cache.getInvocationCount()).isEqualTo(4);
+        assertThat(cache.getLookupCount()).isEqualTo(4);
     }
 
     @Test
@@ -52,6 +107,55 @@ public class FieldCacheTest {
         assertThat(cache.addIfAbsent(GtfsTime.fromSecondsSinceMidnight(2))).isSameInstanceAs(t2);
         // Check cache size and efficiency.
         assertThat(cache.getCacheSize()).isEqualTo(2);
-        assertThat(cache.getInvocationCount()).isEqualTo(4);
+        assertThat(cache.getLookupCount()).isEqualTo(4);
+    }
+
+    @Test
+    public void cacheDate() {
+        FieldCache<GtfsDate> cache = new FieldCache<>();
+        GtfsDate d1 = GtfsDate.fromEpochDay(100);
+        GtfsDate d2 = GtfsDate.fromEpochDay(200);
+        assertThat(cache.addIfAbsent(d1)).isSameInstanceAs(d1);
+        assertThat(cache.addIfAbsent(d2)).isSameInstanceAs(d2);
+        // Put the same values again as different objects.
+        assertThat(cache.addIfAbsent(GtfsDate.fromEpochDay(100))).isSameInstanceAs(d1);
+        assertThat(cache.addIfAbsent(GtfsDate.fromEpochDay(200))).isSameInstanceAs(d2);
+        // Check cache size and efficiency.
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.getLookupCount()).isEqualTo(4);
+    }
+
+    @Test
+    public void cacheColor() {
+        FieldCache<GtfsColor> cache = new FieldCache<>();
+        GtfsColor c1 = GtfsColor.fromInt(0);
+        GtfsColor c2 = GtfsColor.fromInt(0xff00ff);
+        assertThat(cache.addIfAbsent(c1)).isSameInstanceAs(c1);
+        assertThat(cache.addIfAbsent(c2)).isSameInstanceAs(c2);
+        // Put the same values again as different objects.
+        assertThat(cache.addIfAbsent(GtfsColor.fromInt(0))).isSameInstanceAs(c1);
+        assertThat(cache.addIfAbsent(GtfsColor.fromInt(0xff00ff))).isSameInstanceAs(c2);
+        // Check cache size and efficiency.
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.getLookupCount()).isEqualTo(4);
+    }
+
+    @Test
+    public void cacheLanguage() {
+        FieldCache<Locale> cache = new FieldCache<>();
+        Locale l1 = Locale.forLanguageTag("en");
+        Locale l2 = Locale.forLanguageTag("fr");
+        Locale l3 = Locale.forLanguageTag("fr-CA");
+        assertThat(cache.addIfAbsent(l1)).isSameInstanceAs(l1);
+        assertThat(cache.addIfAbsent(l2)).isSameInstanceAs(l2);
+        assertThat(cache.addIfAbsent(l3)).isSameInstanceAs(l3);
+        // Put the same values again as different objects.
+        assertThat(cache.addIfAbsent(Locale.forLanguageTag("en"))).isSameInstanceAs(l1);
+        assertThat(cache.addIfAbsent(Locale.forLanguageTag("fr"))).isSameInstanceAs(l2);
+
+        assertThat(Locale.forLanguageTag("en")).isSameInstanceAs(l1);
+        // Check cache size and efficiency.
+        assertThat(cache.getCacheSize()).isEqualTo(3);
+        assertThat(cache.getLookupCount()).isEqualTo(5);
     }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/FieldCacheTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/FieldCacheTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.parsing;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class FieldCacheTest {
+    @Test
+    public void cacheString() {
+        FieldCache<String> cache = new FieldCache<>();
+        String s1 = "s1";
+        String s2 = "s2";
+        assertThat(cache.addIfAbsent(s1)).isSameInstanceAs(s1);
+        assertThat(cache.addIfAbsent(s2)).isSameInstanceAs(s2);
+        // Put the same values again as different objects.
+        assertThat(cache.addIfAbsent("s1")).isSameInstanceAs(s1);
+        assertThat(cache.addIfAbsent("s2")).isSameInstanceAs(s2);
+        // Check cache size and efficiency.
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.getInvocationCount()).isEqualTo(4);
+    }
+
+    @Test
+    public void cacheTime() {
+        FieldCache<GtfsTime> cache = new FieldCache<>();
+        GtfsTime t1 = GtfsTime.fromSecondsSinceMidnight(1);
+        GtfsTime t2 = GtfsTime.fromSecondsSinceMidnight(2);
+        assertThat(cache.addIfAbsent(t1)).isSameInstanceAs(t1);
+        assertThat(cache.addIfAbsent(t2)).isSameInstanceAs(t2);
+        // Put the same values again as different objects.
+        assertThat(cache.addIfAbsent(GtfsTime.fromSecondsSinceMidnight(1))).isSameInstanceAs(t1);
+        assertThat(cache.addIfAbsent(GtfsTime.fromSecondsSinceMidnight(2))).isSameInstanceAs(t2);
+        // Check cache size and efficiency.
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.getInvocationCount()).isEqualTo(4);
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -61,6 +61,7 @@ public class Main {
         System.out.println("Validators:");
         System.out.println(validatorLoader.listValidators());
 
+        final long startNanos = System.nanoTime();
         // Input.
         feedLoader.setNumThreads(args.getNumThreads());
         NoticeContainer noticeContainer = new NoticeContainer();
@@ -94,6 +95,9 @@ public class Main {
         } catch (IOException exception) {
             exception.printStackTrace();
         }
+
+        final long endNanos = System.nanoTime();
+        System.out.println(String.format("Validation took %.3f seconds", (endNanos - startNanos) / 1e9));
         System.out.println(feedContainer.tableTotals());
     }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.table;
 
+import org.mobilitydata.gtfsvalidator.annotation.CachedField;
 import org.mobilitydata.gtfsvalidator.annotation.ConditionallyRequired;
 import org.mobilitydata.gtfsvalidator.annotation.DefaultValue;
 import org.mobilitydata.gtfsvalidator.annotation.FieldType;
@@ -53,6 +54,7 @@ public interface GtfsStopTimeSchema extends GtfsEntity {
     @SequenceKey
     int stopSequence();
 
+    @CachedField
     String stopHeadsign();
 
     GtfsPickupDropOff pickupType();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTranslationSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTranslationSchema.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.table;
 
+import org.mobilitydata.gtfsvalidator.annotation.CachedField;
 import org.mobilitydata.gtfsvalidator.annotation.ConditionallyRequired;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
@@ -25,9 +26,11 @@ import java.util.Locale;
 @GtfsTable("translations.txt")
 public interface GtfsTranslationSchema extends GtfsEntity {
     @Required
+    @CachedField
     String tableName();
 
     @Required
+    @CachedField
     String fieldName();
 
     @Required
@@ -37,11 +40,14 @@ public interface GtfsTranslationSchema extends GtfsEntity {
     String translation();
 
     @ConditionallyRequired
+    @CachedField
     String recordId();
 
     @ConditionallyRequired
+    @CachedField
     String recordSubId();
 
     @ConditionallyRequired
+    @CachedField
     String fieldValue();
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/Analyser.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/Analyser.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.processor;
 
+import org.mobilitydata.gtfsvalidator.annotation.CachedField;
 import org.mobilitydata.gtfsvalidator.annotation.DefaultValue;
 import org.mobilitydata.gtfsvalidator.annotation.FieldType;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
@@ -80,6 +81,7 @@ public class Analyser {
             fieldBuilder.setFirstKey(method.getAnnotation(FirstKey.class) != null);
             fieldBuilder.setSequenceKey(method.getAnnotation(SequenceKey.class) != null);
             fieldBuilder.setIndex(method.getAnnotation(Index.class) != null);
+            fieldBuilder.setCached(method.getAnnotation(CachedField.class) != null);
 
             if (method.getAnnotation(Positive.class) != null) {
                 fieldBuilder.setNumberBounds(NumberBounds.POSITIVE);

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/FieldNameConverter.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/FieldNameConverter.java
@@ -59,4 +59,12 @@ public final class FieldNameConverter {
     public static String fieldNameField(String field) {
         return CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, field) + "_FIELD_NAME";
     }
+
+    public static String fieldColumnIndex(String field) {
+        return field + "ColumnIndex";
+    }
+
+    public static String fieldDefaultName(String field) {
+        return "DEFAULT_" + CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, field);
+    }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsFieldDescriptor.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsFieldDescriptor.java
@@ -48,6 +48,8 @@ public abstract class GtfsFieldDescriptor {
 
     public abstract boolean index();
 
+    public abstract boolean cached();
+
     public abstract Optional<ForeignKeyDescriptor> foreignKey();
 
     public abstract Optional<RowParser.NumberBounds> numberBounds();
@@ -71,6 +73,8 @@ public abstract class GtfsFieldDescriptor {
         public abstract Builder setSequenceKey(boolean value);
 
         public abstract Builder setIndex(boolean value);
+
+        public abstract Builder setCached(boolean value);
 
         public abstract Builder setForeignKey(Optional<ForeignKeyDescriptor> value);
 


### PR DESCRIPTION
There are many fields that repeat for multiple rows of a single table, e.g., stop_headsign for stop_times.txt or shape_id for shapes.txt. Caching of those values dramatically saves memory for large feeds, e.g., a feed with 25 M stop times requires 8 GiB without caching and 3 GiB with caching.

All tables are read in parallel, that's why we create a separate set of caches for each table. It is tempting to use the same cache for, e.g., trip_id in both trips.txt and stop_times.txt but that would require synchronization that slows down the reading.

The following fields are cached:
* annotated with @CachedField;
* types ID, date, time, color.

Primary keys are not cached since they are unique for each row.