### PR TITLE
feat: Add indexing of trips on block_id

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTripSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTripSchema.java
@@ -49,6 +49,7 @@ public interface GtfsTripSchema extends GtfsEntity {
     GtfsTripDirectionId directionId();
 
     @FieldType(FieldTypeEnum.ID)
+    @Index
     String blockId();
 
     @FieldType(FieldTypeEnum.ID)

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -294,8 +294,8 @@ public class TableContainerGenerator {
                         "$L.put(entity.$L(), entity)",
                         byKeyMapName(indexField.name()),
                         indexField.name());
-                method.endControlFlow();
             }
+            method.endControlFlow();
         }
         return method.build();
     }


### PR DESCRIPTION
This will allow to quickly find all trips that belong to a given block.

This also fixes a bug in the code generator. There will be tests for the
processor in future but now the existing GTFS schema serves as the
integration test.
