### PR TITLE
feat: Add BlockTripsWithOverlappingStopTimesValidator

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
@@ -53,6 +53,8 @@ public class ServicePeriod {
 
     /**
      * Checks whether day in week is in pattern.
+     *
+     * @return whether the day is included in the pattern
      */
     static boolean isIncludedInPattern(DayOfWeek day, byte weeklyPattern) {
         // DayOfWeek.getValue() returns the day-of-week, from 1 (Monday) to 7 (Sunday).
@@ -70,14 +72,14 @@ public class ServicePeriod {
      * Example.
      * Monday, Tuesday, Wednesday and Saturday: {@code weeklyPatternFromMTWTFSS(1, 1, 1, 0, 0, 1, 0) = 0b0100111}
      *
-     * @param monday    whether to include Monday
-     * @param tuesday   whether to include Tuesday
-     * @param wednesday whether to include Wednesday
-     * @param thursday  whether to include Thursday
-     * @param friday    whether to include Friday
-     * @param saturday  whether to include Saturday
-     * @param sunday    whether to include Sunday
-     * @return weekly pattern in a format for ServicePeriod
+     * @param monday    1 to include or 0 to exclude Monday
+     * @param tuesday   1 to include or 0 to exclude Tuesday
+     * @param wednesday 1 to include or 0 to exclude Wednesday
+     * @param thursday  1 to include or 0 to exclude Thursday
+     * @param friday    1 to include or 0 to exclude Friday
+     * @param saturday  1 to include or 0 to exclude Saturday
+     * @param sunday    1 to include or 0 to exclude Sunday
+     * @return weekly pattern for ServicePeriod, in the format 0b0SSFTWTM
      */
     public static byte weeklyPatternFromMTWTFSS(int monday, int tuesday, int wednesday, int thursday, int friday,
                                                 int saturday, int sunday) {
@@ -130,11 +132,11 @@ public class ServicePeriod {
     /**
      * Returns the bitmask for the active week days.
      *
-     * The least significant bit represents Monday. The last bit is not used.
+     * The least significant bit represents Monday. The most significant bit is not used.
      *
      * Example. {@code 0b01101101} is Mon, Wed, Thu, Sat and Sun.
      *
-     * @return the bitmask for the active week days
+     * @return the bitmask for the active week days, in the format 0b0SSFTWTM
      */
     public byte getWeeklyPattern() {
         return weeklyPattern;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
@@ -1,0 +1,195 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+/**
+ * Stores the service of a transit vehicle, in terms of a weekly pattern and exceptions.
+ * <p>
+ * This class is immutable.
+ */
+public class ServicePeriod {
+    private final LocalDate serviceStart;
+    private final LocalDate serviceEnd;
+    private final byte weeklyPattern;
+    private final Set<LocalDate> addedDays;
+    private final Set<LocalDate> removedDays;
+
+    /**
+     * Creates a service period for the given pattern, added and removed days.
+     */
+    public ServicePeriod(LocalDate serviceStart, LocalDate serviceEnd, byte weeklyPattern,
+                         Set<LocalDate> addedDays, Set<LocalDate> removedDays) {
+        Preconditions.checkArgument(serviceStart.compareTo(serviceEnd) <= 0,
+                "serviceStart must be before or equal to serviceEnd");
+        this.serviceStart = Preconditions.checkNotNull(serviceStart);
+        this.serviceEnd = Preconditions.checkNotNull(serviceEnd);
+        this.weeklyPattern = weeklyPattern;
+        this.addedDays = Preconditions.checkNotNull(addedDays);
+        this.removedDays = Preconditions.checkNotNull(removedDays);
+    }
+
+    /**
+     * Creates a service period from the given dates.
+     *
+     * serviceStart and serviceEnd will be set to {@code LocalDate.EPOCH}.
+     */
+    public ServicePeriod(Set<LocalDate> dates) {
+        this.serviceStart = LocalDate.EPOCH;
+        this.serviceEnd = LocalDate.EPOCH;
+        this.weeklyPattern = 0;
+        this.addedDays = Preconditions.checkNotNull(dates);
+        this.removedDays = ImmutableSet.of();
+    }
+
+    /**
+     * Checks whether day in week is in pattern.
+     */
+    static boolean isIncludedInPattern(DayOfWeek day, byte weeklyPattern) {
+        // DayOfWeek.getValue() returns the day-of-week, from 1 (Monday) to 7 (Sunday).
+        return ((weeklyPattern >> (day.getValue() - 1)) & 1) != 0;
+    }
+
+    /**
+     * Returns a binary weekly pattern for the given days.
+     * <p>
+     * Each of the parameters must be either 0 or 1, where 0 means to skip the day and 1 to include it. The parameters
+     * have type {@code int} instead of {@code boolean} because GTFS calendar.txt uses integers there.
+     * <p>
+     * The returned pattern can be passed to {@code ServicePeriod} constructor.
+     * <p>
+     * Example.
+     * Monday, Tuesday, Wednesday and Saturday: {@code weeklyPatternFromMTWTFSS(1, 1, 1, 0, 0, 1, 0) = 0b0100111}
+     *
+     * @param monday    whether to include Monday
+     * @param tuesday   whether to include Tuesday
+     * @param wednesday whether to include Wednesday
+     * @param thursday  whether to include Thursday
+     * @param friday    whether to include Friday
+     * @param saturday  whether to include Saturday
+     * @param sunday    whether to include Sunday
+     * @return weekly pattern in a format for ServicePeriod
+     */
+    public static byte weeklyPatternFromMTWTFSS(int monday, int tuesday, int wednesday, int thursday, int friday,
+                                                int saturday, int sunday) {
+        int[] days = {monday, tuesday, wednesday, thursday, friday, saturday, sunday};
+        byte pattern = 0;
+        for (int i = 0; i < days.length; ++i) {
+            pattern |= (1 & days[i]) << i;
+        }
+        return pattern;
+    }
+
+    /**
+     * Returns the set of active dates in the service period.
+     *
+     * A {@link SortedSet} is returned to have all the dates sorted.
+     *
+     * @return a sorted set of all active dates
+     */
+    public SortedSet<LocalDate> toDates() {
+        SortedSet<LocalDate> activeDates = new TreeSet<>();
+        for (LocalDate current = serviceStart; current.compareTo(serviceEnd) <= 0;
+             current = current.plusDays(1)) {
+            if (isIncludedInPattern(current.getDayOfWeek(), weeklyPattern)) {
+                activeDates.add(current);
+            }
+        }
+        activeDates.addAll(addedDays);
+        activeDates.removeAll(removedDays);
+        return activeDates;
+    }
+
+    /**
+     * Returns the first day of the weekly pattern, inclusive.
+     *
+     * @return the first day of the weekly pattern
+     */
+     public LocalDate getServiceStart() {
+        return serviceStart;
+    }
+
+    /**
+     * Returns the last day of the weekly pattern, inclusive. Must be greater than or equal to serviceStart.
+     *
+     * @return the last day of the weekly pattern
+     */
+    public LocalDate getServiceEnd() {
+        return serviceEnd;
+    }
+
+    /**
+     * Returns the bitmask for the active week days.
+     *
+     * The least significant bit represents Monday. The last bit is not used.
+     *
+     * Example. {@code 0b01101101} is Mon, Wed, Thu, Sat and Sun.
+     *
+     * @return the bitmask for the active week days
+     */
+    public byte getWeeklyPattern() {
+        return weeklyPattern;
+    }
+
+    /**
+     * Days that are explicitly active, regardless of the weekly pattern.
+     *
+     * These dates can be outside of the range of the pattern (service start and service end).
+     *
+     * @return additional active days
+     */
+    public Set<LocalDate> getAddedDays() {
+        return Collections.unmodifiableSet(addedDays);
+    }
+
+    /**
+     * Days that are explicitly inactive, regardless of the weekly pattern.
+     *
+     * The intersection between {@code removedDays} and {@code addedDays} could be non-empty, in which case the removed
+     * have higher precedence.
+     *
+     * @return explictly inactive days
+     */
+    public Set<LocalDate> getRemovedDays() {
+        return Collections.unmodifiableSet(removedDays);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ServicePeriod that = (ServicePeriod)o;
+      return weeklyPattern == that.weeklyPattern &&
+          serviceStart.equals(that.serviceStart) &&
+          serviceEnd.equals(that.serviceEnd) &&
+          addedDays.equals(that.addedDays) &&
+          removedDays.equals(that.removedDays);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(serviceStart, serviceEnd, weeklyPattern, addedDays,
+                          removedDays);
+    }
+
+    @Override
+    public String toString() {
+      return "ServicePeriod{"
+          + "serviceStart=" + serviceStart + ", serviceEnd=" + serviceEnd +
+          ", weeklyPattern=" + weeklyPattern + ", addedDays=" + addedDays +
+          ", removedDays=" + removedDays + '}';
+    }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
@@ -13,121 +13,122 @@ import static com.google.common.truth.Truth.assertThat;
 
 @RunWith(JUnit4.class)
 public class ServicePeriodTest {
-  @Test
-  public void weeklyPatternFromMTWTFSS() {
-    assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 0, 0, 1, 0))
-        .isEqualTo(0b0100111);
-    assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(0, 0, 0, 0, 0, 0, 0))
-        .isEqualTo(0);
-    assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 1, 1, 1, 1))
-        .isEqualTo(0b1111111);
-  }
+    @Test
+    public void weeklyPatternFromMTWTFSS() {
+        assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 0, 0, 1, 0))
+            .isEqualTo(0b0100111);
+        assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(0, 0, 0, 0, 0, 0, 0))
+            .isEqualTo(0);
+        assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 1, 1, 1, 1))
+            .isEqualTo(0b1111111);
+    }
 
