### PR TITLE
fix: to persist the cli app as an artifact in GitHub workflow

### DIFF
--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -108,4 +108,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Application - cli executable .jar -- ${{ steps.prep.outputs.versionTag }}
-          path: application/cli-app/build/libs/gtfs-validator-${{ steps.prep.outputs.versionTag }}_cli.jar
+          path: main/cli/build/libs/gtfs-validator-${{ steps.prep.outputs.versionTag }}_cli.jar

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -108,4 +108,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Application - cli executable .jar -- ${{ steps.prep.outputs.versionTag }}
-          path: main/cli/build/libs/gtfs-validator-${{ steps.prep.outputs.versionTag }}_cli.jar
+          path: main/build/libs/gtfs-validator-${{ steps.prep.outputs.versionTag }}_cli.jar


### PR DESCRIPTION
closes #720 
**Summary:**

This PR provides support to persist the cli app as an artifact in GitHub workflow

**Expected behavior:** 

No code change. Application jar should be persisted after build.

✅ `.jar` is persisted after build
<img width="939" alt="Capture d’écran, le 2021-02-03 à 16 40 20" src="https://user-images.githubusercontent.com/35747326/106806643-96445c00-663e-11eb-897a-506a5aa91e17.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
