### PR TITLE
fix: update Route schema to require routes.route_type field

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsRouteSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsRouteSchema.java
@@ -27,44 +27,46 @@ import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 
+
 @GtfsTable("routes.txt")
 @Required
 public interface GtfsRouteSchema extends GtfsEntity {
-  @FieldType(FieldTypeEnum.ID)
-  @PrimaryKey
-  @Required
-  String routeId();
+    @FieldType(FieldTypeEnum.ID)
+    @PrimaryKey
+    @Required
+    String routeId();
 
-  @FieldType(FieldTypeEnum.ID)
-  @ForeignKey(table = "agency.txt", field = "agency_id")
-  @ConditionallyRequired
-  String agencyId();
+    @FieldType(FieldTypeEnum.ID)
+    @ForeignKey(table = "agency.txt", field = "agency_id")
+    @ConditionallyRequired
+    String agencyId();
 
-  @ConditionallyRequired
-  String routeShortName();
+    @ConditionallyRequired
+    String routeShortName();
 
-  @ConditionallyRequired
-  String routeLongName();
+    @ConditionallyRequired
+    String routeLongName();
 
-  String routeDesc();
+    String routeDesc();
 
-  GtfsRouteType routeType();
+    @Required
+    GtfsRouteType routeType();
 
-  @FieldType(FieldTypeEnum.URL)
-  String routeUrl();
+    @FieldType(FieldTypeEnum.URL)
+    String routeUrl();
 
-  @DefaultValue("FFFFFF")
-  GtfsColor routeColor();
+    @DefaultValue("FFFFFF")
+    GtfsColor routeColor();
 
-  @DefaultValue("000000")
-  GtfsColor routeTextColor();
+    @DefaultValue("000000")
+    GtfsColor routeTextColor();
 
-  @NonNegative
-  int routeSortOrder();
+    @NonNegative
+    int routeSortOrder();
 
-  @DefaultValue("1")
-  GtfsContinuousPickupDropOff continuousPickup();
+    @DefaultValue("1")
+    GtfsContinuousPickupDropOff continuousPickup();
 
-  @DefaultValue("1")
-  GtfsContinuousPickupDropOff continuousDropOff();
+    @DefaultValue("1")
+    GtfsContinuousPickupDropOff continuousDropOff();
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsRouteSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsRouteSchema.java
@@ -27,46 +27,45 @@ import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 
-
 @GtfsTable("routes.txt")
 @Required
 public interface GtfsRouteSchema extends GtfsEntity {
-    @FieldType(FieldTypeEnum.ID)
-    @PrimaryKey
-    @Required
-    String routeId();
+  @FieldType(FieldTypeEnum.ID)
+  @PrimaryKey
+  @Required
+  String routeId();
 
-    @FieldType(FieldTypeEnum.ID)
-    @ForeignKey(table = "agency.txt", field = "agency_id")
-    @ConditionallyRequired
-    String agencyId();
+  @FieldType(FieldTypeEnum.ID)
+  @ForeignKey(table = "agency.txt", field = "agency_id")
+  @ConditionallyRequired
+  String agencyId();
 
-    @ConditionallyRequired
-    String routeShortName();
+  @ConditionallyRequired
+  String routeShortName();
 
-    @ConditionallyRequired
-    String routeLongName();
+  @ConditionallyRequired
+  String routeLongName();
 
-    String routeDesc();
+  String routeDesc();
 
-    @Required
-    GtfsRouteType routeType();
+  @Required
+  GtfsRouteType routeType();
 
-    @FieldType(FieldTypeEnum.URL)
-    String routeUrl();
+  @FieldType(FieldTypeEnum.URL)
+  String routeUrl();
 
-    @DefaultValue("FFFFFF")
-    GtfsColor routeColor();
+  @DefaultValue("FFFFFF")
+  GtfsColor routeColor();
 
-    @DefaultValue("000000")
-    GtfsColor routeTextColor();
+  @DefaultValue("000000")
+  GtfsColor routeTextColor();
 
-    @NonNegative
-    int routeSortOrder();
+  @NonNegative
+  int routeSortOrder();
 
-    @DefaultValue("1")
-    GtfsContinuousPickupDropOff continuousPickup();
+  @DefaultValue("1")
+  GtfsContinuousPickupDropOff continuousPickup();
 
-    @DefaultValue("1")
-    GtfsContinuousPickupDropOff continuousDropOff();
+  @DefaultValue("1")
+  GtfsContinuousPickupDropOff continuousDropOff();
 }


### PR DESCRIPTION
closes #625 

**Summary:**

This PR provides support to require routes.route_type field

**Expected behavior:** 

When creating a `GtfsRoute` entity, if `routes.route_type` is missing, a `MissingRequiredField` should be generated and added to the `noticeContainer`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
