### PR TITLE
ci: Change auto-formatter to pull_request_target

### DIFF
--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -5,6 +5,10 @@ on:
     branches: [ master ]
     paths-ignore:
       - '**.md'
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
   pull_request_target:
     branches: [ master ]
     paths-ignore:
@@ -14,8 +18,13 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name != 'pull_request_target'
+      - if: github.event_name != 'pull_request_target' && github.event_name != 'pull_request'
         uses: actions/checkout@v2
+      - if: github.event_name == 'pull_request'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: axel-op/googlejavaformat-action@v3
       - if: github.event_name == 'pull_request_target'
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -1,0 +1,23 @@
+name: Format code
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+  pull_request_target:
+    branches: [ master ]
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - if: github.event_name != 'pull_request_target'
+        uses: actions/checkout@v2
+      - if: github.event_name == 'pull_request_target'
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request_target.head.ref }}
+      - uses: axel-op/googlejavaformat-action@v3

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -13,16 +13,6 @@ on:
     types: [ prereleased, released ]
 
 jobs:
-  formatting:
-    runs-on: ubuntu-latest
-    steps:
-      - if: github.event_name != 'pull_request'
-        uses: actions/checkout@v2
-      - if: github.event_name == 'pull_request'
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - uses: axel-op/googlejavaformat-action@v3
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
**Summary:**

Hopefully this should allow pushes of format commits on PRs from forks (to be tested after merge to master). See https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/.

Also move workflow to it's own file.

Hopefully closes https://github.com/MobilityData/gtfs-validator/issues/615.