### PR TITLE
feat: Strip leading and trailing whitespaces and emit an error

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * The value in CSV file has leading or trailing whitespaces.
+ *
+ * <p>This warning is emitted for values protected with double quotes since whitespaces for
+ * non-protected values are trimmed automatically by CSV parser.
+ *
+ * <p>Note that this is a warning: not an error because the feed may be still parsed and also not an
+ * info because leading and trailing whitespaces are ambiguous and we want the feed providers to be
+ * aware of them.
+ *
+ * <p>GTFS Validator strips whitespaces from protected values. We do not see any use case when such
+ * a whitespace may be needed. On the other hand, some real-world feeds use trailing whitespaces for
+ * some values and omit them for the others. This is causing the largest problem when a primary key
+ * and a foreign key differ just by a whitespace: it is clear that they are intended to be the same,
+ * that is why we always strip whitespaces.
+ */
+public class LeadingOrTrailingWhitespacesNotice extends ValidationNotice {
+
+  public LeadingOrTrailingWhitespacesNotice(
+      String filename, long csvRowNumber, String fieldName, String fieldValue) {
+    super(
+        ImmutableMap.of(
+            "filename",
+            filename,
+            "csvRowNumber",
+            csvRowNumber,
+            "fieldName",
+            fieldName,
+            "fieldValue",
+            fieldValue),
+        SeverityLevel.WARNING);
+  }
+
+  @Override
+  public String getCode() {
+    return "leading_or_trailing_whitespace";
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
@@ -21,12 +21,11 @@ import com.google.common.collect.ImmutableMap;
 /**
  * The value in CSV file has leading or trailing whitespaces.
  *
- * <p>This warning is emitted for values protected with double quotes since whitespaces for
+ * <p>This notice is emitted for values protected with double quotes since whitespaces for
  * non-protected values are trimmed automatically by CSV parser.
  *
- * <p>Note that this is a warning: not an error because the feed may be still parsed and also not an
- * info because leading and trailing whitespaces are ambiguous and we want the feed providers to be
- * aware of them.
+ * <p>This is an error in the upstream validator but GTFS consumers can patch it to be a warning if
+ * they have feeds that give leading or trailing whitespaces.
  *
  * <p>GTFS Validator strips whitespaces from protected values. We do not see any use case when such
  * a whitespace may be needed. On the other hand, some real-world feeds use trailing whitespaces for
@@ -48,7 +47,7 @@ public class LeadingOrTrailingWhitespacesNotice extends ValidationNotice {
             fieldName,
             "fieldValue",
             fieldValue),
-        SeverityLevel.WARNING);
+        SeverityLevel.ERROR);
   }
 
   @Override

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
@@ -59,7 +59,7 @@ public class CsvFile implements Iterable<CsvRow> {
     settings.getFormat().setLineSeparator("\n");
     settings.getFormat().setDelimiter(',');
     settings.setHeaderExtractionEnabled(true);
-    // Explicitly disable trimming of whitespaces because we will emit warnings for them.
+    // Explicitly disable trimming of whitespaces because we will emit notices for them.
     settings.setIgnoreLeadingWhitespacesInQuotes(false);
     settings.setIgnoreTrailingWhitespacesInQuotes(false);
     parser = new CsvParser(settings);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
@@ -59,6 +59,9 @@ public class CsvFile implements Iterable<CsvRow> {
     settings.getFormat().setLineSeparator("\n");
     settings.getFormat().setDelimiter(',');
     settings.setHeaderExtractionEnabled(true);
+    // Explicitly disable trimming of whitespaces because we will emit warnings for them.
+    settings.setIgnoreLeadingWhitespacesInQuotes(false);
+    settings.setIgnoreTrailingWhitespacesInQuotes(false);
     parser = new CsvParser(settings);
     parser.beginParsing(reader);
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -27,6 +27,7 @@ import org.apache.commons.validator.routines.UrlValidator;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.FieldParsingError;
 import org.mobilitydata.gtfsvalidator.notice.InvalidRowLengthError;
+import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -208,6 +209,15 @@ public class RowParser {
       addNoticeInRow(
           new MissingRequiredFieldError(
               row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex)));
+    }
+    if (s != null) {
+      final String trimmed = s.strip();
+      if (trimmed.length() < s.length()) {
+        addNoticeInRow(
+            new LeadingOrTrailingWhitespacesNotice(
+                row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex), s));
+        s = trimmed;
+      }
     }
     return s;
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -211,12 +211,12 @@ public class RowParser {
               row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex)));
     }
     if (s != null) {
-      final String trimmed = s.strip();
-      if (trimmed.length() < s.length()) {
+      final String stripped = s.strip();
+      if (stripped.length() < s.length()) {
         addNoticeInRow(
             new LeadingOrTrailingWhitespacesNotice(
                 row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex), s));
-        s = trimmed;
+        s = stripped;
       }
     }
     return s;

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -29,6 +29,7 @@ import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
 import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
@@ -233,12 +234,14 @@ public class RowParserTest {
 
   @Test
   public void whitespaces() {
-    // Protected whitespaces are stripped. This is a warning, not an error.
+    // Protected whitespaces are stripped. This is an error but GTFS consumers may patch it to be a
+    // warning.
     RowParser parser = createParser(" 1\t");
     assertThat(parser.asInteger(0, true)).isEqualTo(1);
-    assertThat(parser.hasParseErrorsInRow()).isFalse();
-    assertThat(parser.getNoticeContainer().getValidationNotices())
-        .containsExactly(
-            new LeadingOrTrailingWhitespacesNotice("filename", 8, "column name", " 1\t"));
+    LeadingOrTrailingWhitespacesNotice notice =
+        new LeadingOrTrailingWhitespacesNotice("filename", 8, "column name", " 1\t");
+    assertThat(parser.hasParseErrorsInRow())
+        .isEqualTo(notice.getSeverityLevel() == SeverityLevel.ERROR);
+    assertThat(parser.getNoticeContainer().getValidationNotices()).containsExactly(notice);
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
+import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
 import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
@@ -228,5 +229,16 @@ public class RowParserTest {
     assertThat(createParser("-181").asLongitude(0, true)).isNull();
     assertThat(createParser("181").asLongitude(0, true)).isNull();
     assertThat(createParser("invalid").asLongitude(0, true)).isNull();
+  }
+
+  @Test
+  public void whitespaces() {
+    // Protected whitespaces are stripped. This is a warning, not an error.
+    RowParser parser = createParser(" 1\t");
+    assertThat(parser.asInteger(0, true)).isEqualTo(1);
+    assertThat(parser.hasParseErrorsInRow()).isFalse();
+    assertThat(parser.getNoticeContainer().getValidationNotices())
+        .containsExactly(
+            new LeadingOrTrailingWhitespacesNotice("filename", 8, "column name", " 1\t"));
   }
 }


### PR DESCRIPTION
feat: Strip leading and trailing whitespaces and emit a warning

GTFS reference says:
Remove any extra spaces between fields or field names. Many parsers
consider the spaces to be part of the value, which may cause errors.

GTFS Validator strips whitespaces from protected values. We do not
see any use case when such a whitespace may be needed. On the other
hand, some real-world feeds use trailing whitespaces for some values
and omit them for the others. This is causing the largest problem
when a primary key and a foreign key differ just by a whitespace:
it is clear that they are intended to be the same, that is why we
always strip whitespaces.

Note that this is a warning:
* not an error because the feed may be still parsed;
* not an info because leading and trailing whitespaces are ambiguous
  and we want the feed providers to be aware of them.

