### PR TITLE
feat: Support CSV files that start with UTF-8 BOM

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -18,11 +18,8 @@ package org.mobilitydata.gtfsvalidator.table;
 
 import com.google.common.flogger.FluentLogger;
 import com.google.common.reflect.ClassPath;
-import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -82,10 +79,6 @@ public class GtfsFeedLoader {
     }
   }
 
-  private static Reader createFileReader(InputStream stream) {
-    return new BufferedReader(new InputStreamReader(stream));
-  }
-
   public String listTableLoaders() {
     return String.join(" ", tableLoaders.keySet());
   }
@@ -112,11 +105,11 @@ public class GtfsFeedLoader {
       } else {
         loaderCallables.add(
             () -> {
-              Reader reader = createFileReader(gtfsInput.getFile(filename));
+              InputStream inputStream = gtfsInput.getFile(filename);
               NoticeContainer loaderNotices = new NoticeContainer();
               GtfsTableContainer tableContainer;
               try {
-                tableContainer = loader.load(reader, feedName, validatorLoader, loaderNotices);
+                tableContainer = loader.load(inputStream, feedName, validatorLoader, loaderNotices);
               } catch (RuntimeException e) {
                 // This handler should prevent ExecutionException for
                 // this thread. We catch an exception here for storing
@@ -129,7 +122,7 @@ public class GtfsFeedLoader {
                 // it as missing for continuing validation.
                 tableContainer = loader.loadMissingFile(validatorLoader, loaderNotices);
               } finally {
-                reader.close();
+                inputStream.close();
               }
               return new TableAndNoticeContainers(tableContainer, loaderNotices);
             });

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableLoader.java
@@ -16,7 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.table;
 
-import java.io.Reader;
+import java.io.InputStream;
 import java.util.Set;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -40,7 +40,7 @@ public abstract class GtfsTableLoader<T extends GtfsEntity> {
   public abstract Set<String> getRequiredColumnNames();
 
   public abstract GtfsTableContainer<T> load(
-      Reader reader,
+      InputStream inputStream,
       GtfsFeedName feedName,
       ValidatorLoader validatorLoader,
       NoticeContainer noticeContainer);

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvFileTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvFileTest.java
@@ -18,10 +18,13 @@ package org.mobilitydata.gtfsvalidator.parsing;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.primitives.Bytes;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
+import org.apache.commons.io.ByteOrderMark;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -29,23 +32,27 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CsvFileTest {
 
+  private static InputStream toInputStream(String s) {
+    return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+  }
+
   @Test
   public void emptyFile() throws IOException {
-    Reader reader = new StringReader("");
-    CsvFile csvFile = new CsvFile(reader, "stops.txt");
+    InputStream inputStream = toInputStream("");
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
 
     assertThat(csvFile.isEmpty()).isEqualTo(true);
     assertThat(csvFile.getColumnCount()).isEqualTo(0);
     assertThat(csvFile.getFileName()).isEqualTo("stops.txt");
     assertThat(csvFile.iterator().hasNext()).isEqualTo(false);
 
-    reader.close();
+    inputStream.close();
   }
 
   @Test
   public void headersOnlyFile() throws IOException {
-    Reader reader = new StringReader("stop_id,stop_name");
-    CsvFile csvFile = new CsvFile(reader, "stops.txt");
+    InputStream inputStream = toInputStream("stop_id,stop_name");
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
 
     assertThat(csvFile.isEmpty()).isEqualTo(false);
     assertThat(csvFile.getColumnCount()).isEqualTo(2);
@@ -54,15 +61,15 @@ public class CsvFileTest {
     assertThat(csvFile.getFileName()).isEqualTo("stops.txt");
     assertThat(csvFile.iterator().hasNext()).isEqualTo(false);
 
-    reader.close();
+    inputStream.close();
   }
 
   @Test
   public void fileWithEntities() throws IOException {
-    Reader reader =
-        new StringReader(
+    InputStream inputStream =
+        toInputStream(
             "stop_id,stop_name,stop_lat\n" + "s1,First stop,3.21\n" + "s2,Second stop,1.31\n");
-    CsvFile csvFile = new CsvFile(reader, "stops.txt");
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
 
     assertThat(csvFile.isEmpty()).isEqualTo(false);
     assertThat(csvFile.getColumnCount()).isEqualTo(3);
@@ -86,17 +93,17 @@ public class CsvFileTest {
 
     assertThat(iterator.hasNext()).isEqualTo(false);
 
-    reader.close();
+    inputStream.close();
   }
 
   @Test
   public void fileWithEntitiesWindows() throws IOException {
-    Reader reader =
-        new StringReader(
+    InputStream inputStream =
+        toInputStream(
             "stop_id,stop_name,stop_lat\r\n"
                 + "s1,First stop,3.21\r\n"
                 + "s2,Second stop,1.31\r\n");
-    CsvFile csvFile = new CsvFile(reader, "stops.txt");
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
 
     assertThat(csvFile.isEmpty()).isEqualTo(false);
     assertThat(csvFile.getColumnCount()).isEqualTo(3);
@@ -120,13 +127,13 @@ public class CsvFileTest {
 
     assertThat(iterator.hasNext()).isEqualTo(false);
 
-    reader.close();
+    inputStream.close();
   }
 
   @Test
   public void emptyValues() throws IOException {
-    Reader reader = new StringReader("col0,col1,col2\n" + "a,,\"\",b\n");
-    CsvFile csvFile = new CsvFile(reader, "stops.txt");
+    InputStream inputStream = toInputStream("col0,col1,col2\n" + "a,,\"\",b\n");
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
 
     Iterator<CsvRow> iterator = csvFile.iterator();
     assertThat(iterator.hasNext()).isEqualTo(true);
@@ -137,5 +144,35 @@ public class CsvFileTest {
     assertThat(row.asString(1)).isNull();
     assertThat(row.asString(2)).isNull();
     assertThat(row.asString(3)).isEqualTo("b");
+
+    inputStream.close();
+  }
+
+  @Test
+  public void fileWithNonAscii() throws IOException {
+    InputStream inputStream = toInputStream("stop_id,stop_name\n" + "s1,Первая остановка\n");
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    assertThat(csvFile.iterator().next().asString(1)).isEqualTo("Первая остановка");
+    inputStream.close();
+  }
+
+  @Test
+  public void fileWithBomUtf8() throws IOException {
+    InputStream inputStream =
+        new ByteArrayInputStream(
+            Bytes.concat(
+                ByteOrderMark.UTF_8.getBytes(),
+                ("stop_id,stop_name\n" + "s1,First stop\n").getBytes(StandardCharsets.UTF_8)));
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+
+    assertThat(csvFile.getColumnNames()).asList().containsExactly("stop_id", "stop_name");
+
+    Iterator<CsvRow> iterator = csvFile.iterator();
+    assertThat(iterator.hasNext()).isEqualTo(true);
+    CsvRow row = iterator.next();
+    assertThat(row.asString(0)).isEqualTo("s1");
+    assertThat(row.asString(1)).isEqualTo("First stop");
+
+    inputStream.close();
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvRowTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvRowTest.java
@@ -18,9 +18,10 @@ package org.mobilitydata.gtfsvalidator.parsing;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -28,13 +29,17 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class CsvRowTest {
 
+  private static InputStream toInputStream(String s) {
+    return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+  }
+
   @Test
   public void testCsvRowAllMethods() throws IOException {
-    Reader reader =
-        new StringReader(
+    InputStream inputStream =
+        toInputStream(
             "stop_id,stop_name,stop_lat\n" + "s1,First stop,3.21\n" + "s2,Second stop,1.31\n");
-    CsvFile csvFile = new CsvFile(reader, "stops.txt");
-    reader.close();
+    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    inputStream.close();
 
     String[] columnValues = {
       "stop_id",

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
@@ -18,9 +18,10 @@ package org.mobilitydata.gtfsvalidator.table;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,14 +34,20 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 public class GtfsLevelTableLoaderTest {
   private static final GtfsFeedName FEED_NAME = GtfsFeedName.parseString("au-sydney-buses");
 
+  private static InputStream toInputStream(String s) {
+    return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
+  }
+
   @Test
   public void validFile() throws IOException {
     ValidatorLoader validatorLoader = new ValidatorLoader();
-    Reader reader = new StringReader("level_id,level_name,level_index\n" + "level1,Ground,1\n");
+    InputStream inputStream =
+        toInputStream("level_id,level_name,level_index\n" + "level1,Ground,1\n");
     GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer =
-        (GtfsLevelTableContainer) loader.load(reader, FEED_NAME, validatorLoader, noticeContainer);
+        (GtfsLevelTableContainer)
+            loader.load(inputStream, FEED_NAME, validatorLoader, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(1);
@@ -50,35 +57,37 @@ public class GtfsLevelTableLoaderTest {
     assertThat(level.levelName()).isEqualTo("Ground");
     assertThat(level.levelIndex()).isEqualTo(1);
 
-    reader.close();
+    inputStream.close();
   }
 
   @Test
   public void missingRequiredField() throws IOException {
     ValidatorLoader validatorLoader = new ValidatorLoader();
-    Reader reader = new StringReader("level_id,level_name,level_index\n" + ",Ground,1\n");
+    InputStream inputStream = toInputStream("level_id,level_name,level_index\n" + ",Ground,1\n");
     GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer =
-        (GtfsLevelTableContainer) loader.load(reader, FEED_NAME, validatorLoader, noticeContainer);
+        (GtfsLevelTableContainer)
+            loader.load(inputStream, FEED_NAME, validatorLoader, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isNotEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(0);
-    reader.close();
+    inputStream.close();
   }
 
   @Test
   public void emptyFile() throws IOException {
     ValidatorLoader validatorLoader = new ValidatorLoader();
-    Reader reader = new StringReader("");
+    InputStream inputStream = toInputStream("");
     GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer =
-        (GtfsLevelTableContainer) loader.load(reader, FEED_NAME, validatorLoader, noticeContainer);
+        (GtfsLevelTableContainer)
+            loader.load(inputStream, FEED_NAME, validatorLoader, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isNotEmpty();
     assertThat(noticeContainer.getValidationNotices().get(0).getClass().getSimpleName())
         .isEqualTo("EmptyFileNotice");
-    reader.close();
+    inputStream.close();
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -32,7 +32,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
-import java.io.Reader;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -202,13 +202,14 @@ public class TableLoaderGenerator {
     MethodSpec.Builder method =
         MethodSpec.methodBuilder("load")
             .addModifiers(Modifier.PUBLIC)
-            .addParameter(Reader.class, "reader")
+            .addParameter(InputStream.class, "inputStream")
             .addParameter(GtfsFeedName.class, "feedName")
             .addParameter(ValidatorLoader.class, "validatorLoader")
             .addParameter(NoticeContainer.class, "noticeContainer")
             .returns(
                 ParameterizedTypeName.get(ClassName.get(GtfsTableContainer.class), gtfsEntityType))
-            .addStatement("$T csvFile = new $T(reader, FILENAME)", CsvFile.class, CsvFile.class)
+            .addStatement(
+                "$T csvFile = new $T(inputStream, FILENAME)", CsvFile.class, CsvFile.class)
             .beginControlFlow("if (csvFile.isEmpty())")
             .addStatement(
                 "noticeContainer.addValidationNotice(new $T(FILENAME))", EmptyFileNotice.class)


### PR DESCRIPTION
GTFS spec says:

Files should be encoded in UTF-8 to support all Unicode characters.
Files that include the Unicode byte-order mark (BOM) character are
acceptable. See http://unicode.org/faq/utf_bom.html#BOM for more
information on the BOM character and UTF-8.

The Unicode Standard permits the BOM in UTF-8, but does not require
or recommend its use. Byte order has no meaning in UTF-8, so its only
use in UTF-8 is to signal at the start that the text stream is
encoded in UTF-8, or that it was converted to UTF-8 from a stream that
contained an optional BOM.
