### PR TITLE
feat: validate time fields for trips edges

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -50,7 +50,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                          	| [E039](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E039)      	| `feed_start_date` after `feed_end_date`                                 	|
 |                          	| [E040](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E040)      	| Dataset should be valid for at least the next 7 days                    	|
 |                          	| [E043](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E043)      	| Duplicated field                                                        	|
-|[`MissingTripEdgeNotice`](#MissingTripEdgeNotice) | [E044](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E044)      	| Missing trip edge `arrival_time` and `departure_time` |
+|[`MissingTripEdgeNotice`](#MissingTripEdgeNotice) | [E044](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E044)      	| Missing trip edge `arrival_time` or `departure_time` |
 |                          	| [E046](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E046)      	| Fast travel between stops in `stop_times.txt`                           	|
 |                          	| [E048](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E048)      	| `end_time` after `start_time` in `frequencies.txt`                      	|
 |[`UnusedTripNotice`](#UnusedTripNotice)| [E050](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E050)      	| Trips must be used in `stop_times.txt`                                  	|
@@ -298,4 +298,4 @@ Trips must be referred to at least once in `stop_times.txt`.
 First and last stop of a trip must define both `arrival_time` and `departure_time` fields.
 
 #### References:
-* [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
+* [stop_times.txt specification](http://gtfs.org/reference/static/#stpo_timestxt)

--- a/RULES.md
+++ b/RULES.md
@@ -50,6 +50,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                          	| [E039](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E039)      	| `feed_start_date` after `feed_end_date`                                 	|
 |                          	| [E040](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E040)      	| Dataset should be valid for at least the next 7 days                    	|
 |                          	| [E043](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E043)      	| Duplicated field                                                        	|
+|[`MissingTripEdgeNotice`](#MissingTripEdgeNotice) | [E044](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E044)      	| Missing trip edge `arrival_time` and `departure_time` |
 |                          	| [E046](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E046)      	| Fast travel between stops in `stop_times.txt`                           	|
 |                          	| [E048](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E048)      	| `end_time` after `start_time` in `frequencies.txt`                      	|
 |                          	| [E050](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E050)      	| Trips must be used in `stop_times.txt`                                  	|
@@ -284,6 +285,13 @@ Note that there may be valid cases where routes may have the same routes.route_l
 All routes should have different routes.route_short_name - if two routes.route_short_name are the same, and the two routes belong to the same agency, a notice is generated.
 
 Note that there may be valid cases where routes may have the same routes.route_short_name and this notice can be ignored. For example, routes may have the same routes.route_short_name if they serve difference areas. However, they must not be different trips of the same route or different directions of the same route - these cases should always have unique routes.route_short_name.
+
+#### References:
+* [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
+
+### MissingTripEdgeNotice
+
+First and last stop of a trip must define both `arrival_time` and `departure_time` fields.
 
 #### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingTripEdgeNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingTripEdgeNotice.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MissingTripEdgeNotice extends ValidationNotice {
+  public MissingTripEdgeNotice(
+      long csvRowNumber, int stopSequence, String tripId, String specifiedField) {
+    super(
+        ImmutableMap.of(
+            "csvRowNumber", csvRowNumber,
+            "stopSequence", stopSequence,
+            "tripId", tripId,
+            "specifiedField", specifiedField));
+  }
+
+  @Override
+  public String getCode() {
+    return "missing_trip_edge_arrival_time_departure_time";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.List;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.MissingTripEdgeNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+/**
+ * Validates: the first and last stop times (when ordering by `stop_sequence` value) of a trip
+ * define a value for both `stop_times.departure_time` and `stop_times.arrival_times` fields.
+ *
+ * <p>Generated notice: {@link MissingTripEdgeNotice}.
+ */
+@GtfsValidator
+public class MissingTripEdgeValidator extends FileValidator {
+  @Inject GtfsTripTableContainer tripTable;
+  @Inject GtfsStopTimeTableContainer stopTimeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    tripTable
+        .getEntities()
+        .forEach(
+            trip -> {
+              List<GtfsStopTime> stopTimesForTrip = stopTimeTable.byTripId(trip.tripId());
+              if (!stopTimesForTrip.isEmpty()) {
+                GtfsStopTime tripFirstStop = stopTimesForTrip.get(0);
+                GtfsStopTime tripLastStop = stopTimesForTrip.get(stopTimesForTrip.size() - 1);
+                if (!tripFirstStop.hasArrivalTime()) {
+                  noticeContainer.addValidationNotice(
+                      new MissingTripEdgeNotice(
+                          tripFirstStop.csvRowNumber(),
+                          tripFirstStop.stopSequence(),
+                          trip.tripId(),
+                          "arrival_time"));
+                }
+                if (!tripFirstStop.hasDepartureTime()) {
+                  noticeContainer.addValidationNotice(
+                      new MissingTripEdgeNotice(
+                          tripFirstStop.csvRowNumber(),
+                          tripFirstStop.stopSequence(),
+                          trip.tripId(),
+                          "departure_time"));
+                }
+                if (!tripLastStop.hasArrivalTime()) {
+                  noticeContainer.addValidationNotice(
+                      new MissingTripEdgeNotice(
+                          tripLastStop.csvRowNumber(),
+                          tripLastStop.stopSequence(),
+                          trip.tripId(),
+                          "arrival_time"));
+                }
+                if (!tripLastStop.hasDepartureTime()) {
+                  noticeContainer.addValidationNotice(
+                      new MissingTripEdgeNotice(
+                          tripLastStop.csvRowNumber(),
+                          tripLastStop.stopSequence(),
+                          trip.tripId(),
+                          "departure_time"));
+                }
+              }
+            });
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -43,41 +43,42 @@ public class MissingTripEdgeValidator extends FileValidator {
         .forEach(
             trip -> {
               List<GtfsStopTime> stopTimesForTrip = stopTimeTable.byTripId(trip.tripId());
-              if (!stopTimesForTrip.isEmpty()) {
-                GtfsStopTime tripFirstStop = stopTimesForTrip.get(0);
-                GtfsStopTime tripLastStop = stopTimesForTrip.get(stopTimesForTrip.size() - 1);
-                if (!tripFirstStop.hasArrivalTime()) {
-                  noticeContainer.addValidationNotice(
-                      new MissingTripEdgeNotice(
-                          tripFirstStop.csvRowNumber(),
-                          tripFirstStop.stopSequence(),
-                          trip.tripId(),
-                          "arrival_time"));
-                }
-                if (!tripFirstStop.hasDepartureTime()) {
-                  noticeContainer.addValidationNotice(
-                      new MissingTripEdgeNotice(
-                          tripFirstStop.csvRowNumber(),
-                          tripFirstStop.stopSequence(),
-                          trip.tripId(),
-                          "departure_time"));
-                }
-                if (!tripLastStop.hasArrivalTime()) {
-                  noticeContainer.addValidationNotice(
-                      new MissingTripEdgeNotice(
-                          tripLastStop.csvRowNumber(),
-                          tripLastStop.stopSequence(),
-                          trip.tripId(),
-                          "arrival_time"));
-                }
-                if (!tripLastStop.hasDepartureTime()) {
-                  noticeContainer.addValidationNotice(
-                      new MissingTripEdgeNotice(
-                          tripLastStop.csvRowNumber(),
-                          tripLastStop.stopSequence(),
-                          trip.tripId(),
-                          "departure_time"));
-                }
+              if (stopTimesForTrip.isEmpty()) {
+                return;
+              }
+              GtfsStopTime tripFirstStop = stopTimesForTrip.get(0);
+              GtfsStopTime tripLastStop = stopTimesForTrip.get(stopTimesForTrip.size() - 1);
+              if (!tripFirstStop.hasArrivalTime()) {
+                noticeContainer.addValidationNotice(
+                    new MissingTripEdgeNotice(
+                        tripFirstStop.csvRowNumber(),
+                        tripFirstStop.stopSequence(),
+                        trip.tripId(),
+                        "arrival_time"));
+              }
+              if (!tripFirstStop.hasDepartureTime()) {
+                noticeContainer.addValidationNotice(
+                    new MissingTripEdgeNotice(
+                        tripFirstStop.csvRowNumber(),
+                        tripFirstStop.stopSequence(),
+                        trip.tripId(),
+                        "departure_time"));
+              }
+              if (!tripLastStop.hasArrivalTime()) {
+                noticeContainer.addValidationNotice(
+                    new MissingTripEdgeNotice(
+                        tripLastStop.csvRowNumber(),
+                        tripLastStop.stopSequence(),
+                        trip.tripId(),
+                        "arrival_time"));
+              }
+              if (!tripLastStop.hasDepartureTime()) {
+                noticeContainer.addValidationNotice(
+                    new MissingTripEdgeNotice(
+                        tripLastStop.csvRowNumber(),
+                        tripLastStop.stopSequence(),
+                        trip.tripId(),
+                        "departure_time"));
               }
             });
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.MissingTripEdgeNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+public class MissingTripEdgeValidatorTest {
+  public static GtfsStopTime createStopTime(
+      long csvRowNumber,
+      String tripId,
+      GtfsTime arrivalTime,
+      GtfsTime departureTime,
+      int stopSequence) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setArrivalTime(arrivalTime)
+        .setDepartureTime(departureTime)
+        .setStopSequence(stopSequence)
+        .setStopId("stop id")
+        .build();
+  }
+
+  public static GtfsTrip createTrip(long csvRowNumber, String tripId) {
+    return new GtfsTrip.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setRouteId("route id value")
+        .setTripId(tripId)
+        .setServiceId("service id value")
+        .build();
+  }
+
+  private static GtfsTripTableContainer createTripTable(
+      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
+    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  private static GtfsStopTimeTableContainer createStopTimeTable(
+      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
+    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  @Test
+  public void tripWithFirstStopMissingArrivalTimeShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
+    underTest.tripTable =
+        createTripTable(noticeContainer, ImmutableList.of(createTrip(3, "trip id value")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(2, "trip id value", null, GtfsTime.fromSecondsSinceMidnight(23), 1),
+                createStopTime(4, "trip id value", null, null, 2),
+                createStopTime(5, "trip id value", null, null, 3),
+                createStopTime(
+                    3,
+                    "trip id value",
+                    GtfsTime.fromSecondsSinceMidnight(28),
+                    GtfsTime.fromSecondsSinceMidnight(35),
+                    4)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingTripEdgeNotice(2, 1, "trip id value", "arrival_time"));
+  }
+
+  @Test
+  public void tripWithFirstStopMissingDepartureTimeShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
+    underTest.tripTable =
+        createTripTable(noticeContainer, ImmutableList.of(createTrip(3, "trip id value")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(2, "trip id value", GtfsTime.fromSecondsSinceMidnight(23), null, 1),
+                createStopTime(4, "trip id value", null, null, 2),
+                createStopTime(5, "trip id value", null, null, 3),
+                createStopTime(
+                    3,
+                    "trip id value",
+                    GtfsTime.fromSecondsSinceMidnight(28),
+                    GtfsTime.fromSecondsSinceMidnight(35),
+                    5)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingTripEdgeNotice(2, 1, "trip id value", "departure_time"));
+  }
+
+  @Test
+  public void tripWithLastStopMissingArrivalTimeShouldGenerateNotices() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
+    underTest.tripTable =
+        createTripTable(noticeContainer, ImmutableList.of(createTrip(3, "trip id value")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(
+                    2,
+                    "trip id value",
+                    GtfsTime.fromSecondsSinceMidnight(23),
+                    GtfsTime.fromSecondsSinceMidnight(46),
+                    1),
+                createStopTime(4, "trip id value", null, null, 2),
+                createStopTime(5, "trip id value", null, null, 3),
+                createStopTime(
+                    10, "trip id value", null, GtfsTime.fromSecondsSinceMidnight(456), 5)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingTripEdgeNotice(10, 5, "trip id value", "arrival_time"));
+  }
+
+  @Test
+  public void tripWithLastStopMissingDepartureTimeShouldGenerateNotices() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
+    underTest.tripTable =
+        createTripTable(noticeContainer, ImmutableList.of(createTrip(3, "trip id value")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(
+                    2,
+                    "trip id value",
+                    GtfsTime.fromSecondsSinceMidnight(23),
+                    GtfsTime.fromSecondsSinceMidnight(46),
+                    1),
+                createStopTime(4, "trip id value", null, null, 2),
+                createStopTime(5, "trip id value", null, null, 3),
+                createStopTime(
+                    10, "trip id value", GtfsTime.fromSecondsSinceMidnight(456), null, 5)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingTripEdgeNotice(10, 5, "trip id value", "departure_time"));
+  }
+
+  @Test
+  public void tripWithValidEdgesShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
+    underTest.tripTable =
+        createTripTable(noticeContainer, ImmutableList.of(createTrip(3, "trip id value")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(
+                    2,
+                    "trip id value",
+                    GtfsTime.fromSecondsSinceMidnight(23),
+                    GtfsTime.fromSecondsSinceMidnight(46),
+                    1),
+                createStopTime(4, "trip id value", null, null, 2),
+                createStopTime(5, "trip id value", null, null, 3),
+                createStopTime(
+                    10,
+                    "trip id value",
+                    GtfsTime.fromSecondsSinceMidnight(456),
+                    GtfsTime.fromSecondsSinceMidnight(3556467),
+                    4)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
@@ -120,7 +120,12 @@ public class MissingTripEdgeValidatorTest {
     NoticeContainer noticeContainer = new NoticeContainer();
     MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
     underTest.tripTable =
-        createTripTable(noticeContainer, ImmutableList.of(createTrip(3, "trip id value")));
+        createTripTable(
+            noticeContainer,
+            ImmutableList.of(
+                createTrip(2, "some id value"),
+                createTrip(3, "trip id value"),
+                createTrip(2, "another id value")));
     underTest.stopTimeTable =
         createStopTimeTable(
             noticeContainer,


### PR DESCRIPTION
closes #516 

**Summary:**

This PR implements a new valdiation rule: "First and last stop of a trip must define both `arrival_time` and `departure_time` fields".

**Expected behavior:** 

- a notice should be generated if a trip's first stop does not have value for `arrival_time` field
- a notice should be generated if a trip's first stop does not have value for `departure_time` field
- a notice should be generated if a trip's last stop does not have value for `arrival_time` field
- a notice should be generated if a trip's last stop does not have value for `departure_time` field

New notice: `MissingTripEdgeNotice`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
