### PR TITLE
fix: Update end to end CI to use Java 11 instead of 8

### DIFF
--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -24,10 +24,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.8
+      - name: Set up JDK 1.11
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: 1.11
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This is a follow-on to https://github.com/MobilityData/gtfs-validator/pull/595, which changes the min JDK version to 11 as a result of https://github.com/MobilityData/gtfs-validator/pull/592.

closes https://github.com/MobilityData/gtfs-validator/issues/593