### PR TITLE
feat: Stop times in a trip should have increasing distance

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -59,7 +59,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 | [`OverlappingTripFrequenciesNotice`](#OverlappingTripFrequenciesNotice) | [E053](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E053)      	| Trip frequencies overlap                                                	|
 |                          	| [E054](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E054)      	| Block trips must not have overlapping stop times                        	|
 |[`MissingCalendarAndCalendarDateFilesNotice`](#MissingCalendarAndCalendarDateFilesNotice)| [E056](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E056)      	| Missing `calendar_dates.txt` and `calendar.txt` files                   	|
-|                          	| [E057](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E057)      	| Decreasing `shape_dist_traveled` in `stop_times.txt`| 
+|[`DecreasingStopTimeDistanceNotice`](#DecreasingStopTimeDistanceNotice)| [E057](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E057)      	| Decreasing `shape_dist_traveled` in `stop_times.txt`| 
 |                          	| [E059](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E059)      	| GTFS dataset too big                                                    	|
 |                          	| [E060](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E060)      	| Fatal internal error -- please report                                   	|
 |                          	| [E061](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E061)      	| Out of memory                                                           	|
@@ -315,3 +315,7 @@ A trip must visit more than one stop in stop_times.txt to be usable by passenger
 ### MissingCalendarAndCalendarDateFilesNotice
 
 Both files calendar_dates.txt and calendar.txt are missing from the GTFS archive. At least one of the files must be provided.
+
+### DecreasingStopTimeDistanceNotice
+
+Stop times in a trip should have increasing distance.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DecreasingStopTimeDistanceNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DecreasingStopTimeDistanceNotice.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/** Stop times of a trip have increasing distance (stops.shape_dist_traveled) */
+public class DecreasingStopTimeDistanceNotice extends ValidationNotice {
+  public DecreasingStopTimeDistanceNotice(
+      String tripId,
+      long csvRowNumber,
+      double shapeDistTraveled,
+      int stopSequence,
+      long prevCsvRowNumber,
+      double prevStopTimeDistTraveled,
+      int prevStopSequence) {
+    super(
+        new ImmutableMap.Builder<String, Object>()
+            .put("tripId", tripId)
+            .put("csvRowNumber", csvRowNumber)
+            .put("shapeDistTraveled", shapeDistTraveled)
+            .put("stopSequence", stopSequence)
+            .put("prevCsvRowNumber", prevCsvRowNumber)
+            .put("prevStopTimeDistTraveled", prevStopTimeDistTraveled)
+            .put("prevStopSequence", prevStopSequence)
+            .build());
+  }
+
+  @Override
+  public String getCode() {
+    return "decreasing_stop_time_distance";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.Multimaps;
+import java.util.List;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.DecreasingShapeDistanceNotice;
+import org.mobilitydata.gtfsvalidator.notice.DecreasingStopTimeDistanceNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+
+/**
+ * Validates: stop times of a trip have increasing distance (stops.shape_dist_traveled)
+ *
+ * <p>Generated notice: {@link DecreasingShapeDistanceNotice}.
+ */
+@GtfsValidator
+public class StopTimeIncreasingDistanceValidator extends FileValidator {
+  @Inject GtfsStopTimeTableContainer stopTimeTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    for (List<GtfsStopTime> stopTimeList : Multimaps.asMap(stopTimeTable.byTripIdMap()).values()) {
+      // GtfsStopTime objects are sorted based on @SequenceKey annotation on stop_sequence field.
+      for (int i = 1; i < stopTimeList.size(); ++i) {
+        GtfsStopTime prev = stopTimeList.get(i - 1);
+        GtfsStopTime curr = stopTimeList.get(i);
+        if (prev.hasShapeDistTraveled()
+            && curr.hasShapeDistTraveled()
+            && prev.shapeDistTraveled() > curr.shapeDistTraveled()) {
+          noticeContainer.addValidationNotice(
+              new DecreasingStopTimeDistanceNotice(
+                  curr.tripId(),
+                  curr.csvRowNumber(),
+                  curr.shapeDistTraveled(),
+                  curr.stopSequence(),
+                  prev.csvRowNumber(),
+                  prev.shapeDistTraveled(),
+                  prev.stopSequence()));
+        }
+      }
+    }
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -44,7 +44,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
         GtfsStopTime curr = stopTimeList.get(i);
         if (prev.hasShapeDistTraveled()
             && curr.hasShapeDistTraveled()
-            && prev.shapeDistTraveled() > curr.shapeDistTraveled()) {
+            && prev.shapeDistTraveled() >= curr.shapeDistTraveled()) {
           noticeContainer.addValidationNotice(
               new DecreasingStopTimeDistanceNotice(
                   curr.tripId(),

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.DecreasingStopTimeDistanceNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+
+public class StopTimeIncreasingDistanceValidatorTest {
+  private static GtfsStopTimeTableContainer createStopTimeTable(
+      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
+    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsStopTime createStopTime(
+      long csvRowNumber, String tripId, String stopId, int stopSequence, double shapeDistTraveled) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setStopId(stopId)
+        .setStopSequence(stopSequence)
+        .setShapeDistTraveled(shapeDistTraveled)
+        .build();
+  }
+
+  @Test
+  public void increasingDistanceAlongShapeShouldNotGenerateNotice() {
+    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(1, "first trip", "s0", 2, 10.0d),
+                createStopTime(2, "first trip", "s1", 42, 45.0d),
+                createStopTime(3, "first trip", "s2", 46, 64.0d)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices().isEmpty());
+  }
+
+  @Test
+  public void lastShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
+    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(1, "first trip", "s0", 2, 10.0d),
+                createStopTime(2, "first trip", "s1", 42, 45.0d),
+                createStopTime(3, "first trip", "s2", 46, 4.0d)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new DecreasingStopTimeDistanceNotice("first trip", 3, 4.0d, 46, 2, 45.0d, 42));
+  }
+
+  @Test
+  public void oneIntermediateShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
+    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(1, "first trip", "s0", 2, 10.0d),
+                createStopTime(2, "first trip", "s1", 42, 8.6d),
+                createStopTime(3, "first trip", "s2", 46, 46.0d)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new DecreasingStopTimeDistanceNotice("first trip", 2, 8.6d, 42, 1, 10.0d, 2));
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
@@ -78,6 +78,24 @@ public class StopTimeIncreasingDistanceValidatorTest {
   }
 
   @Test
+  public void twoShapesWithTheSameDistanceShouldGenerateNotice() {
+    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(1, "first trip", "s0", 2, 10.0d),
+                createStopTime(2, "first trip", "s1", 42, 45.0d),
+                createStopTime(3, "first trip", "s2", 46, 45.0d)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new DecreasingStopTimeDistanceNotice("first trip", 3, 45.0d, 46, 2, 45.0d, 42));
+  }
+
+  @Test
   public void oneIntermediateShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
     StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
     NoticeContainer noticeContainer = new NoticeContainer();


### PR DESCRIPTION
closes #526

**Summary:**

This PR implement a new validation rule: Stop times in a trip should have increasing distance

**Expected behavior:** 

When grouped by `stop_times.stop_sequence`, all stops of a given `stop_times.trip_id` should have increasing value for field `stop_times.shape_dist_traveled`, a notice should be generated and added to the `noticeContainer` if a stop times fails at this requirement.

New notice: `StopTimeIncreasingDistanceValidator`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
