### PR TITLE
fix: Make the generated getSingleEntity() method public

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -136,6 +136,7 @@ public class TableContainerGenerator {
 
         if (fileDescriptor.singleRow()) {
             typeSpec.addMethod(MethodSpec.methodBuilder("getSingleEntity")
+                    .addModifiers(Modifier.PUBLIC)
                     .returns(classNames.entityImplementationTypeName())
                     .addStatement("return entities.isEmpty() ? null : entities.get(0)")
                     .build());


### PR DESCRIPTION
This method is generated for single-entity file containers such as
GtfsFeedInfoTableContainer.