### PR TITLE
feat: no duplicate for `fare_rules.txt` zone id fields

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -316,6 +316,6 @@ A trip must visit more than one stop in stop_times.txt to be usable by passenger
 
 Both files calendar_dates.txt and calendar.txt are missing from the GTFS archive. At least one of the files must be provided.
 
-### DecreasingStopTimeDistanceNotice
+### DuplicateFareRuleZoneIdFieldsNotice
 
-Stop times in a trip should have increasing distance.
+The combination of `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields should be unique in GTFS file `fare_rules.txt`.

--- a/RULES.md
+++ b/RULES.md
@@ -393,4 +393,4 @@ Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100
 
 ### DuplicateFareRuleZoneIdFieldsNotice
 
-The combination of `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields should be unique in GTFS file `fare_rules.txt`.
+The combination of `fare_rules.route_id`, `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields should be unique in GTFS file `fare_rules.txt`.

--- a/RULES.md
+++ b/RULES.md
@@ -334,7 +334,7 @@ Both files calendar_dates.txt and calendar.txt are missing from the GTFS archive
 
 ### DecreasingStopTimeDistanceNotice
 
-The combination of `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields should be unique in GTFS file `fare_rules.txt`.
+Stop times in a trip should have increasing distance.
 
 ### NonAsciiOrNonPrintableCharNotice
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateFareRuleZoneIdFieldsNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateFareRuleZoneIdFieldsNotice.java
@@ -18,6 +18,10 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
 
