### PR TITLE
fix: Support trivial enum that have a single value (#605)

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsAnnotationProcessor.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsAnnotationProcessor.java
@@ -83,6 +83,10 @@ public class GtfsAnnotationProcessor extends AbstractProcessor {
     for (TypeElement type : typesIn(annotatedElementsIn(roundEnv, GtfsEnumValues.class))) {
       enumDescriptors.add(analyser.analyzeGtfsEnumType(type));
     }
+    // Support enums that have a single value.
+    for (TypeElement type : typesIn(annotatedElementsIn(roundEnv, GtfsEnumValue.class))) {
+      enumDescriptors.add(analyser.analyzeGtfsEnumType(type));
+    }
     for (GtfsEnumDescriptor enumDescriptor : enumDescriptors) {
       writeJavaFile(new EnumGenerator(enumDescriptor).generateEnumJavaFile());
     }


### PR DESCRIPTION
Google has use cases for that.

This restores https://github.com/MobilityData/gtfs-validator/commit/dcbe2f33371a319ed1d7e0df7565e769928ffa46
that was partially reverted in https://github.com/MobilityData/gtfs-validator/pull/604
