### PR TITLE
fix: Don't fail test on failure to delete temp file

### DIFF
--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
@@ -81,7 +81,7 @@ public class GtfsInputTest {
         assertThat(underTest instanceof GtfsZipFileInput);
         // remove created file
         File toDelete = new File("storage");
-        assertTrue(toDelete.delete());
+        toDelete.delete();
     }
 
     @Test

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
@@ -33,8 +33,7 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 @RunWith(JUnit4.class)
 public class GtfsInputTest {
@@ -92,18 +91,20 @@ public class GtfsInputTest {
                         "valid_zip_sample.zip"),
                 "storage");
         assertThat(underTest instanceof GtfsZipFileInput);
+        assertNotNull(underTest);
         // remove created file
         File toDelete = new File("storage");
-        assertTrue(toDelete.delete());
+        toDelete.delete();
 
         // URL from #398
         underTest = GtfsInput.createFromUrl(
                 new URL("https://octa.net/current/google_transit.zip"),
-                "storage");
+                "storage2");
         assertThat(underTest instanceof GtfsZipFileInput);
+        assertNotNull(underTest);
         // remove created file
-        toDelete = new File("storage");
-        assertTrue(toDelete.delete());
+        toDelete = new File("storage2");
+        toDelete.delete();
     }
 
     @Test

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
@@ -33,7 +33,8 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class GtfsInputTest {
@@ -91,7 +92,6 @@ public class GtfsInputTest {
                         "valid_zip_sample.zip"),
                 "storage");
         assertThat(underTest instanceof GtfsZipFileInput);
-        assertNotNull(underTest);
         // remove created file
         File toDelete = new File("storage");
         toDelete.delete();
@@ -101,7 +101,6 @@ public class GtfsInputTest {
                 new URL("https://octa.net/current/google_transit.zip"),
                 "storage2");
         assertThat(underTest instanceof GtfsZipFileInput);
-        assertNotNull(underTest);
         // remove created file
         toDelete = new File("storage2");
         toDelete.delete();


### PR DESCRIPTION
**Summary:**

Closes https://github.com/MobilityData/gtfs-validator/issues/584.

Delete file failures can happen due to local conditions like file locks and aren't related to validator performance, so this PR removes the assertions that check if the file has been successfully deleted.