### PR TITLE
ci: Don't run GitHub Action build on documentation changes

### DIFF
--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -3,8 +3,12 @@ name: Test Package Document
 on:
   push:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - '**.md'
   release:
     types: [ prereleased, released ]
 


### PR DESCRIPTION
**Summary:**

It's frustrating to sit around and wait for CI builds to finish when only documentation (markdown files) has changed.

**Expected behavior:** 

This PR adds configuration to GitHub Actions to ignore any changes to documentation:
* If the change is to a .md file and it was started via a push or pull request, then don't run the GitHub Action CI build
* Release builds will still be executed even if the only changes are to .md files