+/**
+ * Rows from `fare_rules.txt` must be unique based on `fare_rules.route_id`,
+ * `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id`.
+ */
 public class DuplicateFareRuleZoneIdFieldsNotice extends ValidationNotice {
   public DuplicateFareRuleZoneIdFieldsNotice(
       long csvRowNumber, String fareId, long previousCsvRowNumber, String previousFareId) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateFareRuleZoneIdFieldsNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateFareRuleZoneIdFieldsNotice.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class DuplicateFareRuleZoneIdFieldsNotice extends ValidationNotice {
+  public DuplicateFareRuleZoneIdFieldsNotice(
+      long csvRowNumber, String fareId, long previousCsvRowNumber, String previousFareId) {
+    super(
+        ImmutableMap.of(
+            "csvRowNumber", csvRowNumber,
+            "fareId", fareId,
+            "previousCsvRowNumber", previousCsvRowNumber,
+            "previousFareId", previousFareId));
+  }
+
+  @Override
+  public String getCode() {
+    return "duplicate_fare_rule_zone_id_fields";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateFareRuleZoneIdFieldsNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRule;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
+
+/**
+ * Validates: unique combination of `fare_rules.origin_id`, `fare_rules.contains_id` and
+ * `fare_rules.destination_id` fields in GTFS file `fare_rules.txt`
+ *
+ * <p>Generated notice:
+ *
+ * <ul>
+ *   <li>{@link DuplicateFareRuleZoneIdFieldsNotice}
+ * </ul>
+ */
+@GtfsValidator
+public class DuplicateFareRuleZoneIdFieldsValidator extends FileValidator {
+  @Inject GtfsFareRuleTableContainer fareRuleTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    final Map<String, GtfsFareRule> fareRuleByZoneIdFieldsCombination =
+        new HashMap<>(fareRuleTable.entityCount());
+    fareRuleTable
+        .getEntities()
+        .forEach(
+            fareRule -> {
+              if (fareRule.hasOriginId()
+                  && fareRule.hasDestinationId()
+                  && fareRule.hasContainsId()) {
+                String fieldsCombination =
+                    fareRule.originId() + fareRule.containsId() + fareRule.destinationId();
+                if (fareRuleByZoneIdFieldsCombination.containsKey(fieldsCombination)) {
+                  noticeContainer.addValidationNotice(
+                      new DuplicateFareRuleZoneIdFieldsNotice(
+                          fareRule.csvRowNumber(),
+                          fareRule.fareId(),
+                          fareRuleByZoneIdFieldsCombination.get(fieldsCombination).csvRowNumber(),
+                          fareRuleByZoneIdFieldsCombination.get(fieldsCombination).fareId()));
+                } else {
+                  fareRuleByZoneIdFieldsCombination.put(
+                      fareRule.originId() + fareRule.containsId() + fareRule.destinationId(),
+                      fareRule);
+                }
+              }
+            });
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
@@ -47,25 +47,20 @@ public class DuplicateFareRuleZoneIdFieldsValidator extends FileValidator {
         .getEntities()
         .forEach(
             fareRule -> {
-              if (fareRule.hasOriginId()
-                  && fareRule.hasRouteId()
-                  && fareRule.hasDestinationId()
-                  && fareRule.hasContainsId()) {
-                String fieldsCombination =
-                    fareRule.routeId()
-                        + fareRule.originId()
-                        + fareRule.containsId()
-                        + fareRule.destinationId();
-                if (fareRuleByZoneIdFieldsCombination.containsKey(fieldsCombination)) {
-                  noticeContainer.addValidationNotice(
-                      new DuplicateFareRuleZoneIdFieldsNotice(
-                          fareRule.csvRowNumber(),
-                          fareRule.fareId(),
-                          fareRuleByZoneIdFieldsCombination.get(fieldsCombination).csvRowNumber(),
-                          fareRuleByZoneIdFieldsCombination.get(fieldsCombination).fareId()));
-                } else {
-                  fareRuleByZoneIdFieldsCombination.put(fieldsCombination, fareRule);
-                }
+              String fieldsCombination =
+                  fareRule.routeId()
+                      + fareRule.originId()
+                      + fareRule.containsId()
+                      + fareRule.destinationId();
+              if (fareRuleByZoneIdFieldsCombination.containsKey(fieldsCombination)) {
+                noticeContainer.addValidationNotice(
+                    new DuplicateFareRuleZoneIdFieldsNotice(
+                        fareRule.csvRowNumber(),
+                        fareRule.fareId(),
+                        fareRuleByZoneIdFieldsCombination.get(fieldsCombination).csvRowNumber(),
+                        fareRuleByZoneIdFieldsCombination.get(fieldsCombination).fareId()));
+              } else {
+                fareRuleByZoneIdFieldsCombination.put(fieldsCombination, fareRule);
               }
             });
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
@@ -26,8 +26,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFareRule;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
 
 /**
- * Validates: unique combination of `fare_rules.origin_id`, `fare_rules.contains_id` and
- * `fare_rules.destination_id` fields in GTFS file `fare_rules.txt`
+ * Validates: unique combination of `fare_rules.route_id`, `fare_rules.origin_id`,
+ * `fare_rules.contains_id` and `fare_rules.destination_id` fields in GTFS file `fare_rules.txt`
  *
  * <p>Generated notice:
  *
@@ -48,10 +48,14 @@ public class DuplicateFareRuleZoneIdFieldsValidator extends FileValidator {
         .forEach(
             fareRule -> {
               if (fareRule.hasOriginId()
+                  && fareRule.hasRouteId()
                   && fareRule.hasDestinationId()
                   && fareRule.hasContainsId()) {
                 String fieldsCombination =
-                    fareRule.originId() + fareRule.containsId() + fareRule.destinationId();
+                    fareRule.routeId()
+                        + fareRule.originId()
+                        + fareRule.containsId()
+                        + fareRule.destinationId();
                 if (fareRuleByZoneIdFieldsCombination.containsKey(fieldsCombination)) {
                   noticeContainer.addValidationNotice(
                       new DuplicateFareRuleZoneIdFieldsNotice(
@@ -60,9 +64,7 @@ public class DuplicateFareRuleZoneIdFieldsValidator extends FileValidator {
                           fareRuleByZoneIdFieldsCombination.get(fieldsCombination).csvRowNumber(),
                           fareRuleByZoneIdFieldsCombination.get(fieldsCombination).fareId()));
                 } else {
-                  fareRuleByZoneIdFieldsCombination.put(
-                      fareRule.originId() + fareRule.containsId() + fareRule.destinationId(),
-                      fareRule);
+                  fareRuleByZoneIdFieldsCombination.put(fieldsCombination, fareRule);
                 }
               }
             });

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateFareRuleZoneIdFieldsNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRule;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
+
+public class DuplicateFareRuleZoneIdFieldsValidatorTest {
+  private static GtfsFareRuleTableContainer createFareRuleTable(
+      NoticeContainer noticeContainer, List<GtfsFareRule> entities) {
+    return GtfsFareRuleTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsFareRule createFareRule(
+      long csvRowNumber, String fareId, String originId, String containsId, String destinationId) {
+    return new GtfsFareRule.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setFareId(fareId)
+        .setOriginId(originId)
+        .setContainsId(containsId)
+        .setDestinationId(destinationId)
+        .build();
+  }
+
+  @Test
+  public void duplicateFareRuleZoneIdValuesShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
+    underTest.fareRuleTable =
+        createFareRuleTable(
+            noticeContainer,
+            ImmutableList.of(
+                createFareRule(3, "fare id value", "from id", "by id", "to id"),
+                createFareRule(99, "other fare id value", "from id", "by id", "to id")));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new DuplicateFareRuleZoneIdFieldsNotice(99, "other fare id value", 3, "fare id value"));
+  }
+
+  @Test
+  public void noDuplicateRowValueShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
+    underTest.fareRuleTable =
+        createFareRuleTable(
+            noticeContainer,
+            ImmutableList.of(
+                createFareRule(3, "fare id value", "from id", "by id", "to id"),
+                createFareRule(99, "other fare id value", "other from id", "by id", "to id")));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
@@ -33,9 +33,15 @@ public class DuplicateFareRuleZoneIdFieldsValidatorTest {
   }
 
   public static GtfsFareRule createFareRule(
-      long csvRowNumber, String fareId, String originId, String containsId, String destinationId) {
+      long csvRowNumber,
+      String fareId,
+      String routeId,
+      String originId,
+      String containsId,
+      String destinationId) {
     return new GtfsFareRule.Builder()
         .setCsvRowNumber(csvRowNumber)
+        .setRouteId(routeId)
         .setFareId(fareId)
         .setOriginId(originId)
         .setContainsId(containsId)
@@ -51,8 +57,14 @@ public class DuplicateFareRuleZoneIdFieldsValidatorTest {
         createFareRuleTable(
             noticeContainer,
             ImmutableList.of(
-                createFareRule(3, "fare id value", "from id", "by id", "to id"),
-                createFareRule(99, "other fare id value", "from id", "by id", "to id")));
+                createFareRule(3, "fare id value", "route id value", "from id", "by id", "to id"),
+                createFareRule(
+                    99,
+                    "other fare id value",
+                    "route id value",
+                    "from id",
+                    "by id",
+                    "to id")));
     underTest.validate(noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices())
@@ -68,8 +80,9 @@ public class DuplicateFareRuleZoneIdFieldsValidatorTest {
         createFareRuleTable(
             noticeContainer,
             ImmutableList.of(
-                createFareRule(3, "fare id value", "from id", "by id", "to id"),
-                createFareRule(99, "other fare id value", "other from id", "by id", "to id")));
+                createFareRule(3, "fare id value", "route id", "from id", "by id", "to id"),
+                createFareRule(
+                    99, "other fare id value", "route id", "other from id", "by id", "to id")));
     underTest.validate(noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
@@ -59,12 +59,7 @@ public class DuplicateFareRuleZoneIdFieldsValidatorTest {
             ImmutableList.of(
                 createFareRule(3, "fare id value", "route id value", "from id", "by id", "to id"),
                 createFareRule(
-                    99,
-                    "other fare id value",
-                    "route id value",
-                    "from id",
-                    "by id",
-                    "to id")));
+                    99, "other fare id value", "route id value", "from id", "by id", "to id")));
     underTest.validate(noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices())
@@ -86,5 +81,36 @@ public class DuplicateFareRuleZoneIdFieldsValidatorTest {
     underTest.validate(noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void noDuplicateRowWithEmptyValuesValueShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
+    underTest.fareRuleTable =
+        createFareRuleTable(
+            noticeContainer,
+            ImmutableList.of(
+                createFareRule(3, "fare id value", "route id", null, "by id", "to id"),
+                createFareRule(
+                    99, "other fare id value", "route id", "other from id", null, "to id")));
+    underTest.validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void duplicateFareRuleWithSomeEmptyValuesShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
+    underTest.fareRuleTable =
+        createFareRuleTable(
+            noticeContainer,
+            ImmutableList.of(
+                createFareRule(3, "fare id value", "route id", null, "by id", "to id"),
+                createFareRule(99, "other fare id value", "route id", null, "by id", "to id")));
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new DuplicateFareRuleZoneIdFieldsNotice(99, "other fare id value", 3, "fare id value"));
   }
 }


### PR DESCRIPTION
closes #356

**Summary:**

This PR implements a new validation rule: the combination of `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields should be unique in GTFS file `fare_rules.txt`.

**Expected behavior:** 

- a notice should be generated if two (or more rows) from GTFS files `fare_rules.txt` have duplicate value for the combination of  `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
