### PR TITLE
feat: Allow agencies to omit agency_lang without errors

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/InconsistentAgencyLangNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/InconsistentAgencyLangNotice.java
@@ -18,19 +18,18 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
 
-public class InconsistentAgencyFieldNotice extends ValidationNotice {
-  public InconsistentAgencyFieldNotice(
-      long csvRowNumber, String fieldName, String expected, String actual) {
+public class InconsistentAgencyLangNotice extends ValidationNotice {
+  public InconsistentAgencyLangNotice(long csvRowNumber, String expected, String actual) {
     super(
         ImmutableMap.of(
             "csvRowNumber", csvRowNumber,
-            "fieldName", fieldName,
             "expected", expected,
-            "actual", actual));
+            "actual", actual),
+        SeverityLevel.WARNING);
   }
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_field";
+    return "inconsistent_agency_lang";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/InconsistentAgencyTimezoneNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/InconsistentAgencyTimezoneNotice.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+public class InconsistentAgencyTimezoneNotice extends ValidationNotice {
+  public InconsistentAgencyTimezoneNotice(long csvRowNumber, String expected, String actual) {
+    super(
+        ImmutableMap.of(
+            "csvRowNumber", csvRowNumber,
+            "expected", expected,
+            "actual", actual));
+  }
+
+  @Override
+  public String getCode() {
+    return "inconsistent_agency_timezone";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -20,7 +20,8 @@ import java.time.ZoneId;
 import java.util.Locale;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.annotation.Inject;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyLangNotice;
+import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyTimezoneNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
@@ -35,8 +36,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
  *
  * <ul>
  *   <li>{@link MissingRequiredFieldError} - multiple agencies present but no agency_id set
- *   <li>{@link InconsistentAgencyFieldNotice} - inconsistent timezone or language among the
- *       agencies
+ *   <li>{@link InconsistentAgencyTimezoneNotice} - inconsistent timezone among the agencies
+ *   <li>{@link InconsistentAgencyLangNotice} - inconsistent language among the agencies
  * </ul>
  */
 @GtfsValidator
@@ -68,11 +69,8 @@ public class AgencyConsistencyValidator extends FileValidator {
       GtfsAgency agency = agencyTable.getEntities().get(i);
       if (!commonTimezone.equals(agency.agencyTimezone())) {
         noticeContainer.addValidationNotice(
-            new InconsistentAgencyFieldNotice(
-                agency.csvRowNumber(),
-                GtfsAgencyTableLoader.AGENCY_TIMEZONE_FIELD_NAME,
-                commonTimezone.getId(),
-                agency.agencyTimezone().getId()));
+            new InconsistentAgencyTimezoneNotice(
+                agency.csvRowNumber(), commonTimezone.getId(), agency.agencyTimezone().getId()));
       }
     }
 
@@ -89,9 +87,8 @@ public class AgencyConsistencyValidator extends FileValidator {
         commonLanguage = agency.agencyLang();
       } else if (!commonLanguage.equals(agency.agencyLang())) {
         noticeContainer.addValidationNotice(
-            new InconsistentAgencyFieldNotice(
+            new InconsistentAgencyLangNotice(
                 agency.csvRowNumber(),
-                GtfsAgencyTableLoader.AGENCY_LANG_FIELD_NAME,
                 commonLanguage.getLanguage(),
                 agency.agencyLang().getLanguage()));
       }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.Locale;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
@@ -42,7 +43,7 @@ public class AgencyConsistencyValidatorTest {
       String agencyName,
       String agencyUrl,
       ZoneId agencyTimezone,
-      Locale agencyLang) {
+      @Nullable Locale agencyLang) {
     return new GtfsAgency.Builder()
         .setCsvRowNumber(csvRowNumber)
         .setAgencyId(agencyId)
@@ -188,6 +189,40 @@ public class AgencyConsistencyValidatorTest {
                     "www.mobilitydata.org",
                     ZoneId.of("America/Montreal"),
                     Locale.CANADA)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void agenciesWithOmittedLanguageShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    AgencyConsistencyValidator underTest = new AgencyConsistencyValidator();
+    underTest.agencyTable =
+        createAgencyTable(
+            noticeContainer,
+            ImmutableList.of(
+                createAgency(
+                    1,
+                    "first agency",
+                    "first agency name",
+                    "www.mobilitydata.org",
+                    ZoneId.of("America/Montreal"),
+                    null),
+                createAgency(
+                    2,
+                    "second agency",
+                    "second agency name",
+                    "www.mobilitydata.org",
+                    ZoneId.of("America/Montreal"),
+                    Locale.CANADA_FRENCH),
+                createAgency(
+                    3,
+                    "third agency",
+                    "third agency name",
+                    "www.mobilitydata.org",
+                    ZoneId.of("America/Montreal"),
+                    Locale.CANADA_FRENCH)));
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices()).isEmpty();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -24,7 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyLangNotice;
+import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyTimezoneNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
@@ -108,8 +109,7 @@ public class AgencyConsistencyValidatorTest {
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(
-            new InconsistentAgencyFieldNotice(
-                1, "agency_timezone", "America/Bogota", "America/Montreal"));
+            new InconsistentAgencyTimezoneNotice(1, "America/Bogota", "America/Montreal"));
   }
 
   @Test
@@ -164,7 +164,7 @@ public class AgencyConsistencyValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new InconsistentAgencyFieldNotice(1, "agency_lang", "en", "fr"));
+        .containsExactly(new InconsistentAgencyLangNotice(1, "en", "fr"));
   }
 
   @Test


### PR DESCRIPTION
Some real-world feeds provide agency_lang only for some agencies and
omit it for the rest since this field is optional. Those feeds are
accepted at Google, that is why we relax the existing validation rule.

In general, agency_lang field should be discouraged and feed_lang should
be used instead.