### PR TITLE
feat: Treat NonAsciiOrNonPrintableCharNotice as a warning instead of error

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
@@ -18,14 +18,15 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
 
-/** A row in the input file has a different number of values than specified by the CSV header. */
+/** ID value contains something different from printable ASCII characters. */
 public class NonAsciiOrNonPrintableCharNotice extends ValidationNotice {
   public NonAsciiOrNonPrintableCharNotice(String filename, long csvRowNumber, String columnName) {
     super(
         ImmutableMap.of(
             "filename", filename,
             "csvRowNumber", csvRowNumber,
-            "columnName", columnName));
+            "columnName", columnName),
+        SeverityLevel.WARNING);
   }
 
   @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -195,6 +195,19 @@ public class RowParserTest {
     parser.asId(0, true);
     assertThat(parser.getNoticeContainer().getValidationNotices())
         .containsExactly(new NonAsciiOrNonPrintableCharNotice("filename", 8L, "column name"));
+    // Non-ASCII characters in ID are not an error. Validation may continue.
+    assertThat(parser.hasParseErrorsInRow()).isFalse();
+  }
+
+  @Test
+  public void hasOnlyPrintableAscii() {
+    assertThat(RowParser.hasOnlyPrintableAscii("abc")).isTrue();
+    assertThat(RowParser.hasOnlyPrintableAscii("a bc")).isTrue();
+    assertThat(RowParser.hasOnlyPrintableAscii("@<>&*()!")).isTrue();
+    // Cyrillic - not ASCII.
+    assertThat(RowParser.hasOnlyPrintableAscii("Привет!")).isFalse();
+    // Non-printable.
+    assertThat(RowParser.hasOnlyPrintableAscii("\01\23")).isFalse();
   }
 
   @Test


### PR DESCRIPTION
Issue #549

An error in RowParser stops validation for the whole feed. However, if
ID has non-printable or non-ASCII characters, the feed may be still
successfully parsed and served to the end user.

We are lowering priority of NonAsciiOrNonPrintableCharNotice to WARNING
and modify RowParser so that it checks severity level of its notices.

We also simplify the code of asId function and reduce amount of calls to
row.asString from 3 to 1.
