### PR TITLE
feat: Support UK as a synonym for GB country code

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsFeedName.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsFeedName.java
@@ -36,6 +36,10 @@ public class GtfsFeedName {
 
     private static final String INVALID_FEED_NAME_MESSAGE = "Feed name must follow format `cc-abc-...', where cc is an ISO Alpha 2 country code";
 
+    // ISO 3166-1 Alpha 2 country code for the United Kingdom is "GB" but feed names may use "UK".
+    private static final String UK = "UK";
+    private static final String GB = "GB";
+
     private final String countryFirstName;
 
     private GtfsFeedName(String countryFirstName) {
@@ -54,9 +58,15 @@ public class GtfsFeedName {
 
     /**
      * Checks that the given string is a valid ISO Alpha 2 country code (case insensitive).
+     * <p>
+     * We support "UK" as an additional country code equivalent to the ISO 3166-1 Alpha 2 code "GB".
      */
     public static boolean isValidISOAlpha2(String s) {
-        return s.length() == 2 && ISO_COUNTRIES.contains(s.toUpperCase());
+        if (s.length() != 2) {
+            return false;
+        }
+        s = s.toUpperCase();
+        return s.equals(UK) || ISO_COUNTRIES.contains(s);
     }
 
     /**
@@ -107,12 +117,15 @@ public class GtfsFeedName {
     }
 
     /**
-     * Returns the uppercase ISO Alpha country code component, e.g., "NL" or "AU".
+     * Returns the uppercase ISO 3166-1 Alpha 2 country code component, e.g., "NL" or "AU".
+     *
+     * Note that this returns "GB" for feeds that use the non-standard "UK" country code.
      *
      * @return uppercase ISO Alpha country code
      */
     public String getISOAlpha2CountryCode() {
-        return countryFirstName.substring(0, 2).toUpperCase();
+        String countryCode = countryFirstName.substring(0, 2).toUpperCase();
+        return countryCode.equals(UK) ? GB : countryCode;
     }
 
     @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsFeedNameTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsFeedNameTest.java
@@ -30,6 +30,8 @@ public class GtfsFeedNameTest {
         assertThat(GtfsFeedName.parseString("nl-openov").getISOAlpha2CountryCode()).isEqualTo("NL");
         assertThat(GtfsFeedName.parseString("au-sydney-buses").getISOAlpha2CountryCode()).isEqualTo("AU");
         assertThat(GtfsFeedName.parseString("openov-nl").getISOAlpha2CountryCode()).isEqualTo("NL");
+        assertThat(GtfsFeedName.parseString("uk-feed").getISOAlpha2CountryCode()).isEqualTo("GB");
+        assertThat(GtfsFeedName.parseString("gb-feed").getISOAlpha2CountryCode()).isEqualTo("GB");
     }
 
     @Test
@@ -37,6 +39,8 @@ public class GtfsFeedNameTest {
         assertThat(GtfsFeedName.isValidCountryFirstFeedName("nl-openov")).isTrue();
         assertThat(GtfsFeedName.isValidCountryFirstFeedName("au-sydney-buses")).isTrue();
         assertThat(GtfsFeedName.isValidCountryFirstFeedName("fr-nl")).isTrue();
+        assertThat(GtfsFeedName.isValidCountryFirstFeedName("uk-feed")).isTrue();
+        assertThat(GtfsFeedName.isValidCountryFirstFeedName("gb-feed")).isTrue();
 
         assertThat(GtfsFeedName.isValidCountryFirstFeedName("openov-nl")).isFalse();
         assertThat(GtfsFeedName.isValidCountryFirstFeedName("zz-zz")).isFalse();
@@ -72,5 +76,6 @@ public class GtfsFeedNameTest {
     public void equalsMethod() {
         assertThat(GtfsFeedName.parseString("nl-openov")).isEqualTo(GtfsFeedName.parseString("nl-openov"));
         assertThat(GtfsFeedName.parseString("nl-openov")).isEqualTo(GtfsFeedName.parseString("openov-nl"));
+        assertThat(GtfsFeedName.parseString("uk-feed")).isNotEqualTo(GtfsFeedName.parseString("gb-feed"));
     }
 }


### PR DESCRIPTION
ISO 3166-1 Alpha 2 country code for the United Kingdom is "GB" but feed
names use "UK" instead.