### PR TITLE
fix: Make children of GtfsTableLoader and GtfsTableContainer final

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -108,7 +108,7 @@ public class TableContainerGenerator {
         TypeSpec.Builder typeSpec = TypeSpec.classBuilder(classNames.tableContainerSimpleName())
                 .superclass(ParameterizedTypeName.get(ClassName.get(GtfsTableContainer.class), gtfsEntityType))
                 .addAnnotation(Generated.class)
-                .addModifiers(Modifier.PUBLIC);
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
         typeSpec.addMethod(MethodSpec.methodBuilder("getEntityClass")
                 .addAnnotation(Override.class)

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -119,7 +119,7 @@ public class TableLoaderGenerator {
                 .superclass(ParameterizedTypeName.get(ClassName.get(GtfsTableLoader.class), classNames.entityImplementationTypeName()))
                 .addAnnotation(GtfsLoader.class)
                 .addAnnotation(Generated.class)
-                .addModifiers(Modifier.PUBLIC);
+                .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
         typeSpec.addField(
                 FieldSpec.builder(FluentLogger.class, "logger", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)


### PR DESCRIPTION
Remove the temptation to inherit from automatically generated classes.

Generated children of GtfsEntity and their builders are already marked
as final.

This is a common pattern The AutoValue library also makes its generated
classes final.
