### PR TITLE
fix: Change enum name to GtfsStopTimeTimepointEnum

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
@@ -71,5 +71,5 @@ public interface GtfsStopTimeSchema extends GtfsEntity {
   double shapeDistTraveled();
 
   @DefaultValue("1")
-  GtfsStopTimesTimepoint timepoint();
+  GtfsStopTimeTimepoint timepoint();
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeTimepointEnum.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeTimepointEnum.java
@@ -20,4 +20,4 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
 
 @GtfsEnumValue(name = "APPROXIMATE", value = 0)
 @GtfsEnumValue(name = "EXACT", value = 1)
-public interface GtfsStopTimesTimepointEnum {}
+public interface GtfsStopTimeTimepointEnum {}


### PR DESCRIPTION
Old name: GtfsStopTimesTimepointEnum
New name: GtfsStopTimeTimepointEnum

By convention, all table names should be in singular in schema
definition.
