### PR TITLE
feat: Use java.nio.file.Path and support loading of ZIP files to memory

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
@@ -44,7 +44,7 @@ import java.util.Set;
  */
 public abstract class GtfsInput {
     /**
-     * Creates an specific GtfsInput to read data from the given path.
+     * Creates a specific GtfsInput to read data from the given path.
      *
      * @param path the path to the resource
      * @return the {@code GtfsInput} created after processing the GTFS archive
@@ -98,12 +98,12 @@ public abstract class GtfsInput {
     }
 
     /**
-     * Downloads data from network
+     * Downloads data from network.
      *
-     * @param sourceUrl     the fully qualified URL
-     * @param outputStream  the output stream
-     * @throws IOException         if no file could not be found at the specified location
-     * @throws URISyntaxException  if URL is malformed
+     * @param sourceUrl    the fully qualified URL
+     * @param outputStream the output stream
+     * @throws IOException        if no file could not be found at the specified location
+     * @throws URISyntaxException if URL is malformed
      */
     private static void loadFromUrl(URL sourceUrl, OutputStream outputStream)
             throws IOException, URISyntaxException {
@@ -117,7 +117,7 @@ public abstract class GtfsInput {
     }
 
     /**
-     * Creates a path from a given string or cleans it if the path already exists
+     * Creates a path from a given string or cleans it if the path already exists.
      *
      * @param toCleanOrCreate the path to clean or create as string
      * @return the created @code{Path}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
@@ -23,14 +23,17 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.AccessDeniedException;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -39,57 +42,87 @@ import java.util.Set;
 /**
  * GtfsInput provides a common interface for reading GTFS data, either from a ZIP archive or from a directory.
  */
-public interface GtfsInput {
+public abstract class GtfsInput {
     /**
      * Creates an specific GtfsInput to read data from the given path.
      *
-     * @param path  the path to the resource
-     * @return the @code{GtfsInput} created after processing the GTFS archive
-     * @throws IOException if no file could not be found at the specified location
+     * @param path the path to the resource
+     * @return the {@code GtfsInput} created after processing the GTFS archive
+     * @throws IOException any IO exception that occurred during loading
      */
-    static GtfsInput createFromPath(String path) throws IOException {
-        File file = new File(path);
-        if (!file.exists()) {
-            throw new FileNotFoundException(path);
+    public static GtfsInput createFromPath(Path path) throws IOException {
+        if (!Files.exists(path)) {
+            throw new FileNotFoundException(path.toString());
         }
-        if (file.isDirectory()) {
-            return new GtfsUnarchivedInput(file);
+        if (Files.isDirectory(path)) {
+            return new GtfsUnarchivedInput(path);
         }
-        return new GtfsZipFileInput(file);
+        if (path.getFileSystem().equals(FileSystems.getDefault())) {
+            return new GtfsZipFileInput(path.toFile());
+        }
+        return new GtfsZipInMemoryInput(path.toString(), Files.readAllBytes(path));
     }
 
     /**
-     * Creates an specific GtfsInput to read data from the given URL.
+     * Creates a specific GtfsInput to read data from the given URL.
      *
-     * @param sourceUrl           the fully qualified URL to download of the resource to download
-     * @param targetPathAsString  the path to where the downloaded resource will be stored
-     * @return the @code{GtfsInput} created after download of the GTFS archive
-     * @throws IOException  if no file could not be found at the specified location
-     * @throws URISyntaxException  if URL is malformed
+     * @param sourceUrl          the fully qualified URL to download of the resource to download
+     * @param targetPathAsString the path to where the downloaded resource will be stored
+     * @return the {@code GtfsInput} created after download of the GTFS archive
+     * @throws IOException          if no file could not be found at the specified location
+     * @throws URISyntaxException   if URL is malformed
      * @throws InterruptedException when a thread is waiting, sleeping, or otherwise occupied, and the thread is
-     * interrupted, either before or during the activity
+     *                              interrupted, either before or during the activity
      */
-    static GtfsInput createFromUrl(URL sourceUrl, String targetPathAsString)
+    public static GtfsInput createFromUrl(URL sourceUrl, String targetPathAsString)
             throws IOException, URISyntaxException, InterruptedException {
+        Path targetPath = createPath(targetPathAsString);
+        BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetPath.toString()));
+        loadFromUrl(sourceUrl, outputStream);
+        return createFromPath(targetPath);
+    }
+
+    /**
+     * Creates a specific GtfsInput to read data from the given URL. The loaded ZIP file is kept in memory.
+     *
+     * @param sourceUrl the fully qualified URL to download of the resource to download
+     * @return the {@code GtfsInput} created after download of the GTFS archive
+     * @throws IOException        if no file could not be found at the specified location
+     * @throws URISyntaxException if URL is malformed
+     */
+    public static GtfsInput createFromUrlInMemory(URL sourceUrl)
+            throws IOException, URISyntaxException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        loadFromUrl(sourceUrl, outputStream);
+        return new GtfsZipInMemoryInput(sourceUrl.toString(), outputStream.toByteArray());
+    }
+
+    /**
+     * Downloads data from network
+     *
+     * @param sourceUrl     the fully qualified URL
+     * @param outputStream  the output stream
+     * @throws IOException         if no file could not be found at the specified location
+     * @throws URISyntaxException  if URL is malformed
+     */
+    private static void loadFromUrl(URL sourceUrl, OutputStream outputStream)
+            throws IOException, URISyntaxException {
         CloseableHttpClient httpClient = HttpClients.createDefault();
         HttpGet httpGet = new HttpGet(sourceUrl.toURI());
         CloseableHttpResponse httpResponse = httpClient.execute(httpGet);
-        Path targetPath = createPath(targetPathAsString);
-        BufferedOutputStream outputStream = new BufferedOutputStream(new FileOutputStream(targetPath.toString()));
         httpResponse.getEntity().writeTo(outputStream);
         outputStream.close();
         httpResponse.close();
         httpClient.close();
-        return createFromPath(targetPath.toString());
     }
 
     /**
      * Creates a path from a given string or cleans it if the path already exists
      *
-     * @param toCleanOrCreate  the path to clean or create as string
+     * @param toCleanOrCreate the path to clean or create as string
      * @return the created @code{Path}
      */
-    static Path createPath(final String toCleanOrCreate) throws IOException, InterruptedException {
+    private static Path createPath(final String toCleanOrCreate) throws IOException, InterruptedException {
         // to empty any already existing directory
         Path pathToCleanOrCreate = Paths.get(toCleanOrCreate);
         if (Files.exists(pathToCleanOrCreate)) {
@@ -117,7 +150,7 @@ public interface GtfsInput {
      *
      * @return base names of all available files
      */
-    Set<String> getFilenames();
+    public abstract Set<String> getFilenames();
 
     /**
      * Returns a stream to read data from a given file.
@@ -126,5 +159,5 @@ public interface GtfsInput {
      * @return an stream to read the file data
      * @throws IOException if no file could not be found at the specified location
      */
-    InputStream getFile(String filename) throws IOException;
+    public abstract InputStream getFile(String filename) throws IOException;
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsUnarchivedInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsUnarchivedInput.java
@@ -16,28 +16,27 @@
 
 package org.mobilitydata.gtfsvalidator.input;
 
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Implements support for unarchived GTFS directories.
  */
-public class GtfsUnarchivedInput implements GtfsInput {
-    private final Set<String> filenames = new HashSet();
-    private final File directory;
+public class GtfsUnarchivedInput extends GtfsInput {
+    private final Set<String> filenames;
+    private final Path directory;
 
-    public GtfsUnarchivedInput(File directory) throws IOException {
+    public GtfsUnarchivedInput(Path directory) throws IOException {
         this.directory = directory;
-        for (File file : directory.listFiles()) {
-            if (!file.isDirectory()) {
-                filenames.add(file.getName());
-            }
-        }
+        this.filenames = Files.list(directory)
+                .filter(Files::isRegularFile)
+                .map(x -> x.getFileName().toString())
+                .collect(Collectors.toSet());
     }
 
     @Override
@@ -47,6 +46,6 @@ public class GtfsUnarchivedInput implements GtfsInput {
 
     @Override
     public InputStream getFile(String filename) throws IOException {
-        return new FileInputStream(new File(directory, filename));
+        return Files.newInputStream(directory.resolve(filename));
     }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInput.java
@@ -40,13 +40,13 @@ public class GtfsZipFileInput extends GtfsInput {
         for (Enumeration<? extends ZipEntry> i = zipFile.entries(); i
                 .hasMoreElements(); ) {
             ZipEntry entry = i.nextElement();
-            if (!insideZipDirectory(entry)) {
+            if (!isInsideZipDirectory(entry)) {
                 filenames.add(entry.getName());
             }
         }
     }
 
-    private boolean insideZipDirectory(ZipEntry entry) {
+    static boolean isInsideZipDirectory(ZipEntry entry) {
         // We do not use File.separator because the .zip file specification states:
         // All slashes MUST be forward slashes '/' as opposed to backwards slashes '\' for compatibility with Amiga and
         // UNIX file systems etc.

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipInMemoryInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipInMemoryInput.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import static org.mobilitydata.gtfsvalidator.input.GtfsZipFileInput.isInsideZipDirectory;
+
 /**
  * Implements support for GTFS ZIP archives located at given {@code java.nio.file.Path}.
  */
@@ -40,20 +42,11 @@ public class GtfsZipInMemoryInput extends GtfsInput {
         ZipInputStream zipInputStream = new ZipInputStream(new ByteArrayInputStream(bytes));
         ZipEntry entry = zipInputStream.getNextEntry();
         while (entry != null) {
-            if (!insideZipDirectory(entry)) {
+            if (!isInsideZipDirectory(entry)) {
                 filenames.add(entry.getName());
             }
             entry = zipInputStream.getNextEntry();
         }
-    }
-
-    private boolean insideZipDirectory(ZipEntry entry) {
-        // We do not use File.separator because the .zip file specification states:
-        // All slashes MUST be forward slashes '/' as opposed to backwards slashes '\' for compatibility with Amiga and
-        // UNIX file systems etc.
-        //
-        // Directory names in end with '/'.
-        return entry.getName().contains("/");
     }
 
     @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsUnarchivedInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsUnarchivedInputTest.java
@@ -41,7 +41,7 @@ public class GtfsUnarchivedInputTest {
         tmpDir.newFolder("unarchived/nested-folder");
         tmpDir.newFile("unarchived/nested-folder/nested.txt");
 
-        GtfsInput gtfsInput = GtfsInput.createFromPath(rootDir.getAbsolutePath());
+        GtfsInput gtfsInput = GtfsInput.createFromPath(rootDir.toPath());
         assertThat(gtfsInput.getFilenames()).containsExactly("stops.txt");
     }
 
@@ -50,7 +50,7 @@ public class GtfsUnarchivedInputTest {
         File rootDir = tmpDir.newFolder("unarchived");
         tmpDir.newFile("unarchived/noext");
 
-        GtfsInput gtfsInput = GtfsInput.createFromPath(rootDir.getAbsolutePath());
+        GtfsInput gtfsInput = GtfsInput.createFromPath(rootDir.toPath());
         assertThat(gtfsInput.getFilenames()).containsExactly("noext");
     }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInputTest.java
@@ -49,7 +49,7 @@ public class GtfsZipFileInputTest {
 
         out.close();
 
-        GtfsInput gtfsInput = GtfsInput.createFromPath(zipFile.getAbsolutePath());
+        GtfsInput gtfsInput = GtfsInput.createFromPath(zipFile.toPath());
         assertThat(gtfsInput.getFilenames()).containsExactly("stops.txt");
     }
 
@@ -63,7 +63,7 @@ public class GtfsZipFileInputTest {
 
         out.close();
 
-        GtfsInput gtfsInput = GtfsInput.createFromPath(zipFile.getAbsolutePath());
+        GtfsInput gtfsInput = GtfsInput.createFromPath(zipFile.toPath());
         assertThat(gtfsInput.getFilenames()).containsExactly("noext");
     }
 

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsZipInMemoryInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsZipInMemoryInputTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.input;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+@RunWith(JUnit4.class)
+public class GtfsZipInMemoryInputTest {
+    @Test
+    public void zipInput() throws IOException {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        ZipOutputStream out = new ZipOutputStream(byteStream);
+        ZipEntry e = new ZipEntry("stops.txt");
+        out.putNextEntry(e);
+        final String content = "stops";
+        out.write(content.getBytes());
+        out.closeEntry();
+        out.close();
+
+        GtfsInput gtfsInput = new GtfsZipInMemoryInput("archived.zip", byteStream.toByteArray());
+        assertThat(gtfsInput.getFilenames()).containsExactly("stops.txt");
+        byte[] bytes = new byte[content.length()];
+        gtfsInput.getFile("stops.txt").read(bytes);
+        assertThat(bytes).isEqualTo(content.getBytes());
+        assertThrows(FileNotFoundException.class, () -> gtfsInput.getFile("missing.txt"));
+    }
+
+    @Test
+    public void skipFilesInDirectories() throws IOException {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        ZipOutputStream out = new ZipOutputStream(byteStream);
+
+        out.putNextEntry(new ZipEntry("stops.txt"));
+        out.closeEntry();
+
+        out.putNextEntry(new ZipEntry("nested/file.txt"));
+        out.closeEntry();
+
+        out.close();
+
+        GtfsInput gtfsInput = new GtfsZipInMemoryInput("archived.zip", byteStream.toByteArray());
+        assertThat(gtfsInput.getFilenames()).containsExactly("stops.txt");
+        assertThrows(FileNotFoundException.class, () -> gtfsInput.getFile("nested/file.txt"));
+    }
+
+    @Test
+    public void noFileExtension() throws IOException {
+        ByteArrayOutputStream byteStream = new ByteArrayOutputStream();
+        ZipOutputStream out = new ZipOutputStream(byteStream);
+
+        out.putNextEntry(new ZipEntry("noext"));
+        out.closeEntry();
+
+        out.close();
+
+        GtfsInput gtfsInput = new GtfsZipInMemoryInput("archived.zip", byteStream.toByteArray());
+        assertThat(gtfsInput.getFilenames()).containsExactly("noext");
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -40,7 +40,7 @@ public class Arguments {
     private String url;
 
     @Parameter(names = {"-s", "--storage_directory"}, description = "Target path where to store the GTFS archive " +
-            "downloaded from network")
+            "downloaded from network (if not provided, the ZIP will be stored in memory)")
     private String storageDirectory;
 
     public String getInput() {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/CliParametersAnalyzer.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/CliParametersAnalyzer.java
@@ -39,10 +39,6 @@ public class CliParametersAnalyzer {
                     " '--input' and '--url'");
             return false;
         }
-        if (args.getUrl() != null && args.getStorageDirectory() == null) {
-            logger.atSevere().log("CLI parameter '--storage_directory' must be provided if '--url' is provided");
-            return false;
-        }
         if (args.getStorageDirectory() != null && args.getUrl() == null) {
             logger.atSevere().log("CLI parameter '--storage_directory' must not be provided if '--url' is not provided");
             return false;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.cli;
 
 import com.beust.jcommander.JCommander;
+import com.google.common.base.Strings;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -63,26 +64,22 @@ public class Main {
         feedLoader.setNumThreads(args.getNumThreads());
         NoticeContainer noticeContainer = new NoticeContainer();
         GtfsFeedContainer feedContainer;
+        GtfsInput gtfsInput;
         try {
             if (args.getInput() == null) {
-                feedContainer = feedLoader.loadAndValidate(
-                        GtfsInput.createFromUrl(
-                                new URL(args.getUrl()),
-                                args.getStorageDirectory()),
-                        feedName,
-                        validatorLoader,
-                        noticeContainer);
+                if (Strings.isNullOrEmpty(args.getStorageDirectory())) {
+                    gtfsInput = GtfsInput.createFromUrlInMemory(new URL(args.getUrl()));
+                } else {
+                    gtfsInput = GtfsInput.createFromUrl(new URL(args.getUrl()), args.getStorageDirectory());
+                }
             } else {
-                feedContainer = feedLoader.loadAndValidate(
-                        GtfsInput.createFromPath(args.getInput()),
-                        feedName,
-                        validatorLoader,
-                        noticeContainer);
+                gtfsInput = GtfsInput.createFromPath(Paths.get(args.getInput()));
             }
         } catch (IOException | URISyntaxException | InterruptedException e) {
             e.printStackTrace();
             return;
         }
+        feedContainer = feedLoader.loadAndValidate(gtfsInput, feedName, validatorLoader, noticeContainer);
 
         // Output.
         new File(args.getOutputBase()).mkdirs();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/CliParametersAnalyzerTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/CliParametersAnalyzerTest.java
@@ -84,19 +84,16 @@ public class CliParametersAnalyzerTest {
     }
 
     @Test
-    public void provideUrlWithoutSpecifyingStorageDirectoryCliParameterShouldReturnFalse() {
+    public void provideUrlWithoutSpecifyingStorageDirectoryCliParameterShouldReturnTrue() {
         Arguments mockArguments = mock(Arguments.class);
         when(mockArguments.getUrl()).thenReturn("url to dataset");
         when(mockArguments.getInput()).thenReturn(null);
         when(mockArguments.getStorageDirectory()).thenReturn(null);
 
         CliParametersAnalyzer underTest = new CliParametersAnalyzer();
-        assertThat(underTest.isValid(mockArguments)).isFalse();
-        verify(mockHandler).publish(logRecordCaptor.capture());
-        assertThat(logRecordCaptor.getValue().getMessage()).contains("CLI parameter '--storage_directory' must be " +
-                "provided if '--url' is provided");
+        assertThat(underTest.isValid(mockArguments)).isTrue();
         //noinspection ResultOfMethodCallIgnored because object is mocked
-        verify(mockArguments, times(2)).getUrl();
+        verify(mockArguments, times(1)).getUrl();
         //noinspection ResultOfMethodCallIgnored because object is mocked
         verify(mockArguments, times(2)).getInput();
         //noinspection ResultOfMethodCallIgnored because object is mocked
@@ -133,11 +130,11 @@ public class CliParametersAnalyzerTest {
         CliParametersAnalyzer underTest = new CliParametersAnalyzer();
         assertThat(underTest.isValid(mockArguments)).isTrue();
         //noinspection ResultOfMethodCallIgnored because object is mocked
-        verify(mockArguments, times(3)).getUrl();
+        verify(mockArguments, times(2)).getUrl();
         //noinspection ResultOfMethodCallIgnored because object is mocked
         verify(mockArguments, times(2)).getInput();
         //noinspection ResultOfMethodCallIgnored because object is mocked
-        verify(mockArguments, times(2)).getStorageDirectory();
+        verify(mockArguments, times(1)).getStorageDirectory();
         verifyNoMoreInteractions(mockArguments, mockHandler);
     }
 }


### PR DESCRIPTION
java.nio.file.Path is a more flexible way to retrieve files and
directories.

ZIP file can be loaded to memory instead of being saved to a temporary
directory. This is useful when the ZIP is placed on a non-local file
system or has to be downloaded from the given URL.