### PR TITLE
feat: Avoid race condition for notice containers

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -30,7 +30,8 @@ import java.util.List;
 /**
  * Container for validation notices (errors and warnings).
  * <p>
- * This class is not thread-safe.
+ * This class is not intentionally not thread-safe to increase performance. Each thread
+ * has it's own NoticeContainer, and after execution is complete the results are merged.
  */
 public class NoticeContainer {
     private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -27,6 +27,11 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * Container for validation notices (errors and warnings).
+ * <p>
+ * This class is not thread-safe.
+ */
 public class NoticeContainer {
     private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
     private static final Gson DEFAULT_GSON = new GsonBuilder().serializeNulls().create();

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -75,4 +75,16 @@ public class NoticeContainer {
         }
         return noticesByType;
     }
+
+    /**
+     * Adds all notices from another container.
+     * <p>
+     * This is useful for multithreaded validation: each thread has its own notice container which is merged
+     * into the global container when the thread finishes.
+     *
+     * @param otherContainer a container to take the notices from
+     */
+    public void addAll(NoticeContainer otherContainer) {
+        notices.addAll(otherContainer.notices);
+    }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -141,9 +141,9 @@ public class GtfsFeedLoader {
                 });
             }
             try {
-                exec.invokeAll(validatorCallables).forEach(f -> {
+                exec.invokeAll(validatorCallables).forEach(container -> {
                     try {
-                        noticeContainer.addAll(f.get());
+                        noticeContainer.addAll(container.get());
                     } catch (ExecutionException | InterruptedException e) {
                         e.printStackTrace();
                     }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -50,6 +50,18 @@ public class NoticeContainerTest {
                 "{\"notices\":[{\"code\":\"test_notice\",\"totalNotices\":1,\"notices\":[{\"nullField\":null}]}]}");
     }
 
+    @Test
+    public void addAll() {
+        Notice n1 = new MissingRequiredFileError("stops.txt");
+        Notice n2 = new UnknownFileNotice("unknown.txt");
+        NoticeContainer c1 = new NoticeContainer();
+        c1.addNotice(n1);
+        NoticeContainer c2 = new NoticeContainer();
+        c2.addNotice(n2);
+        c1.addAll(c2);
+        assertThat(c1.getNotices()).containsExactly(n1, n2);
+    }
+
     static private class TestNotice extends Notice {
         private final String code;
 


### PR DESCRIPTION
Notice container is not thread-safe, otherwise it will slow down adding
new notices. Each thread now has its own instance of notice container.
When the thread ends, its container is added to the global one.