-  @Test
-  public void isIncludedInPattern() {
-    // Test all days in 0b0100111 pattern.
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0b0100111))
-        .isTrue();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.TUESDAY, (byte)0b0100111))
-        .isTrue();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.WEDNESDAY, (byte)0b0100111))
-        .isTrue();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.THURSDAY, (byte)0b0100111))
-        .isFalse();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.FRIDAY, (byte)0b0100111))
-        .isFalse();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.SATURDAY, (byte)0b0100111))
-        .isTrue();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0b0100111))
-        .isFalse();
+    @Test
+    public void isIncludedInPattern() {
+        // Test all days in 0b00100111 pattern, in the format of 0b0SSFTWTM
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY,
+                                                     (byte)0b0100111))
+            .isTrue();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.TUESDAY,
+                                                     (byte)0b0100111))
+            .isTrue();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.WEDNESDAY,
+                                                     (byte)0b0100111))
+            .isTrue();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.THURSDAY,
+                                                     (byte)0b0100111))
+            .isFalse();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.FRIDAY,
+                                                     (byte)0b0100111))
+            .isFalse();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.SATURDAY,
+                                                     (byte)0b0100111))
+            .isTrue();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY,
+                                                     (byte)0b0100111))
+            .isFalse();
 
-    // Test corner cases: all days included and no days included.
-    assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0))
-        .isFalse();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0b1111111))
-        .isTrue();
-    assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0))
-        .isFalse();
-    assertThat(
-        ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0b1111111))
-        .isTrue();
-  }
+        // Test corner cases: all days included and no days included.
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0))
+            .isFalse();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY,
+                                                     (byte)0b1111111))
+            .isTrue();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0))
+            .isFalse();
+        assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY,
+                                                     (byte)0b1111111))
+            .isTrue();
+    }
 
-  @Test
-  public void segmentAddedAndRemovedDays() {
-    final LocalDate serviceStart = LocalDate.of(2021, 1, 4);
-    final LocalDate serviceEnd = LocalDate.of(2021, 1, 6);
-    final byte weeklyPattern = 0b1111111;
-    final SortedSet<LocalDate> addedDays = ImmutableSortedSet.of(
-        LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 9),
-        LocalDate.of(2021, 1, 10));
-    final SortedSet<LocalDate> removedDays = ImmutableSortedSet.of(
-        LocalDate.of(2021, 1, 5), LocalDate.of(2021, 1, 9));
-    ServicePeriod period = new ServicePeriod(
-        serviceStart, serviceEnd, weeklyPattern, addedDays, removedDays);
-    assertThat(period.getServiceStart()).isEqualTo(serviceStart);
-    assertThat(period.getServiceEnd()).isEqualTo(serviceEnd);
-    assertThat(period.getWeeklyPattern()).isEqualTo(weeklyPattern);
-    assertThat(period.getAddedDays()).isEqualTo(addedDays);
-    assertThat(period.getRemovedDays()).isEqualTo(removedDays);
-    assertThat(period.toDates())
-        .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
-                                         LocalDate.of(2021, 1, 6),
-                                         LocalDate.of(2021, 1, 10)));
-  }
+    @Test
+    public void segmentAddedAndRemovedDays() {
+        final LocalDate serviceStart = LocalDate.of(2021, 1, 4);
+        final LocalDate serviceEnd = LocalDate.of(2021, 1, 10);
+        final byte weeklyPattern = 0b0000111;
+        final SortedSet<LocalDate> addedDays = ImmutableSortedSet.of(
+            LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 9),
+            LocalDate.of(2021, 1, 10));
+        final SortedSet<LocalDate> removedDays = ImmutableSortedSet.of(
+            LocalDate.of(2021, 1, 5), LocalDate.of(2021, 1, 9));
+        ServicePeriod period = new ServicePeriod(
+            serviceStart, serviceEnd, weeklyPattern, addedDays, removedDays);
+        assertThat(period.getServiceStart()).isEqualTo(serviceStart);
+        assertThat(period.getServiceEnd()).isEqualTo(serviceEnd);
+        assertThat(period.getWeeklyPattern()).isEqualTo(weeklyPattern);
+        assertThat(period.getAddedDays()).isEqualTo(addedDays);
+        assertThat(period.getRemovedDays()).isEqualTo(removedDays);
+        assertThat(period.toDates())
+            .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
+                                             LocalDate.of(2021, 1, 6),
+                                             LocalDate.of(2021, 1, 10)));
+    }
 
-  @Test
-  public void addedDays() {
-    final SortedSet<LocalDate> dates = ImmutableSortedSet.of(
-        LocalDate.of(2021, 1, 3), LocalDate.of(2021, 1, 6),
-        LocalDate.of(2021, 11, 28));
-    assertThat(new ServicePeriod(dates).toDates()).isEqualTo(dates);
-  }
+    @Test
+    public void addedDays() {
+        final SortedSet<LocalDate> dates = ImmutableSortedSet.of(
+            LocalDate.of(2021, 1, 3), LocalDate.of(2021, 1, 6),
+            LocalDate.of(2021, 11, 28));
+        assertThat(new ServicePeriod(dates).toDates()).isEqualTo(dates);
+    }
 
-  @Test
-  public void segment() {
-    // Mon 4 Jan 2021 - Fri 15 Jan 2021
-    // Included days of week: Mon, Tue, Wed, Fri
-    assertThat(new ServicePeriod(
-                   LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 15),
-                   ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 0, 1, 0, 0),
-                   ImmutableSortedSet.of(), ImmutableSortedSet.of())
-                   .toDates())
-        .isEqualTo(ImmutableSortedSet.of(
-            LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 5),
-            LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 8),
-            LocalDate.of(2021, 1, 11), LocalDate.of(2021, 1, 12),
-            LocalDate.of(2021, 1, 13), LocalDate.of(2021, 1, 15)));
-  }
+    @Test
+    public void segment() {
+        // Mon 4 Jan 2021 - Fri 15 Jan 2021
+        // Included days of week: Mon, Tue, Wed, Fri
+        assertThat(
+            new ServicePeriod(
+                LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 15),
+                ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 0, 1, 0, 0),
+                ImmutableSortedSet.of(), ImmutableSortedSet.of())
+                .toDates())
+            .isEqualTo(ImmutableSortedSet.of(
+                LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 5),
+                LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 8),
+                LocalDate.of(2021, 1, 11), LocalDate.of(2021, 1, 12),
+                LocalDate.of(2021, 1, 13), LocalDate.of(2021, 1, 15)));
+    }
 
