### PR TITLE
fix: add system errors to notice container

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/GtfsInputCreationError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/GtfsInputCreationError.java
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
@@ -23,8 +22,8 @@ import com.google.common.collect.ImmutableMap;
  * Describes a runtime exception while creating a @code{GtfsInput}
  */
 public class GtfsInputCreationError extends SystemError {
-    public GtfsInputCreationError(String exceptionClassName,
-                                  String message) {
+
+    public GtfsInputCreationError(String exceptionClassName, String message) {
         super(ImmutableMap.of("exception", exceptionClassName, "message", message));
     }
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/GtfsInputCreationError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/GtfsInputCreationError.java
@@ -19,7 +19,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Describes a runtime exception while creating a @code{GtfsInput}
+ * Describes a runtime exception while creating a code{@GtfsInput}.
  */
 public class GtfsInputCreationError extends SystemError {
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/GtfsInputCreationError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/GtfsInputCreationError.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Describes a runtime exception while creating a @code{GtfsInput}
+ */
+public class GtfsInputCreationError extends SystemError {
+    public GtfsInputCreationError(String exceptionClassName,
+                                  String message) {
+        super(ImmutableMap.of("exception", exceptionClassName, "message", message));
+    }
+
+    @Override
+    public String getCode() {
+        return "runtime_exception_at_gtfs_input_creation";
+    }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
@@ -18,9 +18,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
 
-/**
- * This is related to Input and Output operations in the code.
- */
+/** This is related to Input and Output operations in the code. */
 public class IOError extends SystemError {
 
   public IOError(String message) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
@@ -19,16 +19,16 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Describes a runtime exception while creating a code{@GtfsInput}.
+ * This is related to Input and Output operations in the code.
  */
-public class GtfsInputCreationError extends SystemError {
+public class IOError extends SystemError {
 
-    public GtfsInputCreationError(String exceptionClassName, String message) {
-        super(ImmutableMap.of("exception", exceptionClassName, "message", message));
-    }
+  public IOError(String message) {
+    super(ImmutableMap.of("message", message));
+  }
 
-    @Override
-    public String getCode() {
-        return "runtime_exception_at_gtfs_input_creation";
-    }
+  @Override
+  public String getCode() {
+    return "io_exception";
+  }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
@@ -27,6 +27,6 @@ public class IOError extends SystemError {
 
   @Override
   public String getCode() {
-    return "io_exception";
+    return "io_error";
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
@@ -18,9 +18,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
 
-/**
- * Indicates that a string could not be parsed as a URI reference.
- */
+/** Indicates that a string could not be parsed as a URI reference. */
 public class URISyntaxError extends SystemError {
 
   public URISyntaxError(String message) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
@@ -27,6 +27,6 @@ public class URISyntaxError extends SystemError {
 
   @Override
   public String getCode() {
-    return "uri_syntax_exception";
+    return "uri_syntax_error";
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Indicates that a string could not be parsed as a URI reference.
+ */
+public class URISyntaxError extends SystemError {
+
+  public URISyntaxError(String message) {
+    super(ImmutableMap.of("message", message));
+  }
+
+  @Override
+  public String getCode() {
+    return "uri_syntax_exception";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -92,7 +92,9 @@ public class Main {
     System.out.println(feedContainer.tableTotals());
   }
 
-  /** Generates and exports reports for both validation notices and system errors reports */
+  /**
+   * Generates and exports reports for both validation notices and system errors reports.
+   */
   private static void exportReport(final String outputBase, final NoticeContainer noticeContainer) {
     new File(outputBase).mkdirs();
     try {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -81,7 +81,7 @@ public class Main {
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
       noticeContainer.addSystemError(new IOError(e.getMessage()));
     } catch (URISyntaxException e) {
-      logger.atSevere().withCause(e).log("Syntax error in URL");
+      logger.atSevere().withCause(e).log("Syntax error in URI");
       noticeContainer.addSystemError(new URISyntaxError(e.getMessage()));
     } catch (InterruptedException e) {
       logger.atSevere().withCause(e).log("Interrupted thread");

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -100,9 +100,7 @@ public class Main {
     System.out.println(feedContainer.tableTotals());
   }
 
-  /**
-   * Generates and exports reports for both validation notices and system errors reports.
-   */
+  /** Generates and exports reports for both validation notices and system errors reports. */
   private static void exportReport(final String outputBase, final NoticeContainer noticeContainer) {
     new File(outputBase).mkdirs();
     try {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -78,34 +78,31 @@ public class Main {
       }
     } catch (IOException | URISyntaxException | InterruptedException e) {
       noticeContainer.addSystemError(
-              new GtfsInputCreationError(e.getClass().getCanonicalName(), e.getMessage()));
-      generateAndExportReports(args, noticeContainer);
+          new GtfsInputCreationError(e.getClass().getCanonicalName(), e.getMessage()));
+      exportReport(args.getOutputBase(), noticeContainer);
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
       return;
     }
     feedContainer =
-            feedLoader.loadAndValidate(gtfsInput, feedName, validatorLoader, noticeContainer);
+        feedLoader.loadAndValidate(gtfsInput, feedName, validatorLoader, noticeContainer);
 
     // Output
-    generateAndExportReports(args, noticeContainer);
+    exportReport(args.getOutputBase(), noticeContainer);
     final long endNanos = System.nanoTime();
     System.out.printf("Validation took %.3f seconds%n", (endNanos - startNanos) / 1e9);
     System.out.println(feedContainer.tableTotals());
   }
 
-  /**
-   * Generates and exports reports for both validation notices and system errors reports
-   */
-  private static void generateAndExportReports(
-          final Arguments args, final NoticeContainer noticeContainer) {
-    new File(args.getOutputBase()).mkdirs();
+  /** Generates and exports reports for both validation notices and system errors reports */
+  private static void exportReport(final String outputBase, final NoticeContainer noticeContainer) {
+    new File(outputBase).mkdirs();
     try {
       Files.write(
-              Paths.get(args.getOutputBase(), "report.json"),
-              noticeContainer.exportValidationNotices().getBytes(StandardCharsets.UTF_8));
+          Paths.get(outputBase, "report.json"),
+          noticeContainer.exportValidationNotices().getBytes(StandardCharsets.UTF_8));
       Files.write(
-              Paths.get(args.getOutputBase(), "system_errors.json"),
-              noticeContainer.exportSystemErrors().getBytes(StandardCharsets.UTF_8));
+          Paths.get(outputBase, "system_errors.json"),
+          noticeContainer.exportSystemErrors().getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -19,13 +19,6 @@ package org.mobilitydata.gtfsvalidator.cli;
 import com.beust.jcommander.JCommander;
 import com.google.common.base.Strings;
 import com.google.common.flogger.FluentLogger;
-import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.GtfsInputCreationError;
@@ -33,6 +26,14 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 
 /** The main entry point for GTFS Validator CLI. */
 public class Main {
@@ -95,13 +96,15 @@ public class Main {
   /**
    * Generates and exports reports for both validation notices and system errors reports
    */
-  private static void generateAndExportReports(final Arguments args,
-                                               final NoticeContainer noticeContainer) {
+  private static void generateAndExportReports(
+          final Arguments args, final NoticeContainer noticeContainer) {
     new File(args.getOutputBase()).mkdirs();
     try {
-      Files.write(Paths.get(args.getOutputBase(), "report.json"),
+      Files.write(
+              Paths.get(args.getOutputBase(), "report.json"),
               noticeContainer.exportValidationNotices().getBytes(StandardCharsets.UTF_8));
-      Files.write(Paths.get(args.getOutputBase(), "system_errors.json"),
+      Files.write(
+              Paths.get(args.getOutputBase(), "system_errors.json"),
               noticeContainer.exportSystemErrors().getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -19,14 +19,6 @@ package org.mobilitydata.gtfsvalidator.cli;
 import com.beust.jcommander.JCommander;
 import com.google.common.base.Strings;
 import com.google.common.flogger.FluentLogger;
-import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
-import org.mobilitydata.gtfsvalidator.input.GtfsInput;
-import org.mobilitydata.gtfsvalidator.notice.GtfsInputCreationError;
-import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
-import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -34,6 +26,13 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
+import org.mobilitydata.gtfsvalidator.input.GtfsInput;
+import org.mobilitydata.gtfsvalidator.notice.GtfsInputCreationError;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
 /** The main entry point for GTFS Validator CLI. */
 public class Main {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -28,8 +28,10 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
-import org.mobilitydata.gtfsvalidator.notice.GtfsInputCreationError;
+import org.mobilitydata.gtfsvalidator.notice.IOError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ThreadInterruptedError;
+import org.mobilitydata.gtfsvalidator.notice.URISyntaxError;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
@@ -76,8 +78,14 @@ public class Main {
         gtfsInput = GtfsInput.createFromPath(Paths.get(args.getInput()));
       }
     } catch (IOException | URISyntaxException | InterruptedException e) {
-      noticeContainer.addSystemError(
-          new GtfsInputCreationError(e.getClass().getCanonicalName(), e.getMessage()));
+      if (e instanceof IOException) {
+        noticeContainer.addSystemError(new IOError(e.getMessage()));
+      }
+      if (e instanceof URISyntaxException) {
+        noticeContainer.addSystemError(new URISyntaxError(e.getMessage()));
+      } else {
+        noticeContainer.addSystemError(new ThreadInterruptedError(e.getMessage()));
+      }
       exportReport(args.getOutputBase(), noticeContainer);
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
       return;


### PR DESCRIPTION
closes #548

Duplicated #602

**Summary:**

https://github.com/MobilityData/gtfs-validator/pull/596 introduced the concept of system errors. 
Those need to be added to the noticeContainer in the main method. 
This PR suggests code to proceed.

**Expected behavior:** 

1. System errors should be added to the notice container
2. Reports should be generated and exported.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
