### PR TITLE
feat:  Stop too far from trip shape

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -55,7 +55,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                          	| [E048](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E048)      	| `end_time` after `start_time` in `frequencies.txt`                      	|
 |[`UnusedTripNotice`](#UnusedTripNotice)| [E050](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E050)      	| Trips must be used in `stop_times.txt`                                  	|
 |                          	| [E051](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E051)      	| Trips must have more than one stop to be usable                         	|
-|                          	| [E052](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E052)      	| Stop too far from trip shape                                            	|
+|[`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)| [E052](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E052)      	| Stop too far from trip shape                                            	|
 | [`OverlappingTripFrequenciesNotice`](#OverlappingTripFrequenciesNotice) | [E053](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E053)      	| Trip frequencies overlap                                                	|
 |                          	| [E054](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E054)      	| Block trips must not have overlapping stop times                        	|
 |[`MissingCalendarAndCalendarDateFilesNotice`](#MissingCalendarAndCalendarDateFilesNotice)| [E056](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E056)      	| Missing `calendar_dates.txt` and `calendar.txt` files                   	|
@@ -315,3 +315,10 @@ A trip must visit more than one stop in stop_times.txt to be usable by passenger
 ### MissingCalendarAndCalendarDateFilesNotice
 
 Both files calendar_dates.txt and calendar.txt are missing from the GTFS archive. At least one of the files must be provided.
+
+### StopTooFarFromTripShapeNotice
+
+Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100 meters of stop locations which a trip serves.
+
+#### References:
+* [GTFS Best Practices shapes.txt](https://gtfs.org/best-practices/#shapestxt)

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -69,6 +69,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.google.flogger:flogger:0.5.1'
     implementation 'com.google.flogger:flogger-system-backend:0.5.1'
+    implementation 'org.locationtech.spatial4j:spatial4j:0.7'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopTooFarFromTripShapeNotice.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class StopTooFarFromTripShapeNotice extends ValidationNotice {
+  public StopTooFarFromTripShapeNotice(
+      final String stopId,
+      final int stopSequence,
+      final String tripId,
+      final String shapeId,
+      final double stopShapeThreshold) {
+    super(
+        ImmutableMap.of(
+            "stopId", stopId,
+            "stopSequence", stopSequence,
+            "tripId", tripId,
+            "shapeId", shapeId,
+            "stopShapeThreshold", stopShapeThreshold));
+  }
+
+  @Override
+  public String getCode() {
+    return "stop_too_far_from_trip_shape";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.util;
+
+import static org.locationtech.spatial4j.context.SpatialContext.GEO;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import org.locationtech.spatial4j.distance.DistanceCalculator;
+import org.locationtech.spatial4j.distance.DistanceUtils;
+import org.locationtech.spatial4j.shape.Point;
+import org.locationtech.spatial4j.shape.Shape;
+import org.locationtech.spatial4j.shape.ShapeFactory;
+import org.locationtech.spatial4j.shape.SpatialRelation;
+import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+
+public class GeospatialUtil {
+  static final int KILOMETER_TO_METER_CONVERSION_FACTOR =
+      1000; // conversion factor from kilometers to meters
+  static final double TRIP_BUFFER_METERS =
+      100; // Per GTFS Best Practices (https://gtfs.org/best-practices/#shapestxt)
+  public static final double TRIP_BUFFER_DEGREES =
+      DistanceUtils.KM_TO_DEG * (TRIP_BUFFER_METERS / 1000.0d);
+
+  private GeospatialUtil() {}
+
+  /**
+   * Method returning a {@code ShapeFactory}
+   *
+   * @return a {@link ShapeFactory}
+   */
+  private static ShapeFactory getShapeFactory() {
+    return GEO.getShapeFactory();
+  }
+
+  /**
+   * Method returning a {@code DistanceCalculator}
+   *
+   * @return a {@link DistanceCalculator}
+   */
+  private static DistanceCalculator getDistanceCalculator() {
+    return GEO.getDistCalc();
+  }
+
+  /**
+   * This method calculates distance between two sets of coordinates. Result is expressed in meters.
+   *
+   * @param fromLat latitude of the first coordinates
+   * @param fromLng longitude of the first coordinates
+   * @param toLat latitude of the second coordinates
+   * @param toLng longitude of the second coordinates
+   * @return the calculation result in meters
+   */
+  public static int distanceBetweenMeter(
+      double fromLat, double fromLng, double toLat, double toLng) {
+    final ShapeFactory shapeFactory = getShapeFactory();
+    final DistanceCalculator distanceCalculator = getDistanceCalculator();
+    final Point origin = shapeFactory.pointXY(fromLng, fromLat);
+    final Point destination = shapeFactory.pointXY(toLng, toLat);
+    return (int)
+        (DistanceUtils.DEG_TO_KM
+            * distanceCalculator.distance(origin, destination)
+            * KILOMETER_TO_METER_CONVERSION_FACTOR);
+  }
+
+  /**
+   * Returns a list of E052 errors for the given input, one for each stop that is too far from the
+   * trip shapePoints
+   *
+   * @param trip Trip for this GTFS trip
+   * @param stopTimes a map of StopTimes for a trip, sorted by stop_sequence
+   * @param shapePoints a map of ShapePoints for a trip, sorted by shape_pt_sequence
+   * @param stopTable a map of all stops (keyed on stop_id), needed to obtain the latitude and
+   *     longitude for each stop
+   * @param testedCache a cache for previously tested shape_id and stop_id pairs (keyed on
+   *     shape_id+stop_id). If the combination of shape_id and stop_id appears in this set, we
+   *     shouldn't test it again. Shapes and stops tested in this method execution will be added to
+   *     this testedCache.
+   * @return a list of E052 errors, one for each stop that is too far from the trip shapePoints
+   */
+  public static List<StopTooFarFromTripShapeNotice> checkStopsWithinTripShape(
+      final GtfsTrip trip,
+      final List<GtfsStopTime> stopTimes,
+      final List<GtfsShape> shapePoints,
+      final GtfsStopTableContainer stopTable,
+      final Set<String> testedCache) {
+    List<StopTooFarFromTripShapeNotice> errors = new ArrayList<>();
+    if (trip == null
+        || stopTimes == null
+        || stopTimes.isEmpty()
+        || shapePoints == null
+        || shapePoints.isEmpty()) {
+      // Nothing to do - return empty list
+      return errors;
+    }
+
+    // Create a polyline from the GTFS shapes data
+    ShapeFactory.LineStringBuilder lineBuilder = getShapeFactory().lineString();
+    shapePoints.forEach(
+        (shapePoint -> lineBuilder.pointXY(shapePoint.shapePtLon(), shapePoint.shapePtLat())));
+    Shape shapeLine = lineBuilder.build();
+
+    // Create the buffered version of the trip as a polygon
+    Shape shapeBuffer = shapeLine.getBuffered(TRIP_BUFFER_DEGREES, shapeLine.getContext());
+
+    // Check if each stop is within the buffer polygon
+    stopTimes.forEach(
+        stopTime -> {
+          GtfsStop stop = stopTable.byStopId(stopTime.stopId());
+          if (stop == null || stop.hasStopLat() || stop.hasStopLon()) {
+            // Lat/lon are optional for location_type 4 - skip to the next stop if they aren't
+            // provided
+            return;
+          }
+          if (!(stop.locationType() == GtfsLocationType.STOP)
+              && !(stop.locationType() == GtfsLocationType.BOARDING_AREA)) {
+            // This rule only applies to stops of location_type 0 and 4 - skip to next stop
+            return;
+          }
+          if (testedCache.contains(trip.shapeId() + stop.stopId())) {
+            // We've already tested this combination of shape ID and stop ID - skip to next stop
+            return;
+          }
+          testedCache.add(trip.shapeId() + stop.stopId());
+          org.locationtech.spatial4j.shape.Point p =
+              getShapeFactory().pointXY(stop.stopLon(), stop.stopLat());
+          if (!shapeBuffer.relate(p).equals(SpatialRelation.CONTAINS)) {
+            errors.add(
+                new StopTooFarFromTripShapeNotice(
+                    stopTime.stopId(),
+                    stopTime.stopSequence(),
+                    trip.tripId(),
+                    trip.shapeId(),
+                    TRIP_BUFFER_METERS));
+          }
+        });
+
+    return errors;
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
@@ -38,10 +38,13 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 public class GeospatialUtil {
   static final int KILOMETER_TO_METER_CONVERSION_FACTOR =
       1000; // conversion factor from kilometers to meters
+
+  static final double METER_TO_KILOMETER_CONVERSION_FACTOR =
+      1 / 1000; // conversion factor from kilometers to meters
   static final double TRIP_BUFFER_METERS =
       100; // Per GTFS Best Practices (https://gtfs.org/best-practices/#shapestxt)
   public static final double TRIP_BUFFER_DEGREES =
-      DistanceUtils.KM_TO_DEG * (TRIP_BUFFER_METERS / 1000.0d);
+      DistanceUtils.KM_TO_DEG * TRIP_BUFFER_METERS * METER_TO_KILOMETER_CONVERSION_FACTOR;
 
   private GeospatialUtil() {}
 
@@ -72,7 +75,7 @@ public class GeospatialUtil {
    * @param toLng longitude of the second coordinates
    * @return the calculation result in meters
    */
-  public static int distanceBetweenMeter(
+  public static int distanceInMeterBetween(
       double fromLat, double fromLng, double toLat, double toLng) {
     final ShapeFactory shapeFactory = getShapeFactory();
     final DistanceCalculator distanceCalculator = getDistanceCalculator();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
@@ -128,7 +128,7 @@ public class GeospatialUtil {
     stopTimes.forEach(
         stopTime -> {
           GtfsStop stop = stopTable.byStopId(stopTime.stopId());
-          if (stop == null || stop.hasStopLat() || stop.hasStopLon()) {
+          if (stop == null || !stop.hasStopLat() || !stop.hasStopLon()) {
             // Lat/lon are optional for location_type 4 - skip to the next stop if they aren't
             // provided
             return;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtil.java
@@ -38,8 +38,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 public class GeospatialUtil {
   static final int KILOMETER_TO_METER_CONVERSION_FACTOR =
       1000; // conversion factor from kilometers to meters
-
-  static final double METER_TO_KILOMETER_CONVERSION_FACTOR =
+  static final float METER_TO_KILOMETER_CONVERSION_FACTOR =
       1 / 1000; // conversion factor from kilometers to meters
   static final double TRIP_BUFFER_METERS =
       100; // Per GTFS Best Practices (https://gtfs.org/best-practices/#shapestxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.util.GeospatialUtil;
+
+/**
+ * Validates: a {@link GtfsStop} is within a distance threshold for a trip shape.
+ *
+ * <p>Generated notice: {@link StartAndEndDateOutOfOrderNotice}.
+ */
+@GtfsValidator
+public class StopTooFarFromTripShapeValidator extends FileValidator {
+  @Inject GtfsStopTimeTableContainer stopTimeTable;
+  @Inject GtfsTripTableContainer tripTable;
+  @Inject GtfsShapeTableContainer shapeTable;
+  @Inject GtfsStopTableContainer stopTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    List<StopTooFarFromTripShapeNotice> notices = new ArrayList<>();
+
+    // Cache for previously tested shape_id and stop_id pairs - we don't need to test them more than
+    // once
+    final Set<String> testedCache = new HashSet<>();
+
+    stopTimeTable
+        .byTripIdMap()
+        .forEach(
+            (tripId, tripStopTimes) -> {
+              GtfsTrip trip = tripTable.byTripId(tripId);
+              if (trip == null || !trip.hasShapeId()) {
+                // No shape for this trip - skip to the next trip
+                return;
+              }
+              // Check for possible errors for this combination of stop times and shape points for
+              // this trip_id
+              List<StopTooFarFromTripShapeNotice> noticesForTrip =
+                  GeospatialUtil.checkStopsWithinTripShape(
+                      trip,
+                      stopTimeTable.byTripId(tripId),
+                      shapeTable.byShapeId(trip.shapeId()),
+                      stopTable,
+                      testedCache);
+              notices.addAll(noticesForTrip);
+            });
+    notices.forEach(noticeContainer::addValidationNotice);
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
@@ -26,10 +26,10 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
-import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.util.GeospatialUtil;
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2021 MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
@@ -2,9 +2,69 @@ package org.mobilitydata.gtfsvalidator.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 
 public class GeospatialUtilTest {
+  public static GtfsStopTime createStopTime(
+      long csvRowNumber, String tripId, String stopId, int stopSequence) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setStopSequence(stopSequence)
+        .setStopId(stopId)
+        .build();
+  }
+
+  public static GtfsTrip createTrip(
+      long csvRowNumber, String routeId, String serviceId, String tripId, String shapeId) {
+    return new GtfsTrip.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setRouteId(routeId)
+        .setServiceId(serviceId)
+        .setTripId(tripId)
+        .setShapeId(shapeId)
+        .build();
+  }
+
+  public static GtfsShape createShapePoint(
+      long csvRowNumber,
+      String shapeId,
+      double shapePtLat,
+      double shapePtLon,
+      int shapePtSequence,
+      double shapeDistTraveled) {
+    return new GtfsShape.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setShapeId(shapeId)
+        .setShapePtLat(shapePtLat)
+        .setShapePtLon(shapePtLon)
+        .setShapePtSequence(shapePtSequence)
+        .setShapeDistTraveled(shapeDistTraveled)
+        .build();
+  }
+
+  public static GtfsStop createStop(
+      long csvRowNumber, String stopId, Double stopLat, Double stopLon, int locationType) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(stopId)
+        .setStopLat(stopLat)
+        .setStopLon(stopLon)
+        .setLocationType(locationType)
+        .build();
+  }
 
   @Test
   public void distanceFromToSameCoordinateIsZero() {
@@ -35,7 +95,31 @@ public class GeospatialUtilTest {
    */
   @Test
   public void stopWithinTripShapeBufferShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "trip id", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 2),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -54,7 +138,37 @@ public class GeospatialUtilTest {
    */
   @Test
   public void stopOutsideTripShapeBufferShouldGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest)
+        .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape id", 100));
   }
 
   /**
@@ -73,7 +187,48 @@ public class GeospatialUtilTest {
    */
   @Test
   public void twoTripsWithSameShapeStopOutsideBufferShouldGenerateOneNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip firstTrip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+    GtfsTrip secondTrip = createTrip(9, "route id value", "service id value", "t2", "shape id");
+
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    Set<String> testedCache = new HashSet<>();
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            firstTrip, stopTimes, shapePoints, stopTable, testedCache);
+
+    assertThat(underTest)
+        .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape id", 100));
+    // Validate the 2nd trip - no new errors should be added, because the shapeId+stopId combination
+    // has already been flagged
+    underTest.addAll(
+        GeospatialUtil.checkStopsWithinTripShape(
+            secondTrip, stopTimes, shapePoints, stopTable, testedCache));
+    assertThat(underTest)
+        .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape id", 100));
   }
 
   /**
@@ -92,7 +247,26 @@ public class GeospatialUtilTest {
    */
   @Test
   public void tripWithoutShapeShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "trip id", null);
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2));
+
+    // No shapes.txt data
+    List<GtfsShape> shapePoints = null;
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 2),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -111,7 +285,35 @@ public class GeospatialUtilTest {
    */
   @Test
   public void stopWithoutLocationShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "trip id", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                // No location - optional for location_type=4
+                createStop(2, "1001", null, null, 4),
+                // No location - optional for location_type=4
+                createStop(4, "1002", null, null, 4),
+                // No location - optional for location_type=4
+                createStop(5, "1003", null, null, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -130,7 +332,38 @@ public class GeospatialUtilTest {
    */
   @Test
   public void stopLocationTypeNotZeroOrFourShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip firstTrip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 2),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 2)),
+            noticeContainer);
+
+    Set<String> testedCache = new HashSet<>();
+    assertThat(
+            GeospatialUtil.checkStopsWithinTripShape(
+                firstTrip, stopTimes, shapePoints, stopTable, testedCache))
+        .isEmpty();
   }
 
   /**
@@ -148,8 +381,37 @@ public class GeospatialUtilTest {
    * don't support.
    */
   @Test
-  public void nullStopShouldNotGenerateNotice() {
-    // TODO: implement
+  public void singleStopWithinBufferShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip firstTrip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                // this location is inside buffer
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2)),
+            noticeContainer);
+
+    Set<String> testedCache = new HashSet<>();
+    assertThat(
+            GeospatialUtil.checkStopsWithinTripShape(
+                firstTrip, stopTimes, shapePoints, stopTable, testedCache))
+        .isEmpty();
   }
 
   /**
@@ -168,7 +430,36 @@ public class GeospatialUtilTest {
    */
   @Test
   public void nullTripShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = null;
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -187,7 +478,32 @@ public class GeospatialUtilTest {
    */
   @Test
   public void nullStopTimeShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes = null;
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -206,7 +522,32 @@ public class GeospatialUtilTest {
    */
   @Test
   public void emptyStopTimesShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes = new ArrayList<>();
+
+    List<GtfsShape> shapePoints =
+        ImmutableList.of(
+            createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+            createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+            createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+            createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+            createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f));
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -225,7 +566,29 @@ public class GeospatialUtilTest {
    */
   @Test
   public void nullShapePointsShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+    List<GtfsShape> shapePoints = null;
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 
   /**
@@ -244,6 +607,28 @@ public class GeospatialUtilTest {
    */
   @Test
   public void emptyShapePointsShouldNotGenerateNotice() {
-    // TODO: implement
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTrip trip = createTrip(4, "route id value", "service id value", "t1", "shape id");
+    new GtfsTrip.Builder().setTripId("trip id value").setShapeId("shape id value").build();
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            createStopTime(5, "t1", "1001", 1),
+            createStopTime(8, "t1", "1002", 2),
+            createStopTime(9, "t1", "1003", 3));
+    List<GtfsShape> shapePoints = new ArrayList<>();
+
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+            noticeContainer);
+
+    List<StopTooFarFromTripShapeNotice> underTest =
+        GeospatialUtil.checkStopsWithinTripShape(
+            trip, stopTimes, shapePoints, stopTable, new HashSet<>());
+    assertThat(underTest).isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
@@ -84,14 +84,14 @@ public class GeospatialUtilTest {
 
   @Test
   public void distanceFromToSameCoordinateIsZero() {
-    assertThat(GeospatialUtil.distanceBetweenMeter(45.508888, -73.561668, 45.508888, -73.561668))
+    assertThat(GeospatialUtil.distanceInMeterBetween(45.508888, -73.561668, 45.508888, -73.561668))
         .isEqualTo(0);
   }
 
   @Test
   public void distanceReferenceCheck() {
     // geographic data extracted and validated with an external tool
-    assertThat(GeospatialUtil.distanceBetweenMeter(45.508888, -73.561668, 45.507753, -73.562677))
+    assertThat(GeospatialUtil.distanceInMeterBetween(45.508888, -73.561668, 45.507753, -73.562677))
         .isEqualTo(148);
   }
 
@@ -128,8 +128,8 @@ public class GeospatialUtilTest {
     GtfsStopTableContainer stopTable =
         GtfsStopTableContainer.forEntities(
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 2),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2)),
+                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
+                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D,  0)),
             noticeContainer);
 
     List<StopTooFarFromTripShapeNotice> underTest =
@@ -174,10 +174,10 @@ public class GeospatialUtilTest {
     GtfsStopTableContainer stopTable =
         GtfsStopTableContainer.forEntities(
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 4),
+                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 4),
                 // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+                createStop(5, "1003", 17.05673053256373D, -45.4170801432763D, 4)),
             noticeContainer);
 
     List<StopTooFarFromTripShapeNotice> underTest =
@@ -225,8 +225,8 @@ public class GeospatialUtilTest {
     GtfsStopTableContainer stopTable =
         GtfsStopTableContainer.forEntities(
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0),
+                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
+                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 0),
                 // this location is outside buffer
                 createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
             noticeContainer);
@@ -275,8 +275,8 @@ public class GeospatialUtilTest {
     GtfsStopTableContainer stopTable =
         GtfsStopTableContainer.forEntities(
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 2),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2)),
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0)),
             noticeContainer);
 
     List<StopTooFarFromTripShapeNotice> underTest =
@@ -420,7 +420,7 @@ public class GeospatialUtilTest {
         GtfsStopTableContainer.forEntities(
             ImmutableList.of(
                 // this location is inside buffer
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 2)),
+                createStop(2, "1001", 28.05724310653972D, -82.41350776611507D, 0)),
             noticeContainer);
 
     Set<String> testedCache = new HashSet<>();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
@@ -1,0 +1,249 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class GeospatialUtilTest {
+
+  @Test
+  public void distanceFromToSameCoordinateIsZero() {
+    assertThat(GeospatialUtil.distanceBetweenMeter(45.508888, -73.561668, 45.508888, -73.561668))
+        .isEqualTo(0);
+  }
+
+  @Test
+  public void distanceReferenceCheck() {
+    // geographic data extracted and validated with an external tool
+    assertThat(GeospatialUtil.distanceBetweenMeter(45.508888, -73.561668, 45.507753, -73.562677))
+        .isEqualTo(148);
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void stopWithinTripShapeBufferShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void stopOutsideTripShapeBufferShouldGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void twoTripsWithSameShapeStopOutsideBufferShouldGenerateOneNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void tripWithoutShapeShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void stopWithoutLocationShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void stopLocationTypeNotZeroOrFourShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void nullStopShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void nullTripShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void nullStopTimeShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void emptyStopTimesShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void nullShapePointsShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+
+  /**
+   * Test geospatial implementation
+   *
+   * <p>See map of trip shape and stops (in GeoJSON) at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+   *
+   * <p>For debugging, you can export a JTS-version of the buffer in WKT format using code at
+   * https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554. The WKT
+   * output can then be visualized at https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
+   *
+   * <p>The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because
+   * it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools
+   * don't support.
+   */
+  @Test
+  public void emptyShapePointsShouldNotGenerateNotice() {
+    // TODO: implement
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/GeospatialUtilTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.mobilitydata.gtfsvalidator.util;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -114,10 +114,10 @@ public class StopTooFarFromTripShapeValidatorTest {
         createStopTable(
             noticeContainer,
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0),
+                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
+                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 0),
                 // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373f, -82.4170801432763D, 0)));
+                createStop(5, "1003", 17.456467, -45.4569865, 0)));
     underTest.stopTimeTable =
         createStopTimeTable(
             noticeContainer,
@@ -155,8 +155,8 @@ public class StopTooFarFromTripShapeValidatorTest {
         createStopTable(
             noticeContainer,
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4)));
+                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 4),
+                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 4)));
     underTest.stopTimeTable =
         createStopTimeTable(
             noticeContainer,

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -1,0 +1,166 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+public class StopTooFarFromTripShapeValidatorTest {
+
+  public static GtfsStopTime createStopTime(
+      long csvRowNumber, String tripId, String stopId, int stopSequence) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setStopSequence(stopSequence)
+        .setStopId(stopId)
+        .build();
+  }
+
+  private static GtfsStopTimeTableContainer createStopTimeTable(
+      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
+    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  private static GtfsTripTableContainer createTripTable(
+      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
+    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsTrip createTrip(
+      long csvRowNumber, String routeId, String serviceId, String tripId) {
+    return new GtfsTrip.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setRouteId(routeId)
+        .setServiceId(serviceId)
+        .setTripId(tripId)
+        .build();
+  }
+
+  private static GtfsShapeTableContainer createShapeTable(
+      NoticeContainer noticeContainer, List<GtfsShape> entities) {
+    return GtfsShapeTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsShape createShapePoint(
+      long csvRowNumber,
+      String shapeId,
+      double shapePtLat,
+      double shapePtLon,
+      int shapePtSequence,
+      double shapeDistTraveled) {
+    return new GtfsShape.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setShapeId(shapeId)
+        .setShapePtLat(shapePtLat)
+        .setShapePtLon(shapePtLon)
+        .setShapePtSequence(shapePtSequence)
+        .setShapeDistTraveled(shapeDistTraveled)
+        .build();
+  }
+
+  private static GtfsStopTableContainer createStopTable(
+      NoticeContainer noticeContainer, List<GtfsStop> entities) {
+    return GtfsStopTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsStop createStop(
+      long csvRowNumber, String stopId, double stopLat, double stopLon) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(stopId)
+        .setStopLat(stopLat)
+        .setStopLon(stopLon)
+        .build();
+  }
+
+  @Test
+  public void stopOutsideTripShapeShouldGenerateNotice() {
+    // See map of trip shape and stops (in GeoJSON) at
+    // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+    NoticeContainer noticeContainer = new NoticeContainer();
+    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
+
+    underTest.stopTable =
+        createStopTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D),
+                // this location is outside buffer
+                createStop(5, "1003", 28.05673053256373f, -82.4170801432763D)));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(5, "t1", "1001", 1),
+                createStopTime(8, "t1", "1002", 2),
+                createStopTime(9, "t1", "1003", 3)));
+    underTest.shapeTable =
+        createShapeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                createShapePoint(9, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                createShapePoint(
+                    11, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
+    underTest.tripTable =
+        createTripTable(
+            noticeContainer, ImmutableList.of(createTrip(55, "route id", "service id", "t1")));
+
+    underTest.validate(noticeContainer);
+
+    // FIXME: fix this test
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape id", 100));
+  }
+
+  @Test
+  public void stopWithinTripShapeShouldNotGenerateNotice() {
+    // See map of trip shape and stops (in GeoJSON) at
+    // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
+    NoticeContainer noticeContainer = new NoticeContainer();
+    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
+
+    underTest.stopTable =
+        createStopTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D)));
+    underTest.stopTimeTable =
+        createStopTimeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)));
+    underTest.shapeTable =
+        createShapeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
+    underTest.tripTable =
+        createTripTable(
+            noticeContainer, ImmutableList.of(createTrip(55, "route id", "service id", "t1")));
+
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -39,12 +39,13 @@ public class StopTooFarFromTripShapeValidatorTest {
   }
 
   public static GtfsTrip createTrip(
-      long csvRowNumber, String routeId, String serviceId, String tripId) {
+      long csvRowNumber, String routeId, String serviceId, String tripId, String shapeId) {
     return new GtfsTrip.Builder()
         .setCsvRowNumber(csvRowNumber)
         .setRouteId(routeId)
         .setServiceId(serviceId)
         .setTripId(tripId)
+        .setShapeId(shapeId)
         .build();
   }
 
@@ -76,12 +77,13 @@ public class StopTooFarFromTripShapeValidatorTest {
   }
 
   public static GtfsStop createStop(
-      long csvRowNumber, String stopId, double stopLat, double stopLon) {
+      long csvRowNumber, String stopId, double stopLat, double stopLon, int locationType) {
     return new GtfsStop.Builder()
         .setCsvRowNumber(csvRowNumber)
         .setStopId(stopId)
         .setStopLat(stopLat)
         .setStopLon(stopLon)
+        .setLocationType(locationType)
         .build();
   }
 
@@ -96,10 +98,10 @@ public class StopTooFarFromTripShapeValidatorTest {
         createStopTable(
             noticeContainer,
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D),
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0),
                 // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373f, -82.4170801432763D)));
+                createStop(5, "1003", 28.05673053256373f, -82.4170801432763D, 0)));
     underTest.stopTimeTable =
         createStopTimeTable(
             noticeContainer,
@@ -113,17 +115,15 @@ public class StopTooFarFromTripShapeValidatorTest {
             ImmutableList.of(
                 createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
                 createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(9, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(
-                    11, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
+                createShapePoint(7, "shape id", 28.05800068503469D, -82.4159394137605D, 3, 400f),
+                createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
     underTest.tripTable =
         createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(55, "route id", "service id", "t1")));
-
+            noticeContainer,
+            ImmutableList.of(createTrip(55, "route id", "service id", "t1", "shape id")));
     underTest.validate(noticeContainer);
 
-    // FIXME: fix this test
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape id", 100));
   }
@@ -139,8 +139,8 @@ public class StopTooFarFromTripShapeValidatorTest {
         createStopTable(
             noticeContainer,
             ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D)));
+                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4)));
     underTest.stopTimeTable =
         createStopTimeTable(
             noticeContainer,
@@ -157,7 +157,8 @@ public class StopTooFarFromTripShapeValidatorTest {
                 createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
     underTest.tripTable =
         createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(55, "route id", "service id", "t1")));
+            noticeContainer,
+            ImmutableList.of(createTrip(55, "route id", "service id", "t1", "shape id")));
 
     underTest.validate(noticeContainer);
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
closes #521 


**Summary:**

> This PR implements the rule to check when a stop is too far from the trip shape.
> 
> [GTFS Best Practices](https://gtfs.org/best-practices/#shapestxt) say:
> 
> >Route alignments (in shapes.txt) should be within 100 meters of stop locations which a trip serves.
> 
> Data used in unit tests is available as GeoJSON on GitHub here (GitHub provides a toggle between text and map view):
> https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
> 
> ![image](https://user-images.githubusercontent.com/928045/90898729-f39c6780-e394-11ea-8e6e-407ce1d22caf.png)
> 
> If desired, you can visualize the buffer by exporting a JTS-version of the buffer in WKT format using code at https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a#gistcomment-3425554 and then visualizing the WKT using https://arthur-e.github.io/Wicket/sandbox-gmaps3.html.
> 
> ![image](https://user-images.githubusercontent.com/928045/90898381-8ab4ef80-e394-11ea-9db1-7f0c03b8aa5c.png)
> 
> The spatial4j version of the buffer can't easily be visualized using GeoJSON or WKT because it uses a LineString and a proprietary "buffer" extension to GeoJSON and WKT, which most tools don't support.
> 

from #340 

New notice: `StopTooFarFromTripShapeNotice`
New util class: `GeospatialUtil`

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