-  @Test
-  public void addedAndRemovedDays() {
-    assertThat(
-        new ServicePeriod(LocalDate.EPOCH, LocalDate.EPOCH, (byte)0,
-                          ImmutableSortedSet.of(LocalDate.of(2021, 1, 3),
-                                                LocalDate.of(2021, 1, 6),
-                                                LocalDate.of(2021, 11, 28)),
-                          ImmutableSortedSet.of(LocalDate.of(2021, 1, 6)))
-            .toDates())
-        .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 3),
-                                         LocalDate.of(2021, 11, 28)));
-  }
+    @Test
+    public void addedAndRemovedDays() {
+        assertThat(
+            new ServicePeriod(LocalDate.EPOCH, LocalDate.EPOCH, (byte)0,
+                              ImmutableSortedSet.of(LocalDate.of(2021, 1, 3),
+                                                    LocalDate.of(2021, 1, 6),
+                                                    LocalDate.of(2021, 11, 28)),
+                              ImmutableSortedSet.of(LocalDate.of(2021, 1, 6)))
+                .toDates())
+            .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 3),
+                                             LocalDate.of(2021, 11, 28)));
+    }
 
-  @Test
-  public void singleDay() {
-    assertThat(new ServicePeriod(LocalDate.of(2021, 1, 4),
-                                 LocalDate.of(2021, 1, 4), (byte)0b1111111,
-                                 ImmutableSortedSet.of(),
-                                 ImmutableSortedSet.of())
-                   .toDates())
-        .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 4)));
-  }
+    @Test
+    public void singleDay() {
+        assertThat(new ServicePeriod(LocalDate.of(2021, 1, 4),
+                                     LocalDate.of(2021, 1, 4), (byte)0b1111111,
+                                     ImmutableSortedSet.of(),
+                                     ImmutableSortedSet.of())
+                       .toDates())
+            .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 4)));
+    }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
@@ -1,0 +1,133 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.collect.ImmutableSortedSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.SortedSet;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class ServicePeriodTest {
+  @Test
+  public void weeklyPatternFromMTWTFSS() {
+    assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 0, 0, 1, 0))
+        .isEqualTo(0b0100111);
+    assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(0, 0, 0, 0, 0, 0, 0))
+        .isEqualTo(0);
+    assertThat(ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 1, 1, 1, 1))
+        .isEqualTo(0b1111111);
+  }
+
+  @Test
+  public void isIncludedInPattern() {
+    // Test all days in 0b0100111 pattern.
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0b0100111))
+        .isTrue();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.TUESDAY, (byte)0b0100111))
+        .isTrue();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.WEDNESDAY, (byte)0b0100111))
+        .isTrue();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.THURSDAY, (byte)0b0100111))
+        .isFalse();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.FRIDAY, (byte)0b0100111))
+        .isFalse();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.SATURDAY, (byte)0b0100111))
+        .isTrue();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0b0100111))
+        .isFalse();
+
+    // Test corner cases: all days included and no days included.
+    assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0))
+        .isFalse();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.MONDAY, (byte)0b1111111))
+        .isTrue();
+    assertThat(ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0))
+        .isFalse();
+    assertThat(
+        ServicePeriod.isIncludedInPattern(DayOfWeek.SUNDAY, (byte)0b1111111))
+        .isTrue();
+  }
+
+  @Test
+  public void segmentAddedAndRemovedDays() {
+    final LocalDate serviceStart = LocalDate.of(2021, 1, 4);
+    final LocalDate serviceEnd = LocalDate.of(2021, 1, 6);
+    final byte weeklyPattern = 0b1111111;
+    final SortedSet<LocalDate> addedDays = ImmutableSortedSet.of(
+        LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 9),
+        LocalDate.of(2021, 1, 10));
+    final SortedSet<LocalDate> removedDays = ImmutableSortedSet.of(
+        LocalDate.of(2021, 1, 5), LocalDate.of(2021, 1, 9));
+    ServicePeriod period = new ServicePeriod(
+        serviceStart, serviceEnd, weeklyPattern, addedDays, removedDays);
+    assertThat(period.getServiceStart()).isEqualTo(serviceStart);
+    assertThat(period.getServiceEnd()).isEqualTo(serviceEnd);
+    assertThat(period.getWeeklyPattern()).isEqualTo(weeklyPattern);
+    assertThat(period.getAddedDays()).isEqualTo(addedDays);
+    assertThat(period.getRemovedDays()).isEqualTo(removedDays);
+    assertThat(period.toDates())
+        .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
+                                         LocalDate.of(2021, 1, 6),
+                                         LocalDate.of(2021, 1, 10)));
+  }
+
+  @Test
+  public void addedDays() {
+    final SortedSet<LocalDate> dates = ImmutableSortedSet.of(
+        LocalDate.of(2021, 1, 3), LocalDate.of(2021, 1, 6),
+        LocalDate.of(2021, 11, 28));
+    assertThat(new ServicePeriod(dates).toDates()).isEqualTo(dates);
+  }
+
+  @Test
+  public void segment() {
+    // Mon 4 Jan 2021 - Fri 15 Jan 2021
+    // Included days of week: Mon, Tue, Wed, Fri
+    assertThat(new ServicePeriod(
+                   LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 15),
+                   ServicePeriod.weeklyPatternFromMTWTFSS(1, 1, 1, 0, 1, 0, 0),
+                   ImmutableSortedSet.of(), ImmutableSortedSet.of())
+                   .toDates())
+        .isEqualTo(ImmutableSortedSet.of(
+            LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 5),
+            LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 8),
+            LocalDate.of(2021, 1, 11), LocalDate.of(2021, 1, 12),
+            LocalDate.of(2021, 1, 13), LocalDate.of(2021, 1, 15)));
+  }
+
+  @Test
+  public void addedAndRemovedDays() {
+    assertThat(
+        new ServicePeriod(LocalDate.EPOCH, LocalDate.EPOCH, (byte)0,
+                          ImmutableSortedSet.of(LocalDate.of(2021, 1, 3),
+                                                LocalDate.of(2021, 1, 6),
+                                                LocalDate.of(2021, 11, 28)),
+                          ImmutableSortedSet.of(LocalDate.of(2021, 1, 6)))
+            .toDates())
+        .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 3),
+                                         LocalDate.of(2021, 11, 28)));
+  }
+
+  @Test
+  public void singleDay() {
+    assertThat(new ServicePeriod(LocalDate.of(2021, 1, 4),
+                                 LocalDate.of(2021, 1, 4), (byte)0b1111111,
+                                 ImmutableSortedSet.of(),
+                                 ImmutableSortedSet.of())
+                   .toDates())
+        .isEqualTo(ImmutableSortedSet.of(LocalDate.of(2021, 1, 4)));
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/BlockTripsWithOverlappingStopTimesNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/BlockTripsWithOverlappingStopTimesNotice.java
@@ -1,0 +1,26 @@
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+
+public class BlockTripsWithOverlappingStopTimesNotice extends Notice {
+
+    public BlockTripsWithOverlappingStopTimesNotice(long csvRowNumberA, String tripIdA, String serviceIdA,
+                                                    long csvRowNumberB, String tripIdB, String serviceIdB,
+                                                    GtfsDate intersection) {
+        super(new ImmutableMap.Builder<String, Object>()
+                .put("csvRowNumberA", csvRowNumberA)
+                .put("tripIdA", tripIdA)
+                .put("serviceIdA", serviceIdA)
+                .put("csvRowNumberB", csvRowNumberB)
+                .put("tripIdB", tripIdB)
+                .put("serviceIdB", serviceIdB)
+                .put("intersection", intersection.toYYYYMMDD())
+                .build());
+    }
+
+    @Override
+    public String getCode() {
+        return "block_trips_with_overlapping_stop_times";
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
@@ -121,14 +121,18 @@ public final class CalendarUtil {
     }
 
     /**
-     * Finds the first intersecting date in the given sets, if any. Returns {@code Optional.empty()} if there is no
-     * intersection.
-     * <p>
-     * If either set is empty, then the method always returns false, even if both sets are empty.
+     * Finds the first intersecting date in the given sets, if any. Returns
+     * {@code Optional.empty()} if there is no intersection.
+     *
+     * <p> If either set is empty, then the method always returns {@code
+     * Optional.empty()}, even if both sets are empty.
+     *
+     * <p>Time complexity: O(size(dates1) + size(dates2)).
      *
      * @param dates1 the first sorted set of service dates
      * @param dates2 the second sorted set of service dates
-     * @return the first intersecting date or {@code Optional.empty()}
+     * @return the first intersecting date or {@code Optional.empty()} if there
+     *     is no intersection
      */
     public static Optional<LocalDate> firstIntersectingDate(@Nonnull SortedSet<LocalDate> dates1,
                                                             @Nonnull SortedSet<LocalDate> dates2) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
@@ -1,0 +1,159 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Multimaps;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateExceptionType;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.SortedSet;
+
+/**
+ * Provides a collection of functions to work with service dates in <i>calendar.txt</i> and <i>calendar_dates.txt</i>.
+ */
+public final class CalendarUtil {
+    private CalendarUtil() {
+    }
+
+    /**
+     * Extracts the service period information of a service from GTFS schema.
+     *
+     * @param calendar      the row in <i>calendar.txt</i> or null
+     * @param calendarDates the list of rows in <i>calendar_dates.txt</i>, may
+     *                      be empty
+     * @return a {@link ServicePeriod} object
+     */
+    public static ServicePeriod
+    createServicePeriod(@Nullable GtfsCalendar calendar,
+                        @Nonnull List<GtfsCalendarDate> calendarDates) {
+        // Store service period from calendar.txt, if provided.
+        LocalDate serviceStart;
+        LocalDate serviceEnd;
+        byte weeklyPattern;
+        if (calendar != null) {
+            serviceStart = calendar.startDate().getLocalDate();
+            serviceEnd = calendar.endDate().getLocalDate();
+            weeklyPattern = ServicePeriod.weeklyPatternFromMTWTFSS(
+                    calendar.mondayValue(), calendar.tuesdayValue(),
+                    calendar.wednesdayValue(), calendar.thursdayValue(),
+                    calendar.fridayValue(), calendar.saturdayValue(),
+                    calendar.sundayValue());
+        } else {
+            serviceStart = LocalDate.EPOCH;
+            serviceEnd = LocalDate.EPOCH;
+            weeklyPattern = 0;
+        }
+
+        // Store exception days from calendar_dates.txt, if any.
+        Set<LocalDate> addedDays = new HashSet<>();
+        Set<LocalDate> removedDays = new HashSet<>();
+        for (GtfsCalendarDate calendarDate : calendarDates) {
+            (calendarDate.exceptionType() ==
+                    GtfsCalendarDateExceptionType.SERVICE_ADDED
+                    ? addedDays
+                    : removedDays)
+                    .add(calendarDate.date().getLocalDate());
+        }
+
+        return new ServicePeriod(serviceStart, serviceEnd, weeklyPattern,
+                addedDays, removedDays);
+    }
+
+    /**
+     * Builds a service id to {@code ServicePeriod} mapping using the given
+     * <i>calendar.txt</i> and <i>calendar_dates.txt</i> tables. <p> If either
+     * table is missing, a empty container should be passed in.
+     *
+     * @param calendarTable     the <i>calendar.txt</i> table container, may be
+     *                          empty
+     * @param calendarDateTable the <i>calendar_dates.txt</i> table container,
+     *                          may be empty
+     * @return mapping from service id to {@link ServicePeriod} object
+     */
+    public static Map<String, ServicePeriod> buildServicePeriodMap(
+            @Nonnull GtfsCalendarTableContainer calendarTable,
+            @Nonnull GtfsCalendarDateTableContainer calendarDateTable) {
+        Preconditions.checkNotNull(calendarTable);
+        Preconditions.checkNotNull(calendarDateTable);
+
+        Map<String, ServicePeriod> servicePeriods = new HashMap<>();
+        for (GtfsCalendar calendar : calendarTable.getEntities()) {
+            servicePeriods.put(
+                    calendar.serviceId(),
+                    createServicePeriod(calendar, calendarDateTable.byServiceId(
+                            calendar.serviceId())));
+        }
+        for (List<GtfsCalendarDate> calendarDates :
+                Multimaps.asMap(calendarDateTable.byServiceIdMap()).values()) {
+            if (!servicePeriods.containsKey(calendarDates.get(0).serviceId())) {
+                servicePeriods.put(calendarDates.get(0).serviceId(),
+                        createServicePeriod(null, calendarDates));
+            }
+        }
+        return servicePeriods;
+    }
+
+    /**
+     * Converts a map {service id -> ServicePeriod} to map {service id -> set of dates}.
+     *
+     * @param servicePeriods mapping from service id to {@link ServicePeriod}
+     * @return mapping from service id to a set of included days
+     */
+    public static Map<String, SortedSet<LocalDate>> servicePeriodToServiceDatesMap(
+            @Nonnull Map<String, ServicePeriod> servicePeriods) {
+        Map<String, SortedSet<LocalDate>> serviceDates = new HashMap<>();
+        for (Map.Entry<String, ServicePeriod> kv : servicePeriods.entrySet()) {
+            serviceDates.put(kv.getKey(), kv.getValue().toDates());
+        }
+        return serviceDates;
+    }
+
+    /**
+     * Finds the first intersecting date in the given sets, if any. Returns {@code Optional.empty()} if there is no
+     * intersection.
+     * <p>
+     * If either set is empty, then the method always returns false, even if both sets are empty.
+     *
+     * @param dates1 the first sorted set of service dates
+     * @param dates2 the second sorted set of service dates
+     * @return the first intersecting date or {@code Optional.empty()}
+     */
+    public static Optional<LocalDate> firstIntersectingDate(@Nonnull SortedSet<LocalDate> dates1,
+                                                            @Nonnull SortedSet<LocalDate> dates2) {
+        if (dates1.isEmpty() || dates2.isEmpty()) {
+            return Optional.empty();
+        }
+        Iterator<LocalDate> it1 = dates1.iterator();
+        Iterator<LocalDate> it2 = dates2.iterator();
+        LocalDate date1 = it1.next();
+        LocalDate date2 = it2.next();
+        for (; ; ) {
+            final int compare = date1.compareTo(date2);
+            if (compare == 0) {
+                return Optional.of(date1);
+            } else if (compare < 0) {
+                if (!it1.hasNext()) {
+                    return Optional.empty();
+                }
+                date1 = it1.next();
+            } else {
+                if (!it2.hasNext()) {
+                    return Optional.empty();
+                }
+                date2 = it2.next();
+            }
+        }
+    }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
@@ -31,15 +31,17 @@ public class ServiceIdIntersectionCache {
     }
 
     /**
-     * Finds the first intersecting date in the given sets, if any, and caches the result. Returns
-     * {@code Optional.empty()} if there is no intersection.
+     * Finds the first intersecting date in the given sets, if any, and caches
+     * the result. Returns {@code Optional.empty()} if there is no intersection.
      * <p>
-     * Note that if either service has no active service dates, then the method always returns false, even if the
-     * service ids are the same.
+     * Note that if either service has no active service dates, then the method
+     * always returns {@code Optional.empty()}, even if the service ids are the
+     * same.
      *
      * @param serviceId1 the first service id
      * @param serviceId2 the second service id
-     * @return the first intersecting date or {@code Optional.empty()}
+     * @return the first intersecting date or {@code Optional.empty()} for no
+     *     intersection
      */
     public Optional<LocalDate> findIntersectingDate(String serviceId1, String serviceId2) {
         // We generate the cache key with the smallest service id coming first.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
@@ -1,0 +1,75 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.Optional;
+import java.util.SortedSet;
+
+/**
+ * A helper class for storing cached results that two given services overlap.
+ * <p>
+ * This class is not thread-safe.
+ */
+public class ServiceIdIntersectionCache {
+    static private final LocalDate NO_OVERLAP = LocalDate.EPOCH;
+    private final Map<String, SortedSet<LocalDate>> serviceDates;
+    // The cache stores LocalDate instead of Optional<LocalDate> for size
+    // efficiency. If services do not overlap, we store null.
+    private final Table<String, String, LocalDate> cache =
+            HashBasedTable.create();
+
+    /**
+     * Creates an intersection cache from the given service dates.
+     *
+     * @param serviceDates mapping from service id to a set of included days
+     */
+    public ServiceIdIntersectionCache(Map<String, SortedSet<LocalDate>> serviceDates) {
+        this.serviceDates = serviceDates;
+    }
+
+    /**
+     * Finds the first intersecting date in the given sets, if any, and caches the result. Returns
+     * {@code Optional.empty()} if there is no intersection.
+     * <p>
+     * Note that if either service has no active service dates, then the method always returns false, even if the
+     * service ids are the same.
+     *
+     * @param serviceId1 the first service id
+     * @param serviceId2 the second service id
+     * @return the first intersecting date or {@code Optional.empty()}
+     */
+    public Optional<LocalDate> findIntersectingDate(String serviceId1, String serviceId2) {
+        // We generate the cache key with the smallest service id coming first.
+        if (serviceId1.compareTo(serviceId2) > 0) {
+            String tmp = serviceId2;
+            serviceId2 = serviceId1;
+            serviceId1 = tmp;
+        }
+        LocalDate inCache = cache.get(serviceId1, serviceId2);
+        if (inCache != null) {
+            return inCache.equals(NO_OVERLAP) ? Optional.empty()
+                    : Optional.of(inCache);
+        }
+        SortedSet<LocalDate> dates1 = serviceDates.get(serviceId1);
+        SortedSet<LocalDate> dates2 = serviceDates.get(serviceId2);
+        final Optional<LocalDate> intersection =
+                dates1 == null || dates2 == null ?
+                        Optional.empty() :
+                        CalendarUtil.firstIntersectingDate(dates1, dates2);
+        cache.put(serviceId1, serviceId2, intersection.orElse(NO_OVERLAP));
+        return intersection;
+    }
+
+    /**
+     * Returns the cache size.
+     *
+     * @return cache size.
+     */
+    public int getCacheSize() {
+        return cache.size();
+    }
+}
+

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -1,0 +1,231 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.Multimaps;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.BlockTripsWithOverlappingStopTimesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+import org.mobilitydata.gtfsvalidator.util.CalendarUtil;
+import org.mobilitydata.gtfsvalidator.util.ServiceIdIntersectionCache;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Checks to see if any trips with the same block id have overlapping stop times.
+ * <p>
+ * Both trips have to be operating on the same service day, as determined by comparing the service dates of the trips.
+ * <p>
+ * Generated notices:
+ * <p><ul>
+ * <li>{@link BlockTripsWithOverlappingStopTimesNotice}
+ * </ul>
+ */
+@GtfsValidator
+public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
+    @Inject
+    GtfsTripTableContainer tripTable;
+    @Inject
+    GtfsStopTimeTableContainer stopTimeTable;
+    @Inject
+    GtfsCalendarTableContainer calendarTable;
+    @Inject
+    GtfsCalendarDateTableContainer calendarDateTable;
+
+    @Override
+    public void validate(NoticeContainer noticeContainer) {
+        // If there are no trip or stop time entries, then we can stop right now.
+        if (tripTable.entityCount() == 0 || stopTimeTable.entityCount() == 0) {
+            return;
+        }
+
+        // Our strategy to find trips with overlapping stop times that are active on the same service date is to:
+        // 1) iterate over groups of trips grouped by their block id;
+        // 2) sort the trips within the block by stop times;
+        // 3) iterate over each trip, looking for subsequent trips that
+        //   (a) are active on the same service date and
+        //   (b) have overlapping stop times.
+        // Because the trips will be ordered by stop times, we shouldn't have to look too far down the list.
+        final ServiceIdIntersectionCache serviceIdIntersectionCache = new ServiceIdIntersectionCache(
+                CalendarUtil.servicePeriodToServiceDatesMap(
+                        CalendarUtil.buildServicePeriodMap(calendarTable, calendarDateTable)));
+        for (List<GtfsTrip> tripsInBlock : Multimaps.asMap(tripTable.byBlockIdMap()).values()) {
+            // We don't care about trips without a block id.
+            if (!tripsInBlock.get(0).hasBlockId()) {
+                continue;
+            }
+            // We need a first arrival time and a last departure time for each trip in the block to properly judge trip
+            // overlap.
+            for (GtfsTripOverlap overlap : findOverlapIntervals(
+                    constructOrderedTripIntervals(tripsInBlock), serviceIdIntersectionCache)) {
+                final GtfsTrip tripA = overlap.getTripA();
+                final GtfsTrip tripB = overlap.getTripB();
+                noticeContainer.addNotice(
+                        new BlockTripsWithOverlappingStopTimesNotice(
+                                tripA.csvRowNumber(), tripA.tripId(), tripA.serviceId(),
+                                tripB.csvRowNumber(), tripB.tripId(), tripB.serviceId(),
+                                GtfsDate.fromLocalDate(overlap.intersection)));
+            }
+        }
+    }
+
+    /**
+     * Constructs an ordered list of GtfsTripIntervals for the specified rows in trips.txt.
+     * <p>
+     * Each trip's time interval is constructed from the first and last stop time for a trip. If a particular trip has
+     * no stop times or if the first or last stop time of the trip has no arrival and departure information, the trip is
+     * not included in the interval resulting list.
+     * <p>
+     * Intervals are sorted by increasing first-arrival times, and then last-departure time.
+     */
+    private List<GtfsTripInterval> constructOrderedTripIntervals(List<GtfsTrip> tripsInBlock) {
+        ArrayList<GtfsTripInterval> intervals = new ArrayList<>();
+        intervals.ensureCapacity(tripsInBlock.size());
+        for (GtfsTrip trip : tripsInBlock) {
+            final List<GtfsStopTime> stopTimes = stopTimeTable.byTripId(trip.tripId());
+            if (stopTimes.isEmpty()) {
+                // Invalid trip without stop times is reported separately.
+                continue;
+            }
+            GtfsStopTime firstStopTime = stopTimes.get(0);
+            GtfsStopTime lastStopTime = stopTimes.get(stopTimes.size() - 1);
+            if (!firstStopTime.hasArrivalTime() || !firstStopTime.hasDepartureTime() ||
+                    !lastStopTime.hasArrivalTime() || !lastStopTime.hasDepartureTime()) {
+                continue;
+            }
+            intervals.add(new GtfsTripInterval(
+                    trip,
+                    firstStopTime.arrivalTime(), firstStopTime.departureTime(),
+                    lastStopTime.arrivalTime(), lastStopTime.departureTime()));
+        }
+        // Sort the trips by their first arrival and last departure times.
+        Collections.sort(intervals,
+                Comparator.comparing(GtfsTripInterval::getFirstArrival)
+                        .thenComparing(GtfsTripInterval::getLastDeparture));
+        return intervals;
+    }
+
+    /**
+     * Iterates over each trip intervals, looking for subsequent trips that:
+     * (a) are active on the same service date and
+     * (b) have overlapping stop times.
+     */
+    private List<GtfsTripOverlap> findOverlapIntervals(
+            List<GtfsTripInterval> intervals,
+            ServiceIdIntersectionCache serviceIdIntersectionCache) {
+        List<GtfsTripOverlap> overlaps = new ArrayList<>();
+        // Iterate over each trip, looking for subsequent trips that have
+        // overlapping time ranges.
+        for (int i = 0; i < intervals.size(); ++i) {
+            final GtfsTripInterval interval = intervals.get(i);
+            for (int j = i + 1; j < intervals.size(); ++j) {
+                final GtfsTripInterval nextInterval = intervals.get(j);
+
+                // We can stop searching for overlapping intervals if there is
+                // no more overlap.
+                if (interval.getLastDeparture().compareTo(nextInterval.getFirstArrival()) <= 0) {
+                    break;
+                }
+                // We technically allow two trip intervals to have overlapping stop
+                // time intervals if the arrival/departure pair of the last stop in the
+                // previous trip is exactly the same as the arrival/departure pair of
+                // the first stop in the next trip.  Many agencies model a block
+                // transfer between two trips by basically replicating the
+                // stop_times.txt entry for the two trips, creating a small overlap.
+                if (interval.getLastArrival().equals(nextInterval.getFirstArrival()) &&
+                        interval.getLastDeparture().equals(nextInterval.getFirstDeparture())) {
+                    continue;
+                }
+                final Optional<LocalDate> intersection = serviceIdIntersectionCache.findIntersectingDate(
+                        interval.getTrip().serviceId(), nextInterval.getTrip().serviceId());
+                if (intersection.isPresent()) {
+                    overlaps.add(new GtfsTripOverlap(
+                            interval.getTrip(), nextInterval.getTrip(), intersection.get()));
+                }
+            }
+        }
+        return overlaps;
+    }
+
+    /**
+     * Captures the time interval spanned by the first and last stop time of a particular GTFS trip.
+     */
+    private static class GtfsTripInterval {
+        private final GtfsTrip trip;
+        private final GtfsTime firstArrival;
+        private final GtfsTime firstDeparture;
+        private final GtfsTime lastArrival;
+        private final GtfsTime lastDeparture;
+
+        public GtfsTripInterval(GtfsTrip trip, GtfsTime firstArrival,
+                                GtfsTime firstDeparture, GtfsTime lastArrival,
+                                GtfsTime lastDeparture) {
+            this.trip = trip;
+            this.firstArrival = firstArrival;
+            this.firstDeparture = firstDeparture;
+            this.lastArrival = lastArrival;
+            this.lastDeparture = lastDeparture;
+        }
+
+        public GtfsTrip getTrip() {
+            return trip;
+        }
+
+        public GtfsTime getFirstArrival() {
+            return firstArrival;
+        }
+
+        public GtfsTime getFirstDeparture() {
+            return firstDeparture;
+        }
+
+        public GtfsTime getLastArrival() {
+            return lastArrival;
+        }
+
+        public GtfsTime getLastDeparture() {
+            return lastDeparture;
+        }
+    }
+
+    /**
+     * Captures a trip pair overlapped by time, stores the row numbers of the
+     * overlapped trips and the first intersection.
+     */
+    private static class GtfsTripOverlap {
+        private final GtfsTrip tripA;
+        private final GtfsTrip tripB;
+        private final LocalDate intersection;
+
+        public GtfsTripOverlap(GtfsTrip tripA, GtfsTrip tripB,
+                               LocalDate intersection) {
+            this.tripA = tripA;
+            this.tripB = tripB;
+            this.intersection = intersection;
+        }
+
+        public GtfsTrip getTripA() {
+            return tripA;
+        }
+
+        public GtfsTrip getTripB() {
+            return tripB;
+        }
+
+        public LocalDate getIntersection() {
+            return intersection;
+        }
+    }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
@@ -19,6 +19,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.Optional;
 import java.util.Set;
+import java.util.SortedSet;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -175,16 +176,21 @@ public class CalendarUtilTest {
     }
 
     @Test
-    public void firstIntersectingDate() {
-        assertThat(CalendarUtil.firstIntersectingDate(
-                ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
-                        LocalDate.of(2021, 1, 5),
-                        LocalDate.of(2021, 1, 6)),
-                ImmutableSortedSet.of(
-                        LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 5),
-                        LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 7))))
-                .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+    public void firstIntersectingDateWithIntersection() {
+        final SortedSet<LocalDate> set456 = ImmutableSortedSet.of(
+            LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 5),
+            LocalDate.of(2021, 1, 6));
+        final SortedSet<LocalDate> set1567 = ImmutableSortedSet.of(
+            LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 5),
+            LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 7));
+        assertThat(CalendarUtil.firstIntersectingDate(set456, set1567))
+            .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+        assertThat(CalendarUtil.firstIntersectingDate(set1567, set456))
+            .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+    }
 
