### PR TITLE
feat: verify unicity of routes.route_long_name and routes.route_short_name

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -71,8 +71,8 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                           | [W009](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W009)        	| Dataset should cover at least the next 30 days of service                       	|
 | [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [W010](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010)        	| `feed_end_date` should be provided if `feed_start_date` is provided             	|
 | [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [W011](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011)        	| `feed_start_date` should be provided if `feed_end_date` is provided             	|
-|                           | [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014)        	| Duplicate `routes.route_long_name`                                              	|
-|                           | [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015)        	| Duplicate `routes.route_short_name`                                             	|
+|[`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)| [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014)        	| Duplicate `routes.route_long_name`                                              	|
+|[`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)| [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015)        	| Duplicate `routes.route_short_name`                                             	|
 |                           | [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)        	| Duplicate combination of fields `route_long_name` and `routes.route_short_name` 	|
 
 ## Notices
@@ -274,3 +274,14 @@ Field `parent_station` must be empty when `location_type` is 2.
 
 #### References:
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
+
+### DuplicateRouteNameNotice
+
+All routes should have different `routes.route_long_name`. If routes have the same `routes.route_long_name`, they must be different routes serving different areas; and must not be different trips of the same route or different directions of the same route.
+Note that two routes can have the same `routes.route_long_name` if they do not belong to the same agency.
+
+All routes should have different `rouytes.route_short_name`. If routes have the same `routes.route_short_name`, they must be different routes serving different areas; and must not be different trips of the same route or different directions of the same route. 
+Note that two routes can have the same `routes.route_short_name` if they do not belong to the same agency.
+
+#### References:
+* [routes.txt specification](http://gtfs.org/reference/static/#routestxt)

--- a/RULES.md
+++ b/RULES.md
@@ -277,11 +277,13 @@ Field `parent_station` must be empty when `location_type` is 2.
 
 ### DuplicateRouteNameNotice
 
-All routes should have different `routes.route_long_name`. If routes have the same `routes.route_long_name`, they must be different routes serving different areas; and must not be different trips of the same route or different directions of the same route.
-Note that two routes can have the same `routes.route_long_name` if they do not belong to the same agency.
+All routes should have different routes.route_long_name - if two routes.route_long_name are the same, and the two routes belong to the same agency, a notice is generated.
 
-All routes should have different `rouytes.route_short_name`. If routes have the same `routes.route_short_name`, they must be different routes serving different areas; and must not be different trips of the same route or different directions of the same route. 
-Note that two routes can have the same `routes.route_short_name` if they do not belong to the same agency.
+Note that there may be valid cases where routes may have the same routes.route_long_name and this notice can be ignored. For example, routes may have the same routes.route_long_name if they serve difference areas. However, they must not be different trips of the same route or different directions of the same route - these cases should always have unique routes.route_long_name.
+
+All routes should have different routes.route_short_name - if two routes.route_short_name are the same, and the two routes belong to the same agency, a notice is generated.
+
+Note that there may be valid cases where routes may have the same routes.route_short_name and this notice can be ignored. For example, routes may have the same routes.route_short_name if they serve difference areas. However, they must not be different trips of the same route or different directions of the same route - these cases should always have unique routes.route_short_name.
 
 #### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateRouteNameNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateRouteNameNotice.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class DuplicateRouteNameNotice extends ValidationNotice {
+  public DuplicateRouteNameNotice(String duplicatedField, long csvRowNumber, String routeId) {
+    super(
+        ImmutableMap.of(
+            "duplicatedField", duplicatedField, "csvRowNumber", csvRowNumber, "routeId", routeId));
+  }
+
+  @Override
+  public String getCode() {
+    return "duplicate_route_name";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateRouteNameNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+
+/**
+ * Validates unicity of short and long name for all routes.
+ *
+ * <p>Generated notice:
+ *
+ * <ul>
+ *   <li>{@link DuplicateRouteNameNotice}
+ * </ul>
+ */
+@GtfsValidator
+public class DuplicateRouteNameValidator extends FileValidator {
+  @Inject GtfsRouteTableContainer routeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    final Map<String, GtfsRoute> routeByRouteLongName = new HashMap<>();
+    final Map<String, GtfsRoute> routeByShortName = new HashMap<>();
+    routeTable
+        .getEntities()
+        .forEach(
+            route -> {
+              if (route.hasRouteLongName()) {
+                if (routeByRouteLongName.containsKey(route.routeLongName())) {
+                  if (areRouteFromSameAgency(
+                      route.agencyId(),
+                      routeByRouteLongName.get(route.routeLongName()).agencyId())) {
+                    noticeContainer.addValidationNotice(
+                        new DuplicateRouteNameNotice(
+                            "route_long_name", route.csvRowNumber(), route.routeId()));
+                  }
+                } else {
+                  routeByRouteLongName.put(route.routeLongName(), route);
+                }
+              }
+              if (route.hasRouteShortName()) {
+                if (routeByShortName.containsKey(route.routeShortName())) {
+                  if (areRouteFromSameAgency(
+                      route.agencyId(), routeByShortName.get(route.routeShortName()).agencyId())) {
+                    noticeContainer.addValidationNotice(
+                        new DuplicateRouteNameNotice(
+                            "route_short_name", route.csvRowNumber(), route.routeId()));
+                  }
+                } else {
+                  routeByShortName.put(route.routeShortName(), route);
+                }
+              }
+            });
+  }
+
+  /**
+   * Determines if two routes are from the same agency
+   *
+   * @param routeAgencyId first agency_id
+   * @param otherRouteAgencyId second agency_id
+   * @return true if both agency ids are equals returns false otherwise.
+   */
+  private boolean areRouteFromSameAgency(
+      final String routeAgencyId, final String otherRouteAgencyId) {
+    return routeAgencyId.equals(otherRouteAgencyId);
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -40,15 +40,15 @@ public class DuplicateRouteNameValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    final Map<String, GtfsRoute> routeByRouteLongName = new HashMap<>();
-    final Map<String, GtfsRoute> routeByShortName = new HashMap<>();
+    final Map<String, GtfsRoute> routeByRouteLongName = new HashMap<>(routeTable.entityCount());
+    final Map<String, GtfsRoute> routeByShortName = new HashMap<>(routeTable.entityCount());
     routeTable
         .getEntities()
         .forEach(
             route -> {
               if (route.hasRouteLongName()) {
                 if (routeByRouteLongName.containsKey(route.routeLongName())) {
-                  if (areRouteFromSameAgency(
+                  if (areRoutesFromSameAgency(
                       route.agencyId(),
                       routeByRouteLongName.get(route.routeLongName()).agencyId())) {
                     noticeContainer.addValidationNotice(
@@ -61,7 +61,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
               }
               if (route.hasRouteShortName()) {
                 if (routeByShortName.containsKey(route.routeShortName())) {
-                  if (areRouteFromSameAgency(
+                  if (areRoutesFromSameAgency(
                       route.agencyId(), routeByShortName.get(route.routeShortName()).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
@@ -81,8 +81,8 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @param otherRouteAgencyId second agency_id
    * @return true if both agency ids are equals returns false otherwise.
    */
-  private boolean areRouteFromSameAgency(
+  private boolean areRoutesFromSameAgency(
       final String routeAgencyId, final String otherRouteAgencyId) {
-    return routeAgencyId.equals(otherRouteAgencyId);
+    return routeAgencyId.equalsIgnoreCase(otherRouteAgencyId);
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -1,0 +1,161 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateRouteNameNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+
+public class DuplicateRouteNameValidatorTest {
+
+  private static GtfsRouteTableContainer createRouteTable(
+      NoticeContainer noticeContainer, List<GtfsRoute> entities) {
+    return GtfsRouteTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  private GtfsRoute createRoute(
+      int csvRowNumber,
+      String routeId,
+      String agencyId,
+      String shortName,
+      String longName,
+      int routeType) {
+    return new GtfsRoute.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setRouteId(routeId)
+        .setAgencyId(agencyId)
+        .setRouteShortName(shortName)
+        .setRouteLongName(longName)
+        .setRouteType(routeType)
+        .build();
+  }
+
+  @Test
+  public void duplicateRouteLongNamesOfRoutesFromDifferentAgenciesShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
+    underTest.routeTable =
+        createRouteTable(
+            noticeContainer,
+            ImmutableList.of(
+                createRoute(
+                    2, "1st route id value", "agency id", "short name", "duplicate value", 2),
+                createRoute(
+                    4,
+                    "2nd route id value",
+                    "other agency id",
+                    "other short name",
+                    "duplicate value",
+                    3),
+                createRoute(8, "3rd route id value", null, "another one", "duplicate value", 3)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void duplicateRouteLongNamesOfRoutesFromSameAgencyShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
+    underTest.routeTable =
+        createRouteTable(
+            noticeContainer,
+            ImmutableList.of(
+                createRoute(
+                    2, "1st route id value", "agency id", "short name", "duplicate value", 2),
+                createRoute(
+                    4, "2nd route id value", "agency id", "other short name", "duplicate value", 3),
+                createRoute(
+                    8, "3rd route id value", "agency id", "another one", "duplicate value", 3)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactlyElementsIn(
+            List.of(
+                new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"),
+                new DuplicateRouteNameNotice("route_long_name", 8, "3rd route id value")));
+  }
+
+  @Test
+  public void duplicateRouteShortNamesOfRoutesFromDifferentAgenciesShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
+    underTest.routeTable =
+        createRouteTable(
+            noticeContainer,
+            ImmutableList.of(
+                createRoute(2, "1st route id value", null, "duplicate value", "1st long name", 2),
+                createRoute(
+                    4, "2nd route id value", "agency id", "duplicate value", "2nd long name", 3),
+                createRoute(
+                    8,
+                    "3rd route id value",
+                    "other agency id",
+                    "duplicate value",
+                    "3rd long name",
+                    3)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void duplicateRouteShortNamesOfRoutesFromSameAgencyShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
+    underTest.routeTable =
+        createRouteTable(
+            noticeContainer,
+            ImmutableList.of(
+                createRoute(
+                    2, "1st route id value", "agency id", "duplicate value", "1st long name", 2),
+                createRoute(
+                    4, "2nd route id value", "agency id", "duplicate value", "2nd long name", 3),
+                createRoute(
+                    8, "3rd route id value", "agency id", "duplicate value", "3rd long name", 3)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactlyElementsIn(
+            List.of(
+                new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
+                new DuplicateRouteNameNotice("route_short_name", 8, "3rd route id value")));
+    ;
+  }
+
+  @Test
+  public void uniqueRouteLongNameShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
+    underTest.routeTable =
+        createRouteTable(
+            noticeContainer,
+            ImmutableList.of(
+                createRoute(2, "1st route id value", "agency id", null, "1st value", 2),
+                createRoute(4, "2nd route id value", "another agency id", null, "2nd value", 3),
+                createRoute(8, "3rd route id value", "another one", null, "3rd value", 3)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void uniqueRouteShortNameShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
+    underTest.routeTable =
+        createRouteTable(
+            noticeContainer,
+            ImmutableList.of(
+                createRoute(2, "1st route id value", "agency id", "1st value", null, 2),
+                createRoute(4, "2nd route id value", "another agency id", "2nd value", null, 3),
+                createRoute(8, "3rd route id value", "another one", "3rd value", null, 3)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+}


### PR DESCRIPTION
closes #533
closes #534

**Summary:**

This PR provides code do implement the following validation rule:
- All routes should have different `routes.route_long_name`. If routes have the same `routes.route_long_name`, they must be different routes serving different areas; and must not be different trips of the same route or different directions of the same route.
Note that two routes can have the same `routes.route_long_name` if they do not belong to the same agency.

- All routes should have different `rouytes.route_short_name`. If routes have the same `routes.route_short_name`, they must be different routes serving different areas; and must not be different trips of the same route or different directions of the same route. 
Note that two routes can have the same `routes.route_short_name` if they do not belong to the same agency.

**Expected behavior:** 

- a notice should be generated for each route entity with duplicate `routes.route_long_name`
- a notice should be generated for each route entity with duplicate `routes.route_short_name`
- 
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
