### PR TITLE
feat: Add more context to different notices

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/BlockTripsWithOverlappingStopTimesNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/BlockTripsWithOverlappingStopTimesNotice.java
@@ -4,19 +4,20 @@ import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 
 public class BlockTripsWithOverlappingStopTimesNotice extends Notice {
-
-    public BlockTripsWithOverlappingStopTimesNotice(long csvRowNumberA, String tripIdA, String serviceIdA,
-                                                    long csvRowNumberB, String tripIdB, String serviceIdB,
-                                                    GtfsDate intersection) {
+    public BlockTripsWithOverlappingStopTimesNotice(
+        long csvRowNumberA, String tripIdA, String serviceIdA,
+        long csvRowNumberB, String tripIdB, String serviceIdB, String blockId,
+        GtfsDate intersection) {
         super(new ImmutableMap.Builder<String, Object>()
-                .put("csvRowNumberA", csvRowNumberA)
-                .put("tripIdA", tripIdA)
-                .put("serviceIdA", serviceIdA)
-                .put("csvRowNumberB", csvRowNumberB)
-                .put("tripIdB", tripIdB)
-                .put("serviceIdB", serviceIdB)
-                .put("intersection", intersection.toYYYYMMDD())
-                .build());
+                  .put("csvRowNumberA", csvRowNumberA)
+                  .put("tripIdA", tripIdA)
+                  .put("serviceIdA", serviceIdA)
+                  .put("csvRowNumberB", csvRowNumberB)
+                  .put("tripIdB", tripIdB)
+                  .put("serviceIdB", serviceIdB)
+                  .put("blockId", blockId)
+                  .put("intersection", intersection.toYYYYMMDD())
+                  .build());
     }
 
     @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/LocationWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/LocationWithoutParentStationNotice.java
@@ -24,11 +24,12 @@ import com.google.common.collect.ImmutableMap;
  * The following location types must have `parent_station`: entrance, generic node, boarding area.
  */
 public class LocationWithoutParentStationNotice extends Notice {
-    public LocationWithoutParentStationNotice(String stopId, long csvRowNumber, int locationType) {
-        super(ImmutableMap.of(
-                "stopId", stopId,
-                "csvRowNumber", csvRowNumber,
-                "locationType", locationType));
+    public LocationWithoutParentStationNotice(long csvRowNumber, String stopId,
+                                              String stopName,
+                                              int locationType) {
+        super(ImmutableMap.of("csvRowNumber", csvRowNumber, "stopId", stopId,
+                              "stopName", stopName, "locationType",
+                              locationType));
     }
 
     @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/PlatformWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/PlatformWithoutParentStationNotice.java
@@ -24,10 +24,10 @@ import com.google.common.collect.ImmutableMap;
  * This is different from {@code LocationWithoutParentStationNotice} since it is less severe.
  */
 public class PlatformWithoutParentStationNotice extends Notice {
-    public PlatformWithoutParentStationNotice(String stopId, long csvRowNumber) {
-        super(ImmutableMap.of(
-                "stopId", stopId,
-                "csvRowNumber", csvRowNumber));
+    public PlatformWithoutParentStationNotice(long csvRowNumber, String stopId,
+                                              String stopName) {
+        super(ImmutableMap.of("csvRowNumber", csvRowNumber, "stopId", stopId,
+                              "stopName", stopName));
     }
 
     @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StationWithParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StationWithParentStationNotice.java
@@ -22,11 +22,12 @@ import com.google.common.collect.ImmutableMap;
  * A station has `parent_station` field set.
  */
 public class StationWithParentStationNotice extends Notice {
-    public StationWithParentStationNotice(String stopId, long csvRowNumber, String parentStation) {
-        super(ImmutableMap.of(
-                "stopId", stopId,
-                "csvRowNumber", csvRowNumber,
-                "parentStation", parentStation));
+    public StationWithParentStationNotice(long csvRowNumber, String stopId,
+                                          String stopName,
+                                          String parentStation) {
+        super(ImmutableMap.of("stopId", stopId, "stopName", stopName,
+                              "csvRowNumber", csvRowNumber, "parentStation",
+                              parentStation));
     }
 
     @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/WrongParentLocationTypeNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/WrongParentLocationTypeNotice.java
@@ -22,16 +22,21 @@ import com.google.common.collect.ImmutableMap;
  * Incorrect type of the parent location (e.g., a parent for a stop or an entrance must be a station).
  */
 public class WrongParentLocationTypeNotice extends Notice {
-    public WrongParentLocationTypeNotice(String stopId, long csvRowNumber, int locationType, String parentStation,
-                                         long parentCsvRowNumber, int parentLocationType, int expectedLocationType) {
+    public WrongParentLocationTypeNotice(
+        long csvRowNumber, String stopId, String stopName, int locationType,
+        long parentCsvRowNumber, String parentStation, String parentStopName,
+        int parentLocationType, int expectedLocationType) {
         super(new ImmutableMap.Builder<String, Object>()
-                .put("stopId", stopId)
-                .put("csvRowNumber", csvRowNumber)
-                .put("locationType", locationType)
-                .put("parentStation", parentStation)
-                .put("parentCsvRowNumber", parentCsvRowNumber)
-                .put("parentLocationType", parentLocationType)
-                .put("expectedLocationType", expectedLocationType).build());
+                  .put("csvRowNumber", csvRowNumber)
+                  .put("stopId", stopId)
+                  .put("stopName", stopName)
+                  .put("locationType", locationType)
+                  .put("parentCsvRowNumber", parentCsvRowNumber)
+                  .put("parentStation", parentStation)
+                  .put("parentStopName", parentStopName)
+                  .put("parentLocationType", parentLocationType)
+                  .put("expectedLocationType", expectedLocationType)
+                  .build());
     }
 
     @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -73,10 +73,11 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
                 final GtfsTrip tripA = overlap.getTripA();
                 final GtfsTrip tripB = overlap.getTripB();
                 noticeContainer.addNotice(
-                        new BlockTripsWithOverlappingStopTimesNotice(
-                                tripA.csvRowNumber(), tripA.tripId(), tripA.serviceId(),
-                                tripB.csvRowNumber(), tripB.tripId(), tripB.serviceId(),
-                                GtfsDate.fromLocalDate(overlap.intersection)));
+                    new BlockTripsWithOverlappingStopTimesNotice(
+                        tripA.csvRowNumber(), tripA.tripId(), tripA.serviceId(),
+                        tripB.csvRowNumber(), tripB.tripId(), tripB.serviceId(),
+                        tripA.blockId(),
+                        GtfsDate.fromLocalDate(overlap.intersection)));
             }
         }
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
@@ -44,19 +44,23 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
     public void validate(GtfsStop location, NoticeContainer noticeContainer) {
         if (location.hasParentStation()) {
             if (location.locationType() == GtfsLocationType.STATION) {
-                noticeContainer.addNotice(new StationWithParentStationNotice(location.stopId(),
-                        location.csvRowNumber(), location.parentStation()));
+                noticeContainer.addNotice(new StationWithParentStationNotice(
+                    location.csvRowNumber(), location.stopId(),
+                    location.stopName(), location.parentStation()));
             }
         } else if (location.locationType() == GtfsLocationType.STOP) {
             if (!location.platformCode().isEmpty()) {
                 // This is a platform since it has platform_code. This is a separate notice from
                 // LocationWithoutParentStationNotice because it is less severe.
-                noticeContainer.addNotice(new PlatformWithoutParentStationNotice(location.stopId(),
-                        location.csvRowNumber()));
+                noticeContainer.addNotice(
+                    new PlatformWithoutParentStationNotice(
+                        location.csvRowNumber(), location.stopId(),
+                        location.stopName()));
             }
         } else if (requiresParentStation(location.locationType())) {
-            noticeContainer.addNotice(new LocationWithoutParentStationNotice(location.stopId(), location.csvRowNumber(),
-                    location.locationTypeValue()));
+            noticeContainer.addNotice(new LocationWithoutParentStationNotice(
+                location.csvRowNumber(), location.stopId(), location.stopName(),
+                location.locationTypeValue()));
         }
     }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -57,9 +57,12 @@ public class ParentLocationTypeValidator extends FileValidator {
             GtfsStop parentLocation = stopTable.byStopId(location.parentStation());
             GtfsLocationType expected = expectedParentLocationType(location.locationType());
             if (expected != GtfsLocationType.UNRECOGNIZED && parentLocation.locationType() != expected) {
-                noticeContainer.addNotice(new WrongParentLocationTypeNotice(location.stopId(),
-                        location.csvRowNumber(), location.locationTypeValue(), location.parentStation(),
-                        parentLocation.csvRowNumber(), parentLocation.locationTypeValue(), expected.getNumber()));
+                noticeContainer.addNotice(new WrongParentLocationTypeNotice(
+                    location.csvRowNumber(), location.stopId(),
+                    location.stopName(), location.locationTypeValue(),
+                    parentLocation.csvRowNumber(), location.parentStation(),
+                    parentLocation.stopName(),
+                    parentLocation.locationTypeValue(), expected.getNumber()));
             }
         }
     }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
@@ -164,9 +164,9 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
 
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices())
-                .containsExactly(new BlockTripsWithOverlappingStopTimesNotice(
-                        1, "t0", "WEEK", 2, "t1", "WEEK",
-                        GtfsDate.fromString("20210104")));
+            .containsExactly(new BlockTripsWithOverlappingStopTimesNotice(
+                1, "t0", "WEEK", 2, "t1", "WEEK", "b1",
+                GtfsDate.fromString("20210104")));
     }
 
     @Test
@@ -191,9 +191,9 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
 
         validator.validate(noticeContainer);
         assertThat(noticeContainer.getNotices())
-                .containsExactly(new BlockTripsWithOverlappingStopTimesNotice(
-                        1, "t0", "WEEK", 2, "t1", "WEEK-ALT",
-                        GtfsDate.fromString("20210104")));
+            .containsExactly(new BlockTripsWithOverlappingStopTimesNotice(
+                1, "t0", "WEEK", 2, "t1", "WEEK-ALT", "b1",
+                GtfsDate.fromString("20210104")));
     }
 
     @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
@@ -42,24 +42,29 @@ public class LocationTypeSingleEntityValidatorTest {
 
     @Test
     public void stationWithParentStation() {
-        GtfsStop.Builder builder = new GtfsStop.Builder()
+        GtfsStop.Builder builder =
+            new GtfsStop.Builder()
                 .setStopId("s0")
                 .setCsvRowNumber(1)
+                .setStopName("Stop 0")
                 .setLocationType(GtfsLocationType.STATION.getNumber());
 
         assertThat(validateStop(builder.build())).isEmpty();
 
         builder.setParentStation("parent");
         assertThat(validateStop(builder.build()))
-                .containsExactly(new StationWithParentStationNotice("s0", 1, "parent"));
+            .containsExactly(new StationWithParentStationNotice(
+                1, "s0", "Stop 0", "parent"));
     }
 
     @Test
     public void platformWithoutParentStation() {
         // A GTFS stop with platform_code field should have parent_station.
-        GtfsStop.Builder builder = new GtfsStop.Builder()
+        GtfsStop.Builder builder =
+            new GtfsStop.Builder()
                 .setStopId("s0")
                 .setCsvRowNumber(1)
+                .setStopName("Stop 0")
                 .setLocationType(GtfsLocationType.STOP.getNumber())
                 .setPlatformCode("1")
                 .setParentStation("parent");
@@ -68,7 +73,8 @@ public class LocationTypeSingleEntityValidatorTest {
 
         builder.setParentStation(null);
         assertThat(validateStop(builder.build()))
-                .containsExactly(new PlatformWithoutParentStationNotice("s0", 1));
+            .containsExactly(
+                new PlatformWithoutParentStationNotice(1, "s0", "Stop 0"));
 
         // A GTFS stop without platform_code may be an isolated stop and may have no parent_station.
         builder.setPlatformCode(null);
@@ -79,9 +85,11 @@ public class LocationTypeSingleEntityValidatorTest {
     public void locationWithoutParentStationNotice() {
         for (GtfsLocationType locationType : new GtfsLocationType[]{GtfsLocationType.ENTRANCE,
                 GtfsLocationType.GENERIC_NODE, GtfsLocationType.BOARDING_AREA}) {
-            GtfsStop.Builder builder = new GtfsStop.Builder()
+            GtfsStop.Builder builder =
+                new GtfsStop.Builder()
                     .setStopId("s0")
                     .setCsvRowNumber(1)
+                    .setStopName("Stop 0")
                     .setLocationType(locationType.getNumber())
                     .setParentStation("parent");
 
@@ -89,7 +97,8 @@ public class LocationTypeSingleEntityValidatorTest {
 
             builder.setParentStation(null);
             assertThat(validateStop(builder.build()))
-                    .containsExactly(new LocationWithoutParentStationNotice("s0", 1, locationType.getNumber()));
+                .containsExactly(new LocationWithoutParentStationNotice(
+                    1, "s0", "Stop 0", locationType.getNumber()));
         }
     }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
@@ -37,19 +37,21 @@ public class ParentLocationTypeValidatorTest {
     private List<Notice> validateChildAndParent(GtfsLocationType childType, GtfsLocationType parentType) {
         NoticeContainer noticeContainer = new NoticeContainer();
         ParentLocationTypeValidator validator = new ParentLocationTypeValidator();
-        validator.stopTable = GtfsStopTableContainer.forEntities(ImmutableList.of(
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(1)
-                        .setStopId("child")
-                        .setLocationType(childType.getNumber())
-                        .setParentStation("parent")
-                        .build(),
-                new GtfsStop.Builder()
-                        .setCsvRowNumber(2)
-                        .setStopId("parent")
-                        .setLocationType(parentType.getNumber())
-                        .build()),
-                noticeContainer);
+        validator.stopTable = GtfsStopTableContainer.forEntities(
+            ImmutableList.of(new GtfsStop.Builder()
+                                 .setCsvRowNumber(1)
+                                 .setStopId("child")
+                                 .setStopName("Child location")
+                                 .setLocationType(childType.getNumber())
+                                 .setParentStation("parent")
+                                 .build(),
+                             new GtfsStop.Builder()
+                                 .setCsvRowNumber(2)
+                                 .setStopId("parent")
+                                 .setStopName("Parent location")
+                                 .setLocationType(parentType.getNumber())
+                                 .build()),
+            noticeContainer);
         validator.validate(noticeContainer);
         return noticeContainer.getNotices();
     }
@@ -71,37 +73,49 @@ public class ParentLocationTypeValidatorTest {
     @Test
     public void stopParent() {
         assertThat(validateChildAndParent(GtfsLocationType.STOP, GtfsLocationType.STATION)).isEmpty();
-        assertThat(validateChildAndParent(GtfsLocationType.STOP, GtfsLocationType.ENTRANCE)).contains(
-                new WrongParentLocationTypeNotice("child", 1, GtfsLocationType.STOP.getNumber(),
-                        "parent", 2, GtfsLocationType.ENTRANCE.getNumber(),
-                        GtfsLocationType.STATION.getNumber()));
+        assertThat(validateChildAndParent(GtfsLocationType.STOP,
+                                          GtfsLocationType.ENTRANCE))
+            .contains(new WrongParentLocationTypeNotice(
+                1, "child", "Child location", GtfsLocationType.STOP.getNumber(),
+                2, "parent", "Parent location",
+                GtfsLocationType.ENTRANCE.getNumber(),
+                GtfsLocationType.STATION.getNumber()));
     }
 
     @Test
     public void entranceParent() {
         assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE, GtfsLocationType.STATION)).isEmpty();
-        assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE, GtfsLocationType.STOP)).contains(
-                new WrongParentLocationTypeNotice("child", 1, GtfsLocationType.ENTRANCE.getNumber(),
-                        "parent", 2, GtfsLocationType.STOP.getNumber(),
-                        GtfsLocationType.STATION.getNumber()));
+        assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE,
+                                          GtfsLocationType.STOP))
+            .contains(new WrongParentLocationTypeNotice(
+                1, "child", "Child location",
+                GtfsLocationType.ENTRANCE.getNumber(), 2, "parent",
+                "Parent location", GtfsLocationType.STOP.getNumber(),
+                GtfsLocationType.STATION.getNumber()));
     }
 
     @Test
     public void genericNodeParent() {
         assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE, GtfsLocationType.STATION)).isEmpty();
-        assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE, GtfsLocationType.STOP)).contains(
-                new WrongParentLocationTypeNotice("child", 1, GtfsLocationType.GENERIC_NODE.getNumber(),
-                        "parent", 2, GtfsLocationType.STOP.getNumber(),
-                        GtfsLocationType.STATION.getNumber()));
+        assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE,
+                                          GtfsLocationType.STOP))
+            .contains(new WrongParentLocationTypeNotice(
+                1, "child", "Child location",
+                GtfsLocationType.GENERIC_NODE.getNumber(), 2, "parent",
+                "Parent location", GtfsLocationType.STOP.getNumber(),
+                GtfsLocationType.STATION.getNumber()));
     }
 
     @Test
     public void boardingAreaParent() {
         assertThat(validateChildAndParent(GtfsLocationType.BOARDING_AREA, GtfsLocationType.STOP)).isEmpty();
-        assertThat(validateChildAndParent(GtfsLocationType.BOARDING_AREA, GtfsLocationType.STATION)).contains(
-                new WrongParentLocationTypeNotice("child", 1, GtfsLocationType.BOARDING_AREA.getNumber(),
-                        "parent", 2, GtfsLocationType.STATION.getNumber(),
-                        GtfsLocationType.STOP.getNumber()));
+        assertThat(validateChildAndParent(GtfsLocationType.BOARDING_AREA,
+                                          GtfsLocationType.STATION))
+            .contains(new WrongParentLocationTypeNotice(
+                1, "child", "Child location",
+                GtfsLocationType.BOARDING_AREA.getNumber(), 2, "parent",
+                "Parent location", GtfsLocationType.STATION.getNumber(),
+                GtfsLocationType.STOP.getNumber()));
     }
 
     @Test


### PR DESCRIPTION
Additional context will help to generate clearer messages in
human-readable validation report.

Parameter order in the constructors was unified:
* csvRowNumber
* stopId
* stopName
* locationType

Affected notices:

* BlockTripsWithOverlappingStopTimesNotice
* LocationWithoutParentStationNotice
* PlatformWithoutParentStationNotice
* StationWithParentStationNotice
* WrongParentLocationTypeNotice