### PR TITLE
ci: remove OV's dataset from end to end workflow

### DIFF
--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Validate dataset from -- Greater Sydney
         run: java -jar main/build/libs/*.jar --url https://openmobilitydata.org/p/transport-for-nsw/237/latest/download --output_base output --feed_name au-gs --storage_directory gs.zip
-      - name: Validate dataset from -- OV
-        run: java -jar main/build/libs/*.jar --url http://gtfs.ovapi.nl/gtfs-nl.zip --output_base output --feed_name nl-ov --storage_directory ov.zip
       - name: Validate dataset from -- SMART
         run: java -jar main/build/libs/*.jar --url http://transitfeeds.com/p/sonoma-marin-area-rail-transit/1050/20200930/download --output_base output --feed_name us-smart --storage_directory smart.zip
       - name: Validate dataset from -- STM


### PR DESCRIPTION
**Summary:**

This PR removes OV's dataset from the execution of the end-to-end workflow
**Expected behavior:** 

No code change: workflow should not be executed on Netherlands dataset.

Please make sure these boxes are checked before submitting your pull request - thanks!

- ~[ ] Run the unit tests with `gradle test` to make sure you didn't break anything~
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- ~[ ] Linked all relevant issues~
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
