### PR TITLE
feat: Validate that trip frequencies do not overlap

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/OverlappingFrequencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/OverlappingFrequencyNotice.java
@@ -1,0 +1,28 @@
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+/**
+ * Two frequency entries referring to the same trip may not have an overlapping time range.
+ * <p>
+ * Two entries X and Y are considered to directly overlap if <i>X.start_time <= Y.start_time</i> and
+ * <i>Y.start_time < X.end_time</i>.
+ */
+public class OverlappingFrequencyNotice extends Notice {
+    public OverlappingFrequencyNotice(
+            long prevCsvRowNumber, GtfsTime prevEndTime,
+            long currCsvRowNumber, GtfsTime currStartTime, String tripId) {
+        super(ImmutableMap.of(
+                "prevCsvRowNumber", prevCsvRowNumber,
+                "prevEndTime", prevEndTime.toHHMMSS(),
+                "currCsvRowNumber", currCsvRowNumber,
+                "currStartTime", currStartTime.toHHMMSS(),
+                "tripId", tripId));
+    }
+
+    @Override
+    public String getCode() {
+        return "overlapping_frequency";
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFrequencySchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFrequencySchema.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.table;
 
 import org.mobilitydata.gtfsvalidator.annotation.ForeignKey;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.Index;
 import org.mobilitydata.gtfsvalidator.annotation.Positive;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
@@ -26,6 +27,7 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 public interface GtfsFrequencySchema extends GtfsEntity {
     @Required
     @ForeignKey(table = "trips.txt", field = "trip_id")
+    @Index
     String tripId();
 
     @Required

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
@@ -1,0 +1,56 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.Multimaps;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.OverlappingFrequencyNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsFrequency;
+import org.mobilitydata.gtfsvalidator.table.GtfsFrequencyTableContainer;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Validates that <i>frequencies.txt</i> entries referring to the same trip do not overlap.
+ * <p>
+ * Two entries X and Y are considered to directly overlap if <i>X.start_time <= Y.start_time</i> and
+ * <i>Y.start_time < X.end_time</i>.
+ * <p>
+ * Time complexity: <i>O(n log n)</i> where <i>n</i> is the number of entries in <i>frequencies.txt</i>.
+ * <p>
+ * Generated notices:
+ * <p><ul>
+ * <li>{@link OverlappingFrequencyNotice} - two frequency entries referring to the same trip have an overlapping time
+ *     range.
+ * </ul>
+ */
+@GtfsValidator
+public class OverlappingFrequencyValidator extends FileValidator {
+    @Inject
+    GtfsFrequencyTableContainer table;
+
+    @Override
+    public void validate(NoticeContainer noticeContainer) {
+        for (List<GtfsFrequency> unorderedList : Multimaps.asMap(table.byTripIdMap()).values()) {
+            List<GtfsFrequency> frequencyList = new ArrayList<>(unorderedList);
+            Collections.sort(frequencyList,
+                    Comparator.comparing(GtfsFrequency::startTime)
+                    .thenComparing(GtfsFrequency::endTime)
+                    .thenComparing(GtfsFrequency::headwaySecs));
+
+            for (int i = 1; i < frequencyList.size(); ++i) {
+                GtfsFrequency prev = frequencyList.get(i - 1);
+                GtfsFrequency curr = frequencyList.get(i);
+                if (curr.startTime().isBefore(prev.endTime())) {
+                    noticeContainer.addNotice(new OverlappingFrequencyNotice(
+                            prev.csvRowNumber(), prev.endTime(),
+                            curr.csvRowNumber(), curr.startTime(),
+                            prev.tripId()));
+                }
+            }
+        }
+    }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
@@ -1,0 +1,114 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.Notice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.OverlappingFrequencyNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsFrequency;
+import org.mobilitydata.gtfsvalidator.table.GtfsFrequencyTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class OverlappingFrequencyValidatorTest {
+    private GtfsFrequency createFrequency(
+            long csvRowNumber, String tripId, String startTime, String endTime, int headwaySecs) {
+        return new GtfsFrequency.Builder()
+                .setCsvRowNumber(csvRowNumber)
+                .setTripId(tripId)
+                .setStartTime(GtfsTime.fromString(startTime))
+                .setEndTime(GtfsTime.fromString(endTime))
+                .setHeadwaySecs(headwaySecs).build();
+    }
+
+    private List<Notice> validateFrequencies(GtfsFrequency... frequencies) {
+        NoticeContainer noticeContainer = new NoticeContainer();
+        OverlappingFrequencyValidator validator = new OverlappingFrequencyValidator();
+        validator.table = GtfsFrequencyTableContainer.forEntities(Arrays.asList(frequencies), noticeContainer);
+        validator.validate(noticeContainer);
+        return noticeContainer.getNotices();
+    }
+
+    @Test
+    public void validSequentialInOrder() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
+                createFrequency(3, "t0", "07:00:00", "10:00:00", 300)))
+                .isEmpty();
+    }
+
+    @Test
+    public void validSequentialReversed() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "07:00:00", "10:00:00", 300),
+                createFrequency(3, "t0", "05:00:00", "07:00:00", 600)))
+                .isEmpty();
+    }
+
+    @Test
+    public void validWithGap() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
+                createFrequency(3, "t0", "08:00:00", "10:00:00", 300)))
+                .isEmpty();
+    }
+
+    @Test
+    public void validDifferentTrips() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
+                createFrequency(3, "t1", "06:00:00", "10:00:00", 300)))
+                .isEmpty();
+    }
+
+    @Test
+    public void overlappingPartially() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
+                createFrequency(3, "t0", "06:00:00", "10:00:00", 300)))
+                .containsExactly(new OverlappingFrequencyNotice(
+                        2, GtfsTime.fromString("07:00:00"),
+                        3, GtfsTime.fromString("06:00:00"), "t0"));
+    }
+
+    @Test
+    public void overlappingIncludedSameStart() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
+                createFrequency(3, "t0", "05:00:00", "06:30:00", 300)))
+                .containsExactly(new OverlappingFrequencyNotice(
+                        3, GtfsTime.fromString("06:30:00"),
+                        2, GtfsTime.fromString("05:00:00"), "t0"));
+    }
+
+    @Test
+    public void overlappingIncludedSameEnd() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
+                createFrequency(3, "t0", "06:30:00", "07:00:00", 300)))
+                .containsExactly(new OverlappingFrequencyNotice(
+                        2, GtfsTime.fromString("07:00:00"),
+                        3, GtfsTime.fromString("06:30:00"), "t0"));
+    }
+
+    @Test
+    public void overlappingThreeIntervals() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "05:00:00", "05:25:00", 600),
+                createFrequency(3, "t0", "05:00:00", "05:15:00", 300),
+                createFrequency(4, "t0", "05:20:00", "05:40:00", 300)))
+                .containsExactly(
+                        new OverlappingFrequencyNotice(
+                                3, GtfsTime.fromString("05:15:00"),
+                                2, GtfsTime.fromString("05:00:00"), "t0"),
+                        new OverlappingFrequencyNotice(
+                                2, GtfsTime.fromString("05:25:00"),
+                                4, GtfsTime.fromString("05:20:00"), "t0"));
+    }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
@@ -98,6 +98,16 @@ public class OverlappingFrequencyValidatorTest {
     }
 
     @Test
+    public void overlappingIncluded() {
+        assertThat(validateFrequencies(
+                createFrequency(2, "t0", "07:00:00", "12:00:00", 600),
+                createFrequency(3, "t0", "08:00:00", "11:00:00", 300)))
+                .containsExactly(new OverlappingFrequencyNotice(
+                        2, GtfsTime.fromString("12:00:00"),
+                        3, GtfsTime.fromString("08:00:00"), "t0"));
+    }
+
+    @Test
     public void overlappingThreeIntervals() {
         assertThat(validateFrequencies(
                 createFrequency(2, "t0", "05:00:00", "05:25:00", 600),


### PR DESCRIPTION
closes #522

**Summary:**
This PR validates that trip frequencies do not overlap. 

Two entries X and Y in frequencies.txt are considered to directly overlap if X.start_time <= Y.start_time and Y.start_time < X.end_time.