### PR TITLE
fix: paths to failed test reports

### DIFF
--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -59,14 +59,9 @@ jobs:
         with:
           name: Test report - Java -- ${{ steps.prep.outputs.versionTag }}
           path: |
-            adapter/exporter/build/reports/tests/
-            adapter/parser/build/reports/tests/
-            adapter/repository/in-memory-simple/build/reports/tests/
-            adapter/tree/build/reports/tests/
-            adapter/utils/build/reports/tests/
-            adapter/validator/build/reports/tests/
-            domain/build/reports/tests/
-            usecase/build/reports/tests/
+            core/build/reports/tests/
+            main/build/reports/tests/
+            processor/build/reports/tests/
 
   pack:
     needs: [test]

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -77,8 +77,7 @@ public class AgencyConsistencyValidatorTest {
                     Locale.CANADA)));
 
     underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new MissingRequiredFieldError("agency.txt", 1, "agency_id"));
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -77,7 +77,8 @@ public class AgencyConsistencyValidatorTest {
                     Locale.CANADA)));
 
     underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingRequiredFieldError("agency.txt", 1, "agency_id"));
   }
 
   @Test


### PR DESCRIPTION
closes #722 

**Summary:**

This PR provides support to persist all tests reports as an artifact in GitHub workflow

**Expected behavior:** 

No code change. Reports for failed tests should be persisted an an artefact in GitHub workflow.

✅ reports for failed are generated (https://github.com/MobilityData/gtfs-validator/pull/723/commits/91aa30bd17686c052ce3cc01f688b943d6762960)
<img width="820" alt="Capture d’écran, le 2021-02-03 à 16 50 21" src="https://user-images.githubusercontent.com/35747326/106808141-639b6300-6640-11eb-86d3-9f35aea59e10.png">

✅ reports for failed test are persisted after running GitHub workflow
<img width="797" alt="Capture d’écran, le 2021-02-03 à 16 53 01" src="https://user-images.githubusercontent.com/35747326/106808158-672eea00-6640-11eb-8cf9-ae8d1bab32a0.png">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
