### PR TITLE
feat: Export severity in JSON

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -68,11 +68,12 @@ public class NoticeContainer {
     JsonArray jsonNotices = new JsonArray();
     root.add("notices", jsonNotices);
 
-    ListMultimap<Integer, T> noticesByType = groupNoticesByType(notices);
-    for (Collection<T> noticesOfType : noticesByType.asMap().values()) {
+    for (Collection<T> noticesOfType : groupNoticesByTypeAndSeverity(notices).asMap().values()) {
       JsonObject noticesOfTypeJson = new JsonObject();
       jsonNotices.add(noticesOfTypeJson);
-      noticesOfTypeJson.addProperty("code", noticesOfType.iterator().next().getCode());
+      T firstNotice = noticesOfType.iterator().next();
+      noticesOfTypeJson.addProperty("code", firstNotice.getCode());
+      noticesOfTypeJson.addProperty("severity", firstNotice.getSeverityLevel().toString());
       noticesOfTypeJson.addProperty("totalNotices", noticesOfType.size());
       JsonArray noticesArrayJson = new JsonArray();
       noticesOfTypeJson.add("notices", noticesArrayJson);
@@ -90,10 +91,11 @@ public class NoticeContainer {
     return DEFAULT_GSON.toJson(root);
   }
 
-  private static <T extends Notice> ListMultimap<Integer, T> groupNoticesByType(List<T> notices) {
-    ListMultimap<Integer, T> noticesByType = MultimapBuilder.treeKeys().arrayListValues().build();
+  private static <T extends Notice> ListMultimap<String, T> groupNoticesByTypeAndSeverity(
+      List<T> notices) {
+    ListMultimap<String, T> noticesByType = MultimapBuilder.treeKeys().arrayListValues().build();
     for (T notice : notices) {
-      noticesByType.put(notice.getClass().hashCode(), notice);
+      noticesByType.put(notice.getCode() + notice.getSeverityLevel().ordinal(), notice);
     }
     return noticesByType;
   }


### PR DESCRIPTION
Issue #549

Notices of different severities are grouped independently. This we make
sure that they the MAX_EXPORTS_PER_NOTICE_TYPE limit is applied to
errors and warnings independently.

We chose "severity" instead of "severityLevel" in the JSON format
because the former is shorter.

We also sort the exported notices alphabetically by code and severity.
This makes the report more readable (earlier we sorted them by hashes
that is stable but randomized).