### PR TITLE
feat: Unusable trip

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -54,7 +54,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                          	| [E046](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E046)      	| Fast travel between stops in `stop_times.txt`                           	|
 |                          	| [E048](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E048)      	| `end_time` after `start_time` in `frequencies.txt`                      	|
 |[`UnusedTripNotice`](#UnusedTripNotice)| [E050](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E050)      	| Trips must be used in `stop_times.txt`                                  	|
-|                          	| [E051](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E051)      	| Trips must have more than one stop to be usable                         	|
+|[`UnusableTripNotice`](#UnusableTripNotice)| [E051](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E051)      	| Trips must have more than one stop to be usable                         	|
 |                          	| [E052](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E052)      	| Stop too far from trip shape                                            	|
 | [`OverlappingTripFrequenciesNotice`](#OverlappingTripFrequenciesNotice) | [E053](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E053)      	| Trip frequencies overlap                                                	|
 |                          	| [E054](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E054)      	| Block trips must not have overlapping stop times                        	|
@@ -307,3 +307,7 @@ First and last stop of a trip must define both `arrival_time` and `departure_tim
 
 #### References:
 * [stop_times.txt specification](http://gtfs.org/reference/static/#stpo_timestxt)
+
+### UnusableTripNotice
+
+A trip must visit more than one stop in stop_times.txt to be usable by passengers for boarding and alighting.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusableTripNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnusableTripNotice.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class UnusableTripNotice extends ValidationNotice {
+  public UnusableTripNotice(long csvRowNumber, String tripId) {
+    super(
+        ImmutableMap.of(
+            "csvRowNumber", csvRowNumber,
+            "tripId", tripId));
+  }
+
+  @Override
+  public String getCode() {
+    return "unusable_trip";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.UnusableTripNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+/**
+ * Validates that every trip in "trips.txt" is used by at least two stops from "stop_times.txt"
+ *
+ * <p>Generated notice: {@link UnusableTripNotice}.
+ */
+@GtfsValidator
+public class TripUsabilityValidator extends FileValidator {
+  @Inject GtfsTripTableContainer tripTable;
+  @Inject GtfsStopTimeTableContainer stopTimeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    for (GtfsTrip trip : tripTable.getEntities()) {
+      String tripId = trip.tripId();
+      if (stopTimeTable.byTripId(tripId).size() <= 1) {
+        noticeContainer.addValidationNotice(new UnusableTripNotice(trip.csvRowNumber(), tripId));
+      }
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidatorTest.java
@@ -1,0 +1,112 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.UnusableTripNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+public class TripUsabilityValidatorTest {
+  private static GtfsTripTableContainer createTripTable(
+      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
+    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsTrip createTrip(
+      long csvRowNumber, String routeId, String serviceId, String tripId) {
+    return new GtfsTrip.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setRouteId(routeId)
+        .setServiceId(serviceId)
+        .setTripId(tripId)
+        .build();
+  }
+
+  public static GtfsStopTime createStopTime(
+      long csvRowNumber, String tripId, String time, String stopId, int stopSequence) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setArrivalTime(GtfsTime.fromString(time))
+        .setDepartureTime(GtfsTime.fromString(time))
+        .setStopSequence(stopSequence)
+        .setStopId(stopId)
+        .build();
+  }
+
+  private static GtfsStopTimeTableContainer createStopTimeTable(
+      String[] tripIds, String[] stopIds, String[][] times, NoticeContainer noticeContainer) {
+    Preconditions.checkArgument(
+        tripIds.length == times.length, "tripIds.length must be equal to times.length");
+
+    ArrayList<GtfsStopTime> stopTimes = new ArrayList<>();
+    stopTimes.ensureCapacity(tripIds.length * stopIds.length);
+    for (int i = 0; i < tripIds.length; ++i) {
+      Preconditions.checkArgument(
+          stopIds.length == times[i].length, "stopIds.length must be equal to times[%d].length", i);
+      for (int j = 0; j < stopIds.length; ++j) {
+        stopTimes.add(createStopTime(stopTimes.size() + 1, tripIds[i], times[i][j], stopIds[j], j));
+      }
+    }
+
+    return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+  }
+
+  @Test
+  public void tripServingMoreThanOneStopShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    TripUsabilityValidator underTest = new TripUsabilityValidator();
+
+    underTest.tripTable =
+        createTripTable(
+            noticeContainer,
+            ImmutableList.of(
+                createTrip(1, "route id value", "service id value", "t0"),
+                createTrip(3, "route id value", "service id value", "t1")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            new String[] {"t0", "t1"},
+            new String[] {"s0", "s1"},
+            new String[][] {
+              new String[] {"08:00:00", "09:00:00"}, new String[] {"10:00:00", "11:00:00"},
+            },
+            noticeContainer);
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void tripServingOneStopShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    TripUsabilityValidator underTest = new TripUsabilityValidator();
+
+    underTest.tripTable =
+        createTripTable(
+            noticeContainer,
+            ImmutableList.of(
+                createTrip(1, "route id value", "service id value", "t0"),
+                createTrip(3, "route id value", "service id value", "t1")));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            new String[] {"t0", "t1"},
+            new String[] {"s0", "s1"},
+            new String[][] {
+              new String[] {"08:00:00", "09:00:00"}, new String[] {"10:00:00"},
+            },
+            noticeContainer);
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new UnusableTripNotice(3, "t1"));
+  }
+}


### PR DESCRIPTION
closes #520 

**Summary:**

This PR implements a new validation rule: Trips must have more than one stop to be usable.

**Expected behavior:** 

- a notice should be generated if a trip visits 0 or 1 stop only,
- no notice should be generated when a trip visitis at least 2 stops.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
