### PR TITLE
chore: Use FluentLogger instead of stderr and stdout

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'commons-validator:commons-validator:1.6'
     implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.13'
+    implementation 'com.google.flogger:flogger:0.5.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation 'com.squareup:javapoet:1.13.0'
     implementation 'org.apache.commons:commons-lang3:3.6'
     implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.flogger:flogger:0.5.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
 }
 


### PR DESCRIPTION
FluentLogger is more flexible and professional than stdout and stderr.

Note that Main.java keeps printing to stdout because its information
should be visible to the user on screen.
