### PR TITLE
feat: Abort validation if some files failed to parse

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 
 /**
  * Container for a whole parsed GTFS feed with all its tables.
@@ -28,29 +29,50 @@ import java.util.Map;
  * <p>The tables are kept as {@code GtfsTableContainer} instances.
  */
 public class GtfsFeedContainer {
-  private final Map<String, GtfsTableContainer> tables = new HashMap<>();
-  private final Map<Class<? extends GtfsTableContainer>, GtfsTableContainer> tablesByClass =
+  private final Map<String, GtfsTableContainer<?>> tables = new HashMap<>();
+  private final Map<Class<? extends GtfsTableContainer>, GtfsTableContainer<?>> tablesByClass =
       new HashMap<>();
 
-  public GtfsFeedContainer(List<GtfsTableContainer> tableContainerList) {
-    for (GtfsTableContainer table : tableContainerList) {
+  public GtfsFeedContainer(List<GtfsTableContainer<?>> tableContainerList) {
+    for (GtfsTableContainer<?> table : tableContainerList) {
       tables.put(table.gtfsFilename(), table);
       tablesByClass.put(table.getClass(), table);
     }
   }
 
-  public GtfsTableContainer getTable(String filename) {
+  public GtfsTableContainer<?> getTable(String filename) {
     return tables.get(filename);
   }
 
-  public <T extends GtfsTableContainer> T getTable(Class<T> clazz) {
+  public <T extends GtfsTableContainer<?>> T getTable(Class<T> clazz) {
     return (T) tablesByClass.get(clazz);
+  }
+
+  /**
+   * Tells if all files were successfully parsed.
+   *
+   * <p>If all files in the feed were successfully parsed, then file validators may be executed.
+   *
+   * @return true if all files were successfully parsed, false otherwise
+   */
+  public boolean isParsedSuccessfully() {
+    for (GtfsTableContainer<?> table : tables.values()) {
+      if (!table.isParsedSuccessfully()) {
+        return false;
+      }
+    }
+    return true;
   }
 
   public String tableTotals() {
     List<String> totalList = new ArrayList<>();
-    for (GtfsTableContainer table : tables.values()) {
-      totalList.add(table.gtfsFilename() + "\t" + table.entityCount());
+    for (GtfsTableContainer<?> table : tables.values()) {
+      totalList.add(
+          table.gtfsFilename()
+              + "\t"
+              + (table.getTableStatus() == TableStatus.PARSABLE_HEADERS_AND_ROWS
+                  ? Integer.toString(table.entityCount())
+                  : table.getTableStatus().toString()));
     }
     Collections.sort(totalList);
     return String.join("\n", totalList);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
@@ -18,6 +18,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -115,7 +116,7 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
     BlockTripsWithOverlappingStopTimesValidator validator =
         new BlockTripsWithOverlappingStopTimesValidator();
     validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = GtfsCalendarDateTableContainer.forMissingFile();
+    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
     validator.tripTable =
         createTripTable(
             new String[] {"t0", "t1", "t2", "t3", "t4", "t5"},
@@ -147,7 +148,7 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
     BlockTripsWithOverlappingStopTimesValidator validator =
         new BlockTripsWithOverlappingStopTimesValidator();
     validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = GtfsCalendarDateTableContainer.forMissingFile();
+    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
     validator.tripTable =
         createTripTable(
             new String[] {"t0", "t1", "t2"},
@@ -179,7 +180,7 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
     BlockTripsWithOverlappingStopTimesValidator validator =
         new BlockTripsWithOverlappingStopTimesValidator();
     validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = GtfsCalendarDateTableContainer.forMissingFile();
+    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
     validator.tripTable =
         createTripTable(
             new String[] {"t0", "t1"}, new String[] {"WEEK", "WEEK-ALT"}, "b1", noticeContainer);
@@ -209,7 +210,7 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
     BlockTripsWithOverlappingStopTimesValidator validator =
         new BlockTripsWithOverlappingStopTimesValidator();
     validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = GtfsCalendarDateTableContainer.forMissingFile();
+    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
     validator.tripTable =
         createTripTable(
             new String[] {"t0", "t1"}, new String[] {"WEEK", "WEEK"}, "b1", noticeContainer);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidatorTest.java
@@ -33,6 +33,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 
 @RunWith(JUnit4.class)
 public class MatchingFeedAndAgencyLangValidatorTest {
@@ -67,8 +69,8 @@ public class MatchingFeedAndAgencyLangValidatorTest {
   public void noFeedInfoShouldNotGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     MatchingFeedAndAgencyLangValidator validator = new MatchingFeedAndAgencyLangValidator();
-    validator.agencyTable = GtfsAgencyTableContainer.forEmptyFile();
-    validator.feedInfoTable = GtfsFeedInfoTableContainer.forEmptyFile();
+    validator.agencyTable = new GtfsAgencyTableContainer(TableStatus.EMPTY_FILE);
+    validator.feedInfoTable = new GtfsFeedInfoTableContainer(TableStatus.EMPTY_FILE);
     validator.validate(noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidatorTest.java
@@ -31,6 +31,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
 
@@ -120,8 +121,8 @@ public class MissingCalendarAndCalendarDateValidatorTest {
     NoticeContainer noticeContainer = new NoticeContainer();
     MissingCalendarAndCalendarDateValidator underTest =
         new MissingCalendarAndCalendarDateValidator();
-    underTest.calendarTable = GtfsCalendarTableContainer.forMissingFile();
-    underTest.calendarDateTable = GtfsCalendarDateTableContainer.forMissingFile();
+    underTest.calendarTable = new GtfsCalendarTableContainer(TableStatus.MISSING_FILE);
+    underTest.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
     underTest.validate(noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices())

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -131,6 +131,14 @@ public class TableContainerGenerator {
             .addStatement("return $T.FILENAME", classNames.tableLoaderTypeName())
             .build());
 
+    typeSpec.addMethod(
+        MethodSpec.methodBuilder("isRequired")
+            .addAnnotation(Override.class)
+            .addModifiers(Modifier.PUBLIC)
+            .returns(boolean.class)
+            .addStatement("return $L", fileDescriptor.required())
+            .build());
+
     typeSpec.addField(
         ParameterizedTypeName.get(ClassName.get(List.class), gtfsEntityType),
         "entities",
@@ -162,69 +170,32 @@ public class TableContainerGenerator {
       addListMultimapWithGetters(typeSpec, indexField, classNames.entityImplementationTypeName());
     }
 
-    typeSpec.addMethod(generateConstructor());
-    typeSpec.addMethod(generateForEntitiesMethod());
-    typeSpec.addMethod(generateForEmptyFileMethod());
-    typeSpec.addMethod(generateForMissingFileMethod());
+    typeSpec.addMethod(generateConstructorWithEntities());
+    typeSpec.addMethod(generateConstructorWithStatus());
     typeSpec.addMethod(generateSetupIndicesMethod());
-    typeSpec.addMethod(generateForInvalidHeadersMethod());
+    typeSpec.addMethod(generateForEntitiesMethod());
 
     return typeSpec.build();
   }
 
-  private MethodSpec generateConstructor() {
+  private MethodSpec generateConstructorWithEntities() {
     return MethodSpec.constructorBuilder()
         .addModifiers(Modifier.PRIVATE)
         .addParameter(
             ParameterizedTypeName.get(
                 ClassName.get(List.class), classNames.entityImplementationTypeName()),
             "entities")
+        .addStatement("super(TableStatus.PARSABLE_HEADERS_AND_ROWS)")
         .addStatement("this.entities = entities")
         .build();
   }
 
-  private MethodSpec generateForEmptyFileMethod() {
-    TypeName tableContainerTypeName = classNames.tableContainerTypeName();
-    return MethodSpec.methodBuilder("forEmptyFile")
-        .returns(tableContainerTypeName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addStatement(
-            "$T table = new $T(new $T<>())",
-            tableContainerTypeName,
-            tableContainerTypeName,
-            ArrayList.class)
-        .addStatement("table.setEmptyFile(true)")
-        .addStatement("return table")
-        .build();
-  }
-
-  private MethodSpec generateForMissingFileMethod() {
-    TypeName tableContainerTypeName = classNames.tableContainerTypeName();
-    return MethodSpec.methodBuilder("forMissingFile")
-        .returns(tableContainerTypeName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addStatement(
-            "$T table = new $T(new $T<>())",
-            tableContainerTypeName,
-            tableContainerTypeName,
-            ArrayList.class)
-        .addStatement("table.setMissingFile(true)")
-        .addStatement("return table")
-        .build();
-  }
-
-  private MethodSpec generateForInvalidHeadersMethod() {
-    TypeName tableContainerTypeName = classNames.tableContainerTypeName();
-    return MethodSpec.methodBuilder("forInvalidHeaders")
-        .returns(tableContainerTypeName)
-        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
-        .addStatement(
-            "$T table = new $T(new $T<>())",
-            tableContainerTypeName,
-            tableContainerTypeName,
-            ArrayList.class)
-        .addStatement("table.setInvalidHeaders(true)")
-        .addStatement("return table")
+  private MethodSpec generateConstructorWithStatus() {
+    return MethodSpec.constructorBuilder()
+        .addModifiers(Modifier.PUBLIC)
+        .addParameter(GtfsTableContainer.TableStatus.class, "tableStatus")
+        .addStatement("super(tableStatus)")
+        .addStatement("this.entities = new $T<>()", ArrayList.class)
         .build();
   }
 
@@ -239,8 +210,6 @@ public class TableContainerGenerator {
             "entities")
         .addParameter(NoticeContainer.class, "noticeContainer")
         .addStatement("$T table = new $T(entities)", tableContainerTypeName, tableContainerTypeName)
-        .addStatement("table.setEmptyFile(false)")
-        .addStatement("table.setMissingFile(false)")
         .addStatement("table.setupIndices(noticeContainer)")
         .addStatement("return table")
         .build();


### PR DESCRIPTION
Results of file validations and cross-file validations require all feed
data to be parsed and loaded to memory. This is possible that some
required files are missing or some rows or headers failed to parse,
e.g., a required field is missing or a string cannot be parsed as integer.

This change is aborting validation process if some files failed to parse
to avoid misleading validation notices. The change also removes amount
of boilerplate regarding GTFS table status (empty file, missing file
etc.).

Example.

Consider we failed to parse a row trip.txt but there is another row
in stop_times.txt that references a trip. Then foreign key validator
may notify about a missing trip_id which would be very misleading for
the feed provider.

