### PR TITLE
feat: Inject a context object to validators

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -28,6 +28,8 @@ repositories {
 }
 
 dependencies {
+    annotationProcessor 'com.google.auto.value:auto-value:1.7.4'
+    compileOnly 'com.google.auto.value:auto-value-annotations:1.7.4'
     implementation 'org.apache.httpcomponents:httpclient:4.5.2'
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'com.univocity:univocity-parsers:2.9.0'

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
@@ -1,15 +1,24 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nullable;
 
 /**
  * Describes a runtime exception during loading a table. This normally indicates a bug in validator
  * code.
  */
 public class RuntimeExceptionInLoaderError extends SystemError {
-  public RuntimeExceptionInLoaderError(String filename, String exceptionClassName, String message) {
+  public RuntimeExceptionInLoaderError(
+      String filename, String exceptionClassName, @Nullable String message) {
+    // Throwable.getMessage() may return null, so we need to support it gracefully.
     super(
-        ImmutableMap.of("filename", filename, "exception", exceptionClassName, "message", message));
+        ImmutableMap.of(
+            "filename",
+            filename,
+            "exception",
+            exceptionClassName,
+            "message",
+            message == null ? "" : message));
   }
 
   @Override

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsLoader;
-import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RuntimeExceptionInLoaderError;
@@ -38,6 +37,7 @@ import org.mobilitydata.gtfsvalidator.notice.ThreadExecutionError;
 import org.mobilitydata.gtfsvalidator.notice.ThreadInterruptedError;
 import org.mobilitydata.gtfsvalidator.notice.UnknownFileNotice;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
+import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
 /**
@@ -89,7 +89,7 @@ public class GtfsFeedLoader {
 
   public GtfsFeedContainer loadAndValidate(
       GtfsInput gtfsInput,
-      GtfsFeedName feedName,
+      ValidationContext validationContext,
       ValidatorLoader validatorLoader,
       NoticeContainer noticeContainer) {
     logger.atInfo().log("Loading in %d threads", numThreads);
@@ -109,7 +109,8 @@ public class GtfsFeedLoader {
               NoticeContainer loaderNotices = new NoticeContainer();
               GtfsTableContainer tableContainer;
               try {
-                tableContainer = loader.load(inputStream, feedName, validatorLoader, loaderNotices);
+                tableContainer =
+                    loader.load(inputStream, validationContext, validatorLoader, loaderNotices);
               } catch (RuntimeException e) {
                 // This handler should prevent ExecutionException for
                 // this thread. We catch an exception here for storing
@@ -120,7 +121,8 @@ public class GtfsFeedLoader {
                         filename, e.getClass().getCanonicalName(), e.getMessage()));
                 // Since the file was not loaded successfully, we treat
                 // it as missing for continuing validation.
-                tableContainer = loader.loadMissingFile(validatorLoader, loaderNotices);
+                tableContainer =
+                    loader.loadMissingFile(validationContext, validatorLoader, loaderNotices);
               } finally {
                 inputStream.close();
               }
@@ -131,7 +133,8 @@ public class GtfsFeedLoader {
     ArrayList<GtfsTableContainer<?>> tableContainers = new ArrayList<>();
     tableContainers.ensureCapacity(tableLoaders.size());
     for (GtfsTableLoader loader : remainingLoaders.values()) {
-      tableContainers.add(loader.loadMissingFile(validatorLoader, noticeContainer));
+      tableContainers.add(
+          loader.loadMissingFile(validationContext, validatorLoader, noticeContainer));
     }
     try {
       try {
@@ -170,7 +173,8 @@ public class GtfsFeedLoader {
         return feed;
       }
       List<Callable<NoticeContainer>> validatorCallables = new ArrayList<>();
-      for (FileValidator validator : validatorLoader.createMultiFileValidators(feed)) {
+      for (FileValidator validator :
+          validatorLoader.createMultiFileValidators(feed, validationContext)) {
         validatorCallables.add(
             () -> {
               NoticeContainer validatorNotices = new NoticeContainer();

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableLoader.java
@@ -18,8 +18,8 @@ package org.mobilitydata.gtfsvalidator.table;
 
 import java.io.InputStream;
 import java.util.Set;
-import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
 /**
@@ -41,10 +41,12 @@ public abstract class GtfsTableLoader<T extends GtfsEntity> {
 
   public abstract GtfsTableContainer<T> load(
       InputStream inputStream,
-      GtfsFeedName feedName,
+      ValidationContext validationContext,
       ValidatorLoader validatorLoader,
       NoticeContainer noticeContainer);
 
   public abstract GtfsTableContainer<T> loadMissingFile(
-      ValidatorLoader validatorLoader, NoticeContainer noticeContainer);
+      ValidationContext validationContext,
+      ValidatorLoader validatorLoader,
+      NoticeContainer noticeContainer);
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
@@ -1,0 +1,41 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.auto.value.AutoValue;
+import java.time.ZonedDateTime;
+import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
+
+/**
+ * A read-only context passed to particular validator objects. It gives information relevant for
+ * validation: properties of the feed as a whole, system properties (current time) etc.
+ */
+@AutoValue
+public abstract class ValidationContext {
+  public static Builder builder() {
+    return new AutoValue_ValidationContext.Builder();
+  }
+
+  /** Represents a name of a GTFS feed, such as "nl-openov". */
+  public abstract GtfsFeedName feedName();
+
+  /**
+   * The time when validation started.
+   *
+   * <p>Validator code should use this property instead of calling LocalDate.now() etc. for the
+   * following reasons:
+   *
+   * <ul>
+   *   <li>current date and time is changing but it should not randomly affect validation notices;
+   *   <li>unit tests may need to override the current time.
+   * </ul>
+   */
+  public abstract ZonedDateTime now();
+
+  @AutoValue.Builder
+  public abstract static class Builder {
+    public abstract Builder setFeedName(GtfsFeedName feedName);
+
+    public abstract Builder setNow(ZonedDateTime now);
+
+    public abstract ValidationContext build();
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -26,6 +26,8 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.IOError;
@@ -34,6 +36,7 @@ import org.mobilitydata.gtfsvalidator.notice.ThreadInterruptedError;
 import org.mobilitydata.gtfsvalidator.notice.URISyntaxError;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
+import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
 /** The main entry point for GTFS Validator CLI. */
@@ -91,8 +94,13 @@ public class Main {
       exportReport(args.getOutputBase(), noticeContainer);
       return;
     }
+    ValidationContext validationContext =
+        ValidationContext.builder()
+            .setFeedName(feedName)
+            .setNow(ZonedDateTime.now(ZoneId.systemDefault()))
+            .build();
     feedContainer =
-        feedLoader.loadAndValidate(gtfsInput, feedName, validatorLoader, noticeContainer);
+        feedLoader.loadAndValidate(gtfsInput, validationContext, validatorLoader, noticeContainer);
 
     // Output
     exportReport(args.getOutputBase(), noticeContainer);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import java.time.LocalDate;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
 import org.mobilitydata.gtfsvalidator.notice.FeedExpirationDateNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -37,12 +38,15 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 @GtfsValidator
 public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedInfo> {
 
+  @Inject ValidationContext context;
+
   @Override
   public void validate(GtfsFeedInfo entity, NoticeContainer noticeContainer) {
     if (entity.hasFeedEndDate()) {
-      GtfsDate currentDate = GtfsDate.fromLocalDate(LocalDate.now());
-      GtfsDate currentDatePlusSevenDays = GtfsDate.fromLocalDate(LocalDate.now().plusDays(7));
-      GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(LocalDate.now().plusDays(30));
+      LocalDate now = context.now().toLocalDate();
+      GtfsDate currentDate = GtfsDate.fromLocalDate(now);
+      GtfsDate currentDatePlusSevenDays = GtfsDate.fromLocalDate(now.plusDays(7));
+      GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(now.plusDays(30));
       if (entity.feedEndDate().isBefore(currentDatePlusSevenDays)) {
         noticeContainer.addValidationNotice(
             new FeedExpirationDateNotice(

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
@@ -22,17 +22,25 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
 /** Runs GtfsLevelTableContainer on test CSV data. */
 @RunWith(JUnit4.class)
 public class GtfsLevelTableLoaderTest {
-  private static final GtfsFeedName FEED_NAME = GtfsFeedName.parseString("au-sydney-buses");
+  private static final GtfsFeedName TEST_FEED_NAME = GtfsFeedName.parseString("au-sydney-buses");
+  private static final ZonedDateTime TEST_NOW =
+      ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
+
+  private static final ValidationContext VALIDATION_CONTEXT =
+      ValidationContext.builder().setFeedName(TEST_FEED_NAME).setNow(TEST_NOW).build();
 
   private static InputStream toInputStream(String s) {
     return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
@@ -47,7 +55,7 @@ public class GtfsLevelTableLoaderTest {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer =
         (GtfsLevelTableContainer)
-            loader.load(inputStream, FEED_NAME, validatorLoader, noticeContainer);
+            loader.load(inputStream, VALIDATION_CONTEXT, validatorLoader, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(1);
@@ -68,7 +76,7 @@ public class GtfsLevelTableLoaderTest {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer =
         (GtfsLevelTableContainer)
-            loader.load(inputStream, FEED_NAME, validatorLoader, noticeContainer);
+            loader.load(inputStream, VALIDATION_CONTEXT, validatorLoader, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isNotEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(0);
@@ -83,7 +91,7 @@ public class GtfsLevelTableLoaderTest {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer =
         (GtfsLevelTableContainer)
-            loader.load(inputStream, FEED_NAME, validatorLoader, noticeContainer);
+            loader.load(inputStream, VALIDATION_CONTEXT, validatorLoader, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isNotEmpty();
     assertThat(noticeContainer.getValidationNotices().get(0).getClass().getSimpleName())

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -18,10 +18,12 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.FeedExpirationDateNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -29,10 +31,17 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 
 public class FeedExpirationDateValidatorTest {
+  private static final GtfsFeedName TEST_FEED_NAME = GtfsFeedName.parseString("au-sydney-buses");
+  private static final ZonedDateTime TEST_NOW =
+      ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
+
+  private static final ValidationContext VALIDATION_CONTEXT =
+      ValidationContext.builder().setFeedName(TEST_FEED_NAME).setNow(TEST_NOW).build();
 
   private List<ValidationNotice> validateFeedInfo(GtfsFeedInfo feedInfo) {
     NoticeContainer container = new NoticeContainer();
     FeedExpirationDateValidator validator = new FeedExpirationDateValidator();
+    validator.context = VALIDATION_CONTEXT;
     validator.validate(feedInfo, container);
     return container.getValidationNotices();
   }
@@ -50,55 +59,60 @@ public class FeedExpirationDateValidatorTest {
   @Test
   public void feedExpiringInFiveDaysFromNowShouldGenerateNotice() {
     assertThat(
-            validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(LocalDate.now().plusDays(3)))))
+            validateFeedInfo(
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(3)))))
         .containsExactly(
             new FeedExpirationDateNotice(
                 1,
-                GtfsDate.fromLocalDate(LocalDate.now()),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(3)),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(7))));
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(3)),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7))));
   }
 
   @Test
   public void feedExpiringInSevenDaysFromNowShouldGenerateNotice() {
     assertThat(
-            validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(LocalDate.now().plusDays(7)))))
+            validateFeedInfo(
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7)))))
         .containsExactly(
             new FeedExpirationDateNotice(
                 1,
-                GtfsDate.fromLocalDate(LocalDate.now()),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(7)),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(30))));
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7)),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30))));
   }
 
   @Test
   public void feedExpiring7to30DaysFromNowShouldGenerateNotice() {
     assertThat(
-            validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(LocalDate.now().plusDays(23)))))
+            validateFeedInfo(
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(23)))))
         .containsExactly(
             new FeedExpirationDateNotice(
                 1,
-                GtfsDate.fromLocalDate(LocalDate.now()),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(23)),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(30))));
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(23)),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30))));
   }
 
   @Test
   public void feedExpiring30DaysFromNowShouldGenerateNotice() {
     assertThat(
-            validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(LocalDate.now().plusDays(30)))))
+            validateFeedInfo(
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30)))))
         .containsExactly(
             new FeedExpirationDateNotice(
                 1,
-                GtfsDate.fromLocalDate(LocalDate.now()),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(30)),
-                GtfsDate.fromLocalDate(LocalDate.now().plusDays(30))));
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30)),
+                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30))));
   }
 
   @Test
   public void feedExpiringInMoreThan30DaysFromNowShouldNotGenerateNotice() {
     assertThat(
-            validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(LocalDate.now().plusDays(45)))))
+            validateFeedInfo(
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(45)))))
         .isEmpty();
   }
 }


### PR DESCRIPTION
ValidationContext is a read-only object that describes the feed as
a whole and also some system properties relevant for validation.

Any validator may request to inject ValidationContext using the usual
@Inject annotation. We chose that instead of modifying the signature of
validate() method because most validators do not need this context and
we want to avoid a huge refactoring.