### PR TITLE
fix(NPE): check hasAgencyLang() before executing agencyLang() method

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
@@ -56,7 +56,12 @@ public class MatchingFeedAndAgencyLangValidator extends FileValidator {
     Set<String> agencyLangCollection = new HashSet<>();
     agencyTable
         .getEntities()
-        .forEach(agency -> agencyLangCollection.add(agency.agencyLang().getISO3Language()));
+        .forEach(
+            agency -> {
+              if (agency.hasAgencyLang()) {
+                agencyLangCollection.add(agency.agencyLang().getISO3Language());
+              }
+            });
     if (feedInfoFeedLang.equals(Locale.forLanguageTag("mul"))) {
       // If feed_lang is mul and there isn't more than one agency_lang, that's an error
       if (agencyLangCollection.size() <= 1) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidatorTest.java
@@ -180,20 +180,21 @@ public class MatchingFeedAndAgencyLangValidatorTest {
                 "eng", new HashSet<>(Arrays.asList("ita", "fra"))));
   }
 
-    @Test
-    public void mulFeedLandAndMoreThanOneAgencyShouldNotGenerateNotice() {
-      NoticeContainer noticeContainer = new NoticeContainer();
-      MatchingFeedAndAgencyLangValidator underTest = new MatchingFeedAndAgencyLangValidator();
-      underTest.agencyTable =
-          createAgencyTable(
-              noticeContainer,
-              ImmutableList.of(
-                  createAgency(2, "agency id value", Locale.ITALIAN),
-                  createAgency(3, "other agency id value", Locale.FRANCE)));
-      underTest.feedInfoTable =
-          createFeedInfoTable(noticeContainer, ImmutableList.of(createFeedInfo(2, Locale.forLanguageTag("mul"))));
-      underTest.validate(noticeContainer);
+  @Test
+  public void mulFeedLandAndMoreThanOneAgencyShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MatchingFeedAndAgencyLangValidator underTest = new MatchingFeedAndAgencyLangValidator();
+    underTest.agencyTable =
+        createAgencyTable(
+            noticeContainer,
+            ImmutableList.of(
+                createAgency(2, "agency id value", Locale.ITALIAN),
+                createAgency(3, "other agency id value", Locale.FRANCE)));
+    underTest.feedInfoTable =
+        createFeedInfoTable(
+            noticeContainer, ImmutableList.of(createFeedInfo(2, Locale.forLanguageTag("mul"))));
+    underTest.validate(noticeContainer);
 
-      assertThat(noticeContainer.getValidationNotices()).isEmpty();
-    }
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
 }


### PR DESCRIPTION
closes #594 

**Summary:**

This PR fixes an NPE thrown during langage verification

**Expected behavior:** 

No NPE should be thrown when `agency.agency_lang` is not provided while executing `MatchingFeedAndAgencyLangValidator` use case

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
