### PR TITLE
docs: Remove "[REQUEST]" prefix from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: "[REQUEST]"
+title: ""
 labels: ''
 assignees: 'Cristhian-HA'
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-title: ""
+title: "[REQUEST]"
 labels: ''
 assignees: 'Cristhian-HA'
 


### PR DESCRIPTION
**Summary:**

Currently `[REQUEST]` is prepended to all issue titles. It doesn't seem to serve any purpose so let's remove it.

**Expected behavior:** 

When you open a feature request issue, `[REQUEST]` should no longer be autopopulated in the issue title.