### PR TITLE
feat: Accept the existing feeds in feed-and-agency-lang validator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/FeedInfoLangAndAgencyLangMismatchNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/FeedInfoLangAndAgencyLangMismatchNotice.java
@@ -20,12 +20,14 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Set;
 
 public class FeedInfoLangAndAgencyLangMismatchNotice extends ValidationNotice {
-  public FeedInfoLangAndAgencyLangMismatchNotice(
-      String feedInfoLang, Set<String> agencyLangCollection) {
+  public FeedInfoLangAndAgencyLangMismatchNotice(long csvRowNumber, String agencyId, String agencyName, String agencyLang, String feedLang) {
     super(
         ImmutableMap.of(
-            "feedInfoLang", feedInfoLang,
-            "agencyLangCollection", agencyLangCollection));
+            "csvRowNumber", csvRowNumber,
+            "agencyId", agencyId,
+            "agencyName", agencyName,
+            "agencyLang", agencyLang,
+            "feedLang", feedLang));
   }
 
   @Override


### PR DESCRIPTION
To tell the truth, agency_lang field is misleading and it would be great
to deprecate it in favour of feed_lang. That would be nice to encourage
using feed_lang and omitting agency_lang.

1. We add more context to the generated error. Now it is clear which
   agency on which line is breaking the validation rule.
2. There are a lot of feeds that specify feed_lang and no agency_lang.
   They are accepted after that change.
3. The existing http://gtfs.org/reference/static/#feed_infotxt does
   not forbid having feed_lang="mul" and a single agency.
   Consider a feed that covers Biel/Bienne, sets feed_lang=mul,
   agency_lang='' and provides translations.txt for German and French.
