### PR TITLE
fix: Do not crash on 0 entities in feed_info.txt

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
@@ -58,7 +58,7 @@ public class CsvFile implements Iterable<CsvRow> {
     /**
      * Tells if the file is empty, i.e. it has no rows and even no headers.
      *
-     * @return @code true} is the file is empty, {@code false} otherwise
+     * @return true is the file is empty, false otherwise
      */
     public boolean isEmpty() {
         return isEmpty;
@@ -80,7 +80,7 @@ public class CsvFile implements Iterable<CsvRow> {
     /**
      * Advances to the next row.
      *
-     * @return the next @code CsvRow} or null if end of file was reached.
+     * @return the next {@link CsvRow} or null if end of file was reached.
      */
     @Nullable
     private CsvRow nextResult() {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
@@ -58,7 +58,7 @@ public class CsvFile implements Iterable<CsvRow> {
     /**
      * Tells if the file is empty, i.e. it has no rows and even no headers.
      *
-     * @return true is the file is empty, false otherwise
+     * @return true if the file is empty, false otherwise
      */
     public boolean isEmpty() {
         return isEmpty;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -57,7 +57,7 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
     /**
      * Tells if the file is missing.
      *
-     * @return true is the file is missing, false otherwise
+     * @return true if the file is missing, false otherwise
      */
     public boolean isMissingFile() {
         return missingFile;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -76,7 +76,7 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
      * <p>
      * Note that unknown headers are not considered invalid.
      *
-     * @return true is the file has invalid headers, false otherwise
+     * @return true if the file has invalid headers, false otherwise
      */
     public void setInvalidHeaders(boolean invalidHeaders) {
         this.invalidHeaders = invalidHeaders;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -41,6 +41,11 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
 
     public abstract String gtfsFilename();
 
+    /**
+     * Tells if the file is empty, i.e. it has no rows and even no headers.
+     *
+     * @return true is the file is empty, false otherwise
+     */
     public boolean isEmptyFile() {
         return emptyFile;
     }
@@ -49,6 +54,11 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
         this.emptyFile = emptyFile;
     }
 
+    /**
+     * Tells if the file is missing.
+     *
+     * @return true is the file is missing, false otherwise
+     */
     public boolean isMissingFile() {
         return missingFile;
     }
@@ -61,6 +71,13 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
         return invalidHeaders;
     }
 
+    /**
+     * Tells if the file is invalid headers, e.g., some required headers are missing.
+     * <p>
+     * Note that unknown headers are not considered invalid.
+     *
+     * @return true is the file has invalid headers, false otherwise
+     */
     public void setInvalidHeaders(boolean invalidHeaders) {
         this.invalidHeaders = invalidHeaders;
     }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -44,7 +44,7 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
     /**
      * Tells if the file is empty, i.e. it has no rows and even no headers.
      *
-     * @return true is the file is empty, false otherwise
+     * @return true if the file is empty, false otherwise
      */
     public boolean isEmptyFile() {
         return emptyFile;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
@@ -51,7 +51,7 @@ public class MatchingFeedAndAgencyLangValidator extends FileValidator{
 
     @Override
     public void validate(NoticeContainer noticeContainer) {
-        if (feedInfoTable.isEmptyFile()) {
+        if (feedInfoTable.entityCount() == 0) {
             return;
         }
         // the previous early return ensures feedInfoTable is not empty


### PR DESCRIPTION
The previously used method isEmptyFile() tells if the whole text file is
empty. That crashed the Validator for a non-empty feed_info.txt file
that contains only the headers.

This commit adds documentation to isEmptyFile() and other methods in
GtfsTableContainer.

The unit test was changed to use the real TableContainer classes with
their real behaviour.

Closes https://github.com/MobilityData/gtfs-validator/issues/583