### PR TITLE
feat: Do not skip a row if an optional field is invalid

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 
 /** Base class for all notices produced by GTFS validator. */
 public abstract class Notice {
-  private Map<String, Object> context;
+  private final Map<String, Object> context;
 
   public Notice(Map<String, Object> context) {
     this.context = context;
@@ -46,14 +46,18 @@ public abstract class Notice {
       return true;
     }
     if (other instanceof Notice) {
-      return context.equals(((Notice) other).context);
+      Notice otherNotice = (Notice) other;
+      return getCode().equals(otherNotice.getCode())
+          && getContext().equals(otherNotice.getContext());
     }
     return false;
   }
 
   @Override
   public String toString() {
-    return getCode() + " " + Joiner.on(",").withKeyValueSeparator("=").join(context);
+    return getCode()
+        + " "
+        + Joiner.on(",").useForNull("null").withKeyValueSeparator("=").join(context);
   }
 
   @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
@@ -1,0 +1,47 @@
+package org.mobilitydata.gtfsvalidator.notice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class NoticeTest {
+  @Test
+  public void equalsOtherNotice() {
+    assertThat(new TestValidationNotice("code_one", ImmutableMap.of("field", "value")))
+        .isEqualTo(new TestValidationNotice("code_one", ImmutableMap.of("field", "value")));
+    assertThat(new TestValidationNotice("code_one", ImmutableMap.of("field", "value")))
+        .isNotEqualTo(new TestValidationNotice("code_two", ImmutableMap.of("field", "value")));
+    assertThat(new TestValidationNotice("code_one", ImmutableMap.of("field", "value")))
+        .isNotEqualTo(new TestValidationNotice("code_one", ImmutableMap.of("field2", "value2")));
+  }
+
+  @Test
+  public void nullInContext() {
+    // Use HashMap because ImmutableMap does not support nulls.
+    Map<String, Object> context = new HashMap<>();
+    context.put("nullField", null);
+    Notice notice = new TestValidationNotice("test_notice", context);
+    // toString() must not crash.
+    assertThat(notice.toString()).isEqualTo("test_notice nullField=null");
+  }
+
+  private static class TestValidationNotice extends ValidationNotice {
+    private final String code;
+
+    public TestValidationNotice(String code, Map<String, Object> context) {
+      super(context);
+      this.code = code;
+    }
+
+    @Override
+    public String getCode() {
+      return code;
+    }
+  }
+}

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -291,7 +291,7 @@ public class TableLoaderGenerator {
     }
 
     method
-        .beginControlFlow("if (!rowParser.hasParseErrorsInRow())")
+        .beginControlFlow("if (!rowParser.hasErrorsInRequiredFields())")
         .addStatement("$T entity = builder.build()", gtfsEntityType)
         .addStatement("validatorLoader.invokeSingleEntityValidators(entity, noticeContainer)")
         .addStatement("entities.add(entity)")


### PR DESCRIPTION
GTFS validator tries to recover after parsing errors, so that it can
demonstrate more validation notices.

The old behaviour.
If any field fails to parse (e.g., invalid integer etc.), then the
whole row is skipped (e.g., we skip the whole trip entity).
This leads to a cascade of foreign key errors since other tables may
reference this invalid row (e.g., stop_times may reference this trip).

The new behaviour.
If an OPTIONAL field fails to parse, we emit a validation error
(e.g., FieldParsingError), treat this field as missing and still accept
this row. That allows to keep validating the feed.
However, if a REQUIRED field fails to parse, then we still skip the
whole row since we do not want to read an invalid entity from it.
