### PR TITLE
refactor: Migrate to java.time.ZoneId from java.util.TimeZone

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/FieldTypeEnum.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/FieldTypeEnum.java
@@ -34,7 +34,7 @@ package org.mobilitydata.gtfsvalidator.annotation;
  * * {@code GtfsColor} - {@code COLOR};
  * * {@code GtfsDate} - {@code DATE};
  * * {@code GtfsTime} - {@code TIME};
- * * {@code TimeZone} - {@code TIMEZONE};
+ * * {@code ZoneId} - {@code TIMEZONE};
  * * {@code Locale} - {@code LANGUAGE_CODE};
  * * {@code Currency} - {@code CURRENCY_CODE}
  * * {@code BigDecimal} - {@code DECIMAL}.

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -36,7 +36,6 @@ import java.math.BigDecimal;
 import java.time.ZoneId;
 import java.util.Currency;
 import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * Parses cells of a CSV row as values of requested data types.
@@ -67,10 +66,10 @@ public class RowParser {
             return new BigDecimal(s);
         }
     };
-    private final ValueParser<TimeZone> timezoneParser = new ValueParser("timezone") {
+    private final ValueParser<ZoneId> timezoneParser = new ValueParser("timezone") {
         @Override
-        TimeZone parseString(String s) {
-            return TimeZone.getTimeZone(ZoneId.of(s));
+        ZoneId parseString(String s) {
+            return ZoneId.of(s);
         }
     };
     private final ValueParser<Locale> languageCodeParser = new ValueParser("language code") {
@@ -223,7 +222,7 @@ public class RowParser {
     }
 
     @Nullable
-    public TimeZone asTimezone(int columnIndex, boolean required) {
+    public ZoneId asTimezone(int columnIndex, boolean required) {
         return timezoneParser.parseField(columnIndex, required);
     }
 

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -30,7 +30,6 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -169,7 +168,7 @@ public class RowParserTest {
 
     @Test
     public void asTimezone() {
-        assertThat(createParser("America/Toronto").asTimezone(0, true)).isEqualTo(TimeZone.getTimeZone(ZoneId.of("America/Toronto")));
+        assertThat(createParser("America/Toronto").asTimezone(0, true)).isEqualTo(ZoneId.of("America/Toronto"));
 
         assertThat(createParser("invalid").asTimezone(0, true)).isNull();
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsAgencySchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsAgencySchema.java
@@ -23,8 +23,8 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
 import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 
+import java.time.ZoneId;
 import java.util.Locale;
-import java.util.TimeZone;
 
 @GtfsTable("agency.txt")
 @Required
@@ -42,7 +42,7 @@ public interface GtfsAgencySchema extends GtfsEntity {
     String agencyUrl();
 
     @Required
-    TimeZone agencyTimezone();
+    ZoneId agencyTimezone();
 
     Locale agencyLang();
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
@@ -25,7 +25,7 @@ import org.mobilitydata.gtfsvalidator.annotation.Index;
 import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 
-import java.util.TimeZone;
+import java.time.ZoneId;
 
 @GtfsTable("stops.txt")
 @Required
@@ -68,7 +68,7 @@ public interface GtfsStopSchema extends GtfsEntity {
     String parentStation();
 
     @FieldType(FieldTypeEnum.TIMEZONE)
-    TimeZone stopTimezone();
+    ZoneId stopTimezone();
 
     GtfsWheelchairBoarding wheelchairBoarding();
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -25,8 +25,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
 
+import java.time.ZoneId;
 import java.util.Locale;
-import java.util.TimeZone;
 
 /**
  * Validates that all agencies have the same timezone and language and that agency_id field is set if there is more than
@@ -58,19 +58,19 @@ public class AgencyConsistencyValidator extends FileValidator {
             }
         }
 
-        TimeZone commonTimezone = agencyTable.getEntities().get(0).agencyTimezone();
+        ZoneId commonTimezone = agencyTable.getEntities().get(0).agencyTimezone();
         boolean hasLanguage = agencyTable.getEntities().get(0).hasAgencyLang();
         Locale commonLanguage = agencyTable.getEntities().get(0).agencyLang();
         // Timezone and language must be the same for all agencies.
         for (int i = 1; i < agencyCount; ++i) {
             GtfsAgency agency = agencyTable.getEntities().get(i);
-            if (!commonTimezone.getID().equals(agency.agencyTimezone().getID())) {
+            if (!commonTimezone.equals(agency.agencyTimezone())) {
                 noticeContainer.addNotice(
                         new InconsistentAgencyFieldNotice(
                                 agency.csvRowNumber(),
                                 GtfsAgencyTableLoader.AGENCY_TIMEZONE_FIELD_NAME,
-                                commonTimezone.getID(),
-                                agency.agencyTimezone().getID()));
+                                commonTimezone.getId(),
+                                agency.agencyTimezone().getId()));
             }
             if (hasLanguage != agency.hasAgencyLang()
                     || (hasLanguage && agency.hasAgencyLang() && !commonLanguage.equals(agency.agencyLang()))) {

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/Analyser.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/Analyser.java
@@ -44,9 +44,9 @@ import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleTypeVisitor8;
 import java.math.BigDecimal;
+import java.time.ZoneId;
 import java.util.Currency;
 import java.util.Locale;
-import java.util.TimeZone;
 
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.mobilitydata.gtfsvalidator.processor.EnumGenerator.createEnumName;
@@ -127,7 +127,7 @@ public class Analyser {
                 if (name.equals(String.class.getCanonicalName())) {
                     return FieldTypeEnum.TEXT;
                 }
-                if (name.equals(TimeZone.class.getCanonicalName())) {
+                if (name.equals(ZoneId.class.getCanonicalName())) {
                     return FieldTypeEnum.TIMEZONE;
                 }
                 if (name.equals(Locale.class.getCanonicalName())) {

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
@@ -32,7 +32,6 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeMirror;
 import java.time.ZoneId;
-import java.util.TimeZone;
 
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.fieldDefaultName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.getValueMethodName;
@@ -137,7 +136,7 @@ public class EntityImplementationGenerator {
             case TIME:
                 return CodeBlock.of("$T.fromSecondsSinceMidnight(0)", GtfsTime.class);
             case TIMEZONE:
-                return CodeBlock.of("$T.getTimeZone($T.of(\"UTC\"))", TimeZone.class, ZoneId.class);
+                return CodeBlock.of("$T.of(\"UTC\")", ZoneId.class);
             case CURRENCY_CODE:
             case LANGUAGE_CODE:
             default:


### PR DESCRIPTION
One should avoid using the date/time APIs in java.util.
This includes java.util.Date (and its subclass, java.sql.Timestamp),
java.util.Calendar, java.util.TimeZone, etc. They are bad APIs [1].
Even Oracle now acknowledges that these classes have "several
drawbacks" [2].

java.time is the best date/time library that Java offers. Compared to
JodaTime, it has better precision, better APIs, and is built directly
into the language.

[1] https://dzone.com/articles/game-over-jdks-date-and-time-c
[2] https://docs.oracle.com/javase/tutorial/datetime/iso/legacy.html