### PR TITLE
feat: Missing both calendar_dates.txt and calendar.txt files

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -58,7 +58,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                          	| [E052](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E052)      	| Stop too far from trip shape                                            	|
 | [`OverlappingTripFrequenciesNotice`](#OverlappingTripFrequenciesNotice) | [E053](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E053)      	| Trip frequencies overlap                                                	|
 |                          	| [E054](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E054)      	| Block trips must not have overlapping stop times                        	|
-|                          	| [E056](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E056)      	| Missing `calendar_dates.txt` and `calendar.txt` files                   	|
+|[`MissingCalendarAndCalendarDateFilesNotice`](#MissingCalendarAndCalendarDateFilesNotice)| [E056](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E056)      	| Missing `calendar_dates.txt` and `calendar.txt` files                   	|
 |                          	| [E057](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E057)      	| Decreasing `shape_dist_traveled` in `stop_times.txt`| 
 |                          	| [E059](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E059)      	| GTFS dataset too big                                                    	|
 |                          	| [E060](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E060)      	| Fatal internal error -- please report                                   	|
@@ -307,3 +307,7 @@ First and last stop of a trip must define both `arrival_time` and `departure_tim
 
 #### References:
 * [stop_times.txt specification](http://gtfs.org/reference/static/#stpo_timestxt)
+
+### MissingCalendarAndCalendarDateFilesNotice
+
+Both files calendar_dates.txt and calendar.txt are missing from the GTFS archive. At least one of the files must be provided.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingCalendarAndCalendarDateFilesNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingCalendarAndCalendarDateFilesNotice.java
@@ -19,8 +19,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Short name of a route is too long (more than 12 characters,
- * https://gtfs.org/best-practices/#routestxt).
+ * GTFS files `calendar.txt` and `calendar_dates.txt` cannot be missing from the GTFS archive.
  */
 public class MissingCalendarAndCalendarDateFilesNotice extends ValidationNotice {
   public MissingCalendarAndCalendarDateFilesNotice() {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingCalendarAndCalendarDateFilesNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingCalendarAndCalendarDateFilesNotice.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Short name of a route is too long (more than 12 characters,
+ * https://gtfs.org/best-practices/#routestxt).
+ */
+public class MissingCalendarAndCalendarDateFilesNotice extends ValidationNotice {
+  public MissingCalendarAndCalendarDateFilesNotice() {
+    super(ImmutableMap.of());
+  }
+
+  @Override
+  public String getCode() {
+    return "missing_calendar_and_calendar_date_files";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidator.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.MissingCalendarAndCalendarDateFilesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+
+/**
+ * Validates at least one of the following files is provided: `calendar.txt` and
+ * `calendar_dates.txt`.
+ *
+ * <p>Generated notices:
+ *
+ * <ul>
+ *   <li>{@link MissingCalendarAndCalendarDateFilesNotice}.
+ * </ul>
+ */
+@GtfsValidator
+public class MissingCalendarAndCalendarDateValidator extends FileValidator {
+  @Inject GtfsCalendarTableContainer calendarTable;
+  @Inject GtfsCalendarDateTableContainer calendarDateTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    if (calendarTable.isMissingFile() && calendarDateTable.isMissingFile()) {
+      noticeContainer.addValidationNotice(new MissingCalendarAndCalendarDateFilesNotice());
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidatorTest.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.MissingCalendarAndCalendarDateFilesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
+
+public class MissingCalendarAndCalendarDateValidatorTest {
+  static final Set<DayOfWeek> weekDays =
+      ImmutableSet.of(
+          DayOfWeek.MONDAY,
+          DayOfWeek.TUESDAY,
+          DayOfWeek.WEDNESDAY,
+          DayOfWeek.THURSDAY,
+          DayOfWeek.FRIDAY);
+
+  private static GtfsCalendarTableContainer createCalendarTable(
+      NoticeContainer noticeContainer, List<GtfsCalendar> entities) {
+    return GtfsCalendarTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsCalendarDate createCalendarDate(
+      long csvRowNumber, String serviceId, GtfsDate date, int exceptionType) {
+    return new GtfsCalendarDate.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setServiceId(serviceId)
+        .setDate(date)
+        .setExceptionType(exceptionType)
+        .build();
+  }
+
+  private static GtfsCalendarDateTableContainer createCalendarDateTable(
+      NoticeContainer noticeContainer, List<GtfsCalendarDate> entities) {
+    return GtfsCalendarDateTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  @Test
+  public void bothFilesProvidedShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingCalendarAndCalendarDateValidator underTest =
+        new MissingCalendarAndCalendarDateValidator();
+    underTest.calendarTable =
+        createCalendarTable(
+            noticeContainer,
+            ImmutableList.of(
+                CalendarUtilTest.createGtfsCalendar(
+                    "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 10), weekDays)));
+    underTest.calendarDateTable =
+        createCalendarDateTable(
+            noticeContainer,
+            ImmutableList.of(createCalendarDate(2, "WEEK", GtfsDate.fromEpochDay(24354), 2)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void calendarOnlyProvidedShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingCalendarAndCalendarDateValidator underTest =
+        new MissingCalendarAndCalendarDateValidator();
+    underTest.calendarTable =
+        createCalendarTable(
+            noticeContainer,
+            ImmutableList.of(
+                CalendarUtilTest.createGtfsCalendar(
+                    "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 10), weekDays)));
+    underTest.calendarDateTable = createCalendarDateTable(noticeContainer, ImmutableList.of());
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void calendarDateOnlyProvidedShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingCalendarAndCalendarDateValidator underTest =
+        new MissingCalendarAndCalendarDateValidator();
+    underTest.calendarTable = createCalendarTable(noticeContainer, ImmutableList.of());
+    underTest.calendarDateTable =
+        createCalendarDateTable(
+            noticeContainer,
+            ImmutableList.of(createCalendarDate(2, "WEEK", GtfsDate.fromEpochDay(24354), 2)));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void bothMissingFilesShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    MissingCalendarAndCalendarDateValidator underTest =
+        new MissingCalendarAndCalendarDateValidator();
+    underTest.calendarTable = GtfsCalendarTableContainer.forMissingFile();
+    underTest.calendarDateTable = GtfsCalendarDateTableContainer.forMissingFile();
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingCalendarAndCalendarDateFilesNotice());
+  }
+}


### PR DESCRIPTION
closes #525

**Summary:**

This PR implements a new validation rule: Missing both calendar_dates.txt and calendar.txt files
**Expected behavior:** 

- a notice should be generated when both `calendar.txt` and `calendar_dates.txt` files are missing
-  no notice should be generated if at least one of said files is provided in the GTFS archive.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
