### PR TITLE
fix: Specify field type for stop_times.trip_id as ID

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
@@ -31,6 +31,7 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 @GtfsTable("stop_times.txt")
 @Required
 public interface GtfsStopTimeSchema extends GtfsEntity {
+    @FieldType(FieldTypeEnum.ID)
     @Required
     @ForeignKey(table = "trips.txt", field = "trip_id")
     @FirstKey


### PR DESCRIPTION
This PR provides support to specify field type for stop_times.trip_id as ID