+    @Test
+    public void firstIntersectingDateNoIntersection() {
         assertThat(CalendarUtil.firstIntersectingDate(
                 ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
                         LocalDate.of(2021, 1, 5)),

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
@@ -1,0 +1,204 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSortedSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateExceptionType;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class CalendarUtilTest {
+    public static GtfsCalendar createGtfsCalendar(String serviceId,
+                                                  LocalDate startDate,
+                                                  LocalDate endDate,
+                                                  Set<DayOfWeek> days) {
+        GtfsCalendar.Builder calendar =
+                new GtfsCalendar.Builder()
+                        .setServiceId(serviceId)
+                        .setStartDate(GtfsDate.fromLocalDate(startDate))
+                        .setEndDate(GtfsDate.fromLocalDate(endDate));
+        if (days.contains(DayOfWeek.MONDAY)) {
+            calendar.setMonday(1);
+        }
+        if (days.contains(DayOfWeek.TUESDAY)) {
+            calendar.setTuesday(1);
+        }
+        if (days.contains(DayOfWeek.WEDNESDAY)) {
+            calendar.setWednesday(1);
+        }
+        if (days.contains(DayOfWeek.THURSDAY)) {
+            calendar.setThursday(1);
+        }
+        if (days.contains(DayOfWeek.FRIDAY)) {
+            calendar.setFriday(1);
+        }
+        if (days.contains(DayOfWeek.SATURDAY)) {
+            calendar.setSaturday(1);
+        }
+        if (days.contains(DayOfWeek.SUNDAY)) {
+            calendar.setSunday(1);
+        }
+        return calendar.build();
+    }
+
+    private static GtfsCalendarDate addedCalendarDate(String serviceId,
+                                                      LocalDate date) {
+        return new GtfsCalendarDate.Builder()
+                .setServiceId(serviceId)
+                .setDate(GtfsDate.fromLocalDate(date))
+                .setExceptionType(
+                        GtfsCalendarDateExceptionType.SERVICE_ADDED.getNumber())
+                .build();
+    }
+
+    private static GtfsCalendarDate removedCalendarDate(String serviceId,
+                                                        LocalDate date) {
+        return new GtfsCalendarDate.Builder()
+                .setServiceId(serviceId)
+                .setDate(GtfsDate.fromLocalDate(date))
+                .setExceptionType(
+                        GtfsCalendarDateExceptionType.SERVICE_REMOVED.getNumber())
+                .build();
+    }
+
+    @Test
+    public void createServicePeriod() {
+        ServicePeriod servicePeriod = CalendarUtil.createServicePeriod(
+                createGtfsCalendar(
+                        "s1", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 5),
+                        ImmutableSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                                DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)),
+                ImmutableList.of(addedCalendarDate("s1", LocalDate.of(2021, 1, 6)),
+                        removedCalendarDate("s1", LocalDate.of(2021, 1, 7))));
+        assertThat(servicePeriod.getServiceStart())
+                .isEqualTo(LocalDate.of(2021, 1, 4));
+        assertThat(servicePeriod.getServiceEnd())
+                .isEqualTo(LocalDate.of(2021, 1, 5));
+        assertThat(servicePeriod.getWeeklyPattern()).isEqualTo(0b0010111);
+        assertThat(servicePeriod.getAddedDays())
+                .containsExactly(LocalDate.of(2021, 1, 6));
+        assertThat(servicePeriod.getRemovedDays())
+                .containsExactly(LocalDate.of(2021, 1, 7));
+    }
+
+    @Test
+    public void CreateServicePeriodEmpty() {
+        ServicePeriod servicePeriod =
+                CalendarUtil.createServicePeriod(null, ImmutableList.of());
+        assertThat(servicePeriod.getServiceStart()).isEqualTo(LocalDate.EPOCH);
+        assertThat(servicePeriod.getServiceEnd()).isEqualTo(LocalDate.EPOCH);
+        assertThat(servicePeriod.getWeeklyPattern()).isEqualTo(0);
+        assertThat(servicePeriod.getAddedDays()).isEmpty();
+        assertThat(servicePeriod.getRemovedDays()).isEmpty();
+    }
+
+    @Test
+    public void buildServicePeriodMap() {
+        NoticeContainer noticeContainer = new NoticeContainer();
+        GtfsCalendarTableContainer calendarTable =
+                GtfsCalendarTableContainer.forEntities(
+                        ImmutableList.of(createGtfsCalendar(
+                                "s1", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 5),
+                                ImmutableSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                                        DayOfWeek.WEDNESDAY, DayOfWeek.FRIDAY)),
+                                createGtfsCalendar(
+                                        "s2", LocalDate.of(2021, 2, 14), LocalDate.of(2021, 2, 15),
+                                        ImmutableSet.of(DayOfWeek.SUNDAY))),
+                        noticeContainer);
+
+        GtfsCalendarDateTableContainer calendarDateTable =
+                GtfsCalendarDateTableContainer.forEntities(
+                        ImmutableList.of(
+                                addedCalendarDate("s1", LocalDate.of(2021, 1, 6)),
+                                removedCalendarDate("s1", LocalDate.of(2021, 1, 7)),
+                                addedCalendarDate("s3", LocalDate.of(2021, 3, 8)),
+                                removedCalendarDate("s3", LocalDate.of(2021, 3, 9))),
+                        noticeContainer);
+
+        assertThat(
+                CalendarUtil.buildServicePeriodMap(calendarTable, calendarDateTable))
+                .containsExactly(
+                        "s1",
+                        new ServicePeriod(LocalDate.of(2021, 1, 4),
+                                LocalDate.of(2021, 1, 5), (byte) 0b0010111,
+                                ImmutableSet.of(LocalDate.of(2021, 1, 6)),
+                                ImmutableSet.of(LocalDate.of(2021, 1, 7))),
+                        "s2",
+                        new ServicePeriod(LocalDate.of(2021, 2, 14),
+                                LocalDate.of(2021, 2, 15), (byte) 0b1000000,
+                                ImmutableSet.of(), ImmutableSet.of()),
+                        "s3",
+                        new ServicePeriod(LocalDate.EPOCH, LocalDate.EPOCH, (byte) 0,
+                                ImmutableSet.of(LocalDate.of(2021, 3, 8)),
+                                ImmutableSet.of(LocalDate.of(2021, 3, 9))));
+    }
+
+    @Test
+    public void servicePeriodToServiceDatesMap() {
+        assertThat(
+                CalendarUtil.servicePeriodToServiceDatesMap(ImmutableMap.of(
+                        "s1",
+                        new ServicePeriod(LocalDate.of(2021, 1, 4),
+                                LocalDate.of(2021, 1, 5), (byte) 0b0010111,
+                                ImmutableSet.of(LocalDate.of(2021, 1, 6)),
+                                ImmutableSet.of(LocalDate.of(2021, 1, 7))),
+                        "s2",
+                        new ServicePeriod(LocalDate.of(2021, 2, 14),
+                                LocalDate.of(2021, 2, 15), (byte) 0b1000000,
+                                ImmutableSet.of(), ImmutableSet.of()),
+                        "s3",
+                        new ServicePeriod(LocalDate.EPOCH, LocalDate.EPOCH, (byte) 0,
+                                ImmutableSet.of(LocalDate.of(2021, 3, 8)),
+                                ImmutableSet.of(LocalDate.of(2021, 3, 9))))))
+                .containsExactly("s1",
+                        ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
+                                LocalDate.of(2021, 1, 5),
+                                LocalDate.of(2021, 1, 6)),
+                        "s2", ImmutableSortedSet.of(LocalDate.of(2021, 2, 14)),
+                        "s3", ImmutableSortedSet.of(LocalDate.of(2021, 3, 8)));
+    }
+
+    @Test
+    public void firstIntersectingDate() {
+        assertThat(CalendarUtil.firstIntersectingDate(
+                ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
+                        LocalDate.of(2021, 1, 5),
+                        LocalDate.of(2021, 1, 6)),
+                ImmutableSortedSet.of(
+                        LocalDate.of(2021, 1, 1), LocalDate.of(2021, 1, 5),
+                        LocalDate.of(2021, 1, 6), LocalDate.of(2021, 1, 7))))
+                .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+
+        assertThat(CalendarUtil.firstIntersectingDate(
+                ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
+                        LocalDate.of(2021, 1, 5)),
+                ImmutableSortedSet.of(LocalDate.of(2021, 1, 6),
+                        LocalDate.of(2021, 1, 7))))
+                .isEqualTo(Optional.empty());
+
+        assertThat(CalendarUtil.firstIntersectingDate(
+                ImmutableSortedSet.of(LocalDate.of(2021, 1, 4)),
+                ImmutableSortedSet.of()))
+                .isEqualTo(Optional.empty());
+
+        assertThat(CalendarUtil.firstIntersectingDate(ImmutableSortedSet.of(),
+                ImmutableSortedSet.of()))
+                .isEqualTo(Optional.empty());
+    }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCacheTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCacheTest.java
@@ -1,0 +1,51 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSortedSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class ServiceIdIntersectionCacheTest {
+
+    @Test
+    public void findIntersectingDate() {
+        final ServiceIdIntersectionCache cache = new ServiceIdIntersectionCache(
+                ImmutableMap.of("s1",
+                        ImmutableSortedSet.of(LocalDate.of(2021, 1, 4),
+                                LocalDate.of(2021, 1, 5),
+                                LocalDate.of(2021, 1, 6)),
+                        "s2",
+                        ImmutableSortedSet.of(LocalDate.of(2021, 1, 1),
+                                LocalDate.of(2021, 1, 5),
+                                LocalDate.of(2021, 1, 6),
+                                LocalDate.of(2021, 1, 7))));
+
+        // The first call puts the data to cache and the second retrieves it from
+        // there.
+        assertThat(cache.getCacheSize()).isEqualTo(0);
+        assertThat(cache.findIntersectingDate("s1", "s2"))
+                .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+        assertThat(cache.getCacheSize()).isEqualTo(1);
+        assertThat(cache.findIntersectingDate("s1", "s2"))
+                .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+        assertThat(cache.getCacheSize()).isEqualTo(1);
+        assertThat(cache.findIntersectingDate("s2", "s1"))
+                .isEqualTo(Optional.of(LocalDate.of(2021, 1, 5)));
+        assertThat(cache.getCacheSize()).isEqualTo(1);
+
+        // Test non-existent services.
+        assertThat(cache.findIntersectingDate("s1", "notFound"))
+                .isEqualTo(Optional.empty());
+        assertThat(cache.getCacheSize()).isEqualTo(2);
+        assertThat(cache.findIntersectingDate("notFound", "notFound"))
+                .isEqualTo(Optional.empty());
+        assertThat(cache.getCacheSize()).isEqualTo(3);
+    }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
@@ -1,0 +1,198 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.BlockTripsWithOverlappingStopTimesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Set;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class BlockTripsWithOverlappingStopTimesValidatorTest {
+
+    private static GtfsCalendarTableContainer
+    createCalendarTable(NoticeContainer noticeContainer) {
+        final Set<DayOfWeek> weekDays = ImmutableSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY, DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY);
+        return GtfsCalendarTableContainer.forEntities(
+                ImmutableList.of(
+                        CalendarUtilTest.createGtfsCalendar(
+                                "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4),
+                                weekDays),
+                        CalendarUtilTest.createGtfsCalendar(
+                                "WEEK-ALT", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4),
+                                weekDays),
+                        CalendarUtilTest.createGtfsCalendar(
+                                "SAT", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4),
+                                ImmutableSet.of(DayOfWeek.SATURDAY)),
+                        CalendarUtilTest.createGtfsCalendar(
+                                "SUN", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4),
+                                ImmutableSet.of(DayOfWeek.SUNDAY))),
+                noticeContainer);
+    }
+
+    public static GtfsStopTime createStopTime(long csvRowNumber, String tripId,
+                                              String time, String stopId,
+                                              int stopSequence) {
+        return new GtfsStopTime.Builder()
+                .setCsvRowNumber(csvRowNumber)
+                .setTripId(tripId)
+                .setArrivalTime(GtfsTime.fromString(time))
+                .setDepartureTime(GtfsTime.fromString(time))
+                .setStopSequence(stopSequence)
+                .setStopId(stopId)
+                .build();
+    }
+
+    public static GtfsTrip createTrip(long csvRowNumber, String tripId,
+                                      String serviceId, String blockId) {
+        return new GtfsTrip.Builder()
+                .setCsvRowNumber(csvRowNumber)
+                .setTripId(tripId)
+                .setServiceId(serviceId)
+                .setBlockId(blockId)
+                .build();
+    }
+
+    private static GtfsTripTableContainer
+    createTripTable(String[] tripIds, String[] serviceIds, String blockId,
+                    NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(
+                tripIds.length == serviceIds.length,
+                "tripIds.length must be equal to serviceIds.length");
+
+        ArrayList<GtfsTrip> trips = new ArrayList<>();
+        trips.ensureCapacity(tripIds.length);
+        for (int i = 0; i < tripIds.length; ++i) {
+            trips.add(
+                    createTrip(trips.size() + 1, tripIds[i], serviceIds[i], blockId));
+        }
+
+        return GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    }
+
+    private static GtfsStopTimeTableContainer
+    createStopTimeTable(String[] tripIds, String[] stopIds, String[][] times,
+                        NoticeContainer noticeContainer) {
+        Preconditions.checkArgument(tripIds.length == times.length,
+                "tripIds.length must be equal to times.length");
+
+        ArrayList<GtfsStopTime> stopTimes = new ArrayList<>();
+        stopTimes.ensureCapacity(tripIds.length * stopIds.length);
+        for (int i = 0; i < tripIds.length; ++i) {
+            Preconditions.checkArgument(
+                    stopIds.length == times[i].length,
+                    "stopIds.length must be equal to times[%d].length", i);
+            for (int j = 0; j < stopIds.length; ++j) {
+                stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i],
+                        times[i][j], stopIds[j], j));
+            }
+        }
+
+        return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+    }
+
+    @Test
+    public void goodFeed() {
+        final NoticeContainer noticeContainer = new NoticeContainer();
+
+        BlockTripsWithOverlappingStopTimesValidator validator =
+                new BlockTripsWithOverlappingStopTimesValidator();
+        validator.calendarTable = createCalendarTable(noticeContainer);
+        validator.calendarDateTable =
+                GtfsCalendarDateTableContainer.forMissingFile();
+        validator.tripTable = createTripTable(
+                new String[]{"t0", "t1", "t2", "t3", "t4", "t5"},
+                new String[]{"WEEK", "WEEK", "WEEK", "SAT", "SAT", "SAT"}, "b1",
+                noticeContainer);
+        validator.stopTimeTable =
+                createStopTimeTable(new String[]{"t0", "t1", "t2", "t3", "t4", "t5"},
+                        new String[]{"s0", "s1"},
+                        new String[][]{
+                                new String[]{"08:00:00", "09:00:00"},
+                                new String[]{"10:00:00", "11:00:00"},
+                                new String[]{"12:00:00", "13:00:00"},
+                                new String[]{"08:00:00", "09:00:00"},
+                                new String[]{"10:00:00", "11:00:00"},
+                                new String[]{"12:00:00", "13:00:00"},
+                        },
+                        noticeContainer);
+
+        validator.validate(noticeContainer);
+        assertThat(noticeContainer.getNotices()).isEmpty();
+    }
+
+    @Test
+    public void overlapWithSameServiceId() {
+        final NoticeContainer noticeContainer = new NoticeContainer();
+
+        BlockTripsWithOverlappingStopTimesValidator validator =
+                new BlockTripsWithOverlappingStopTimesValidator();
+        validator.calendarTable = createCalendarTable(noticeContainer);
+        validator.calendarDateTable =
+                GtfsCalendarDateTableContainer.forMissingFile();
+        validator.tripTable = createTripTable(new String[]{"t0", "t1", "t2"},
+                new String[]{"WEEK", "WEEK", "WEEK"},
+                "b1", noticeContainer);
+        validator.stopTimeTable = createStopTimeTable(
+                new String[]{"t0", "t1", "t2"}, new String[]{"s0", "s1"},
+                new String[][]{
+                        new String[]{"08:00:00", "09:00:00"},
+                        new String[]{"08:30:00", "09:30:00"},
+                        new String[]{"12:00:00", "13:00:00"},
+                },
+                noticeContainer);
+
+        validator.validate(noticeContainer);
+        assertThat(noticeContainer.getNotices())
+                .containsExactly(new BlockTripsWithOverlappingStopTimesNotice(
+                        1, "t0", "WEEK", 2, "t1", "WEEK",
+                        GtfsDate.fromString("20210104")));
+    }
+
+    @Test
+    public void overlapWithDifferentServiceId() {
+        final NoticeContainer noticeContainer = new NoticeContainer();
+
+        BlockTripsWithOverlappingStopTimesValidator validator =
+                new BlockTripsWithOverlappingStopTimesValidator();
+        validator.calendarTable = createCalendarTable(noticeContainer);
+        validator.calendarDateTable =
+                GtfsCalendarDateTableContainer.forMissingFile();
+        validator.tripTable = createTripTable(new String[]{"t0", "t1"},
+                new String[]{"WEEK", "WEEK-ALT"},
+                "b1", noticeContainer);
+        validator.stopTimeTable = createStopTimeTable(
+                new String[]{"t0", "t1"}, new String[]{"s0", "s1"},
+                new String[][]{
+                        new String[]{"08:00:00", "09:00:00"},
+                        new String[]{"08:30:00", "09:30:00"},
+                },
+                noticeContainer);
+
+        validator.validate(noticeContainer);
+        assertThat(noticeContainer.getNotices())
+                .containsExactly(new BlockTripsWithOverlappingStopTimesNotice(
+                        1, "t0", "WEEK", 2, "t1", "WEEK-ALT",
+                        GtfsDate.fromString("20210104")));
+    }
+}


### PR DESCRIPTION
closes #523, closes https://github.com/MobilityData/gtfs-validator/issues/362

This checks to see if any trips with the same block id have
overlapping stop times. Both trips have to be operating on the same
service day, as determined by comparing the service dates of the
trips.
