### PR TITLE
feat: check all trips are used in stop_times.txt

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -52,7 +52,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                          	| [E043](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E043)      	| Duplicated field                                                        	|
 |                          	| [E046](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E046)      	| Fast travel between stops in `stop_times.txt`                           	|
 |                          	| [E048](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E048)      	| `end_time` after `start_time` in `frequencies.txt`                      	|
-|                          	| [E050](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E050)      	| Trips must be used in `stop_times.txt`                                  	|
+|[`UnusedTripNotice`](#UnusedTripNotice)| [E050](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E050)      	| Trips must be used in `stop_times.txt`                                  	|
 |                          	| [E051](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E051)      	| Trips must have more than one stop to be usable                         	|
 |                          	| [E052](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E052)      	| Stop too far from trip shape                                            	|
 | [`OverlappingTripFrequenciesNotice`](#OverlappingTripFrequenciesNotice) | [E053](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E053)      	| Trip frequencies overlap                                                	|
@@ -274,3 +274,7 @@ Field `parent_station` must be empty when `location_type` is 2.
 
 #### References:
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
+
+### UnusedTripNotice
+
+Trips must be referred to at least once in `stop_times.txt`.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusedTripNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusedTripNotice.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class UnusedTripNotice extends ValidationNotice {
+  public UnusedTripNotice(String tripId, long csvRowNumber) {
+    super(
+        ImmutableMap.of(
+            "tripId", tripId,
+            "csvRowNumber", csvRowNumber));
+  }
+
+  @Override
+  public String getCode() {
+    return "unused_trip";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusedTripNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusedTripNotice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2020 Google LLC, MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusedTripNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusedTripNotice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC, MobilityData IO
+ * Copyright 2021 MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2020 Google LLC, MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -35,7 +35,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 @GtfsValidator
 public class TripUsageValidator extends FileValidator {
   @Inject GtfsTripTableContainer tripTable;
-
   @Inject GtfsStopTimeTableContainer stopTimeTable;
 
   @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC, MobilityData IO
+ * Copyright 2021 MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.UnusedShapeNotice;
+import org.mobilitydata.gtfsvalidator.notice.UnusedTripNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+/**
+ * Validates that every trip in "trips.txt" is used by some stop from "stop_times.txt"
+ *
+ * <p>Generated notice: {@link UnusedShapeNotice}.
+ */
+@GtfsValidator
+public class TripUsageValidator extends FileValidator {
+  @Inject GtfsTripTableContainer tripTable;
+
+  @Inject GtfsStopTimeTableContainer stopTimeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    // Do not report the same shape_id multiple times.
+    Set<String> reportedTrips = new HashSet<>();
+    for (GtfsTrip trip : tripTable.getEntities()) {
+      String tripId = trip.tripId();
+      if (reportedTrips.add(tripId) && stopTimeTable.byTripId(tripId).isEmpty()) {
+        noticeContainer.addValidationNotice(new UnusedTripNotice(tripId, trip.csvRowNumber()));
+      }
+    }
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -40,7 +40,7 @@ public class TripUsageValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    // Do not report the same shape_id multiple times.
+    // Do not report the same trip_id multiple times.
     Set<String> reportedTrips = new HashSet<>();
     for (GtfsTrip trip : tripTable.getEntities()) {
       String tripId = trip.tripId();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidatorTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.UnusedTripNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+public class TripUsageValidatorTest {
+
+  private static GtfsTripTableContainer createTripTable(
+      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
+    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsTrip createTrip(
+      long csvRowNumber, String routeId, String serviceId, String tripId) {
+    return new GtfsTrip.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setRouteId(routeId)
+        .setServiceId(serviceId)
+        .setTripId(tripId)
+        .build();
+  }
+
+  public static GtfsStopTime createStopTime(
+      long csvRowNumber, String tripId, String time, String stopId, int stopSequence) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setArrivalTime(GtfsTime.fromString(time))
+        .setDepartureTime(GtfsTime.fromString(time))
+        .setStopSequence(stopSequence)
+        .setStopId(stopId)
+        .build();
+  }
+
+  private static GtfsStopTimeTableContainer createStopTimeTable(
+      String[] tripIds, String[] stopIds, String[][] times, NoticeContainer noticeContainer) {
+    Preconditions.checkArgument(
+        tripIds.length == times.length, "tripIds.length must be equal to times.length");
+
+    ArrayList<GtfsStopTime> stopTimes = new ArrayList<>();
+    stopTimes.ensureCapacity(tripIds.length * stopIds.length);
+    for (int i = 0; i < tripIds.length; ++i) {
+      Preconditions.checkArgument(
+          stopIds.length == times[i].length, "stopIds.length must be equal to times[%d].length", i);
+      for (int j = 0; j < stopIds.length; ++j) {
+        stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i], times[i][j], stopIds[j], j));
+      }
+    }
+
+    return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+  }
+
+  @Test
+  public void allTripsUsedShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    TripUsageValidator underTest = new TripUsageValidator();
+
+    underTest.tripTable =
+        createTripTable(
+            noticeContainer,
+            ImmutableList.of(
+                createTrip(1, "route id value", "service id value", "t0"),
+                createTrip(3, "route id value", "service id value", "t1")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            new String[] {"t0", "t1"},
+            new String[] {"s0", "s1"},
+            new String[][] {
+              new String[] {"08:00:00", "09:00:00"}, new String[] {"10:00:00", "11:00:00"},
+            },
+            noticeContainer);
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void unusedTripShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    TripUsageValidator underTest = new TripUsageValidator();
+
+    underTest.tripTable =
+        createTripTable(
+            noticeContainer,
+            ImmutableList.of(
+                createTrip(1, "route id value", "service id value", "used trip id value"),
+                createTrip(3, "route id value", "service id value", "unused trip id value")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            new String[] {"used trip id value"},
+            new String[] {"s0", "s1"},
+            new String[][] {
+              new String[] {"08:00:00", "09:00:00"},
+            },
+            noticeContainer);
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new UnusedTripNotice("unused trip id value", 3));
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC, MobilityData IO
+ * Copyright 2021 MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
closes #519

**Summary:**

This PR implements a new validation rule: all trips must be used in stop_times.txt

**Expected behavior:** 

- trips that are not used in `stop_times.txt` should generate a notice
- trips that are used in `stop_times.txt` should not generate a notice

New notice: `UnusedTripNotice`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~