### PR TITLE
feat: Support optional primary keys

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.processor;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.byKeyMapName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.byKeyMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.fieldNameField;
+import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.hasMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.GtfsEntityClasses.TABLE_PACKAGE_NAME;
 
 import com.google.common.collect.ArrayListMultimap;
@@ -48,6 +49,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
  * <p>E.g., GtfsStopTableContainer class is generated for "stops.txt".
  */
 public class TableContainerGenerator {
+
   private final GtfsFileDescriptor fileDescriptor;
   private final GtfsEntityClasses classNames;
 
@@ -274,6 +276,9 @@ public class TableContainerGenerator {
       String byKeyMap = byKeyMapName(primaryKey.name());
       method.beginControlFlow("for ($T newEntity : entities)", gtfsEntityType);
       method
+          .beginControlFlow("if (!newEntity.$L())", hasMethodName(primaryKey.name()))
+          .addStatement("continue")
+          .endControlFlow()
           .addStatement(
               "$T oldEntity = $L.getOrDefault(newEntity.$L(), null)",
               classNames.entityImplementationTypeName(),


### PR DESCRIPTION
Some tables such as agency.txt and attributions.txt have optional
primary keys. When a key is set, it must be unique. At the same time,
several attributions are allowed to have no attribution_id.

Generated code for GtfsAttributionTableContainer.

```java
  private void setupIndices(NoticeContainer noticeContainer) {
    for (GtfsAttribution newEntity : entities) {
      if (!newEntity.hasAttributionId()) {
        continue;
      }
      GtfsAttribution oldEntity = byAttributionIdMap.getOrDefault(newEntity.attributionId(), null);
      if (oldEntity != null) {
        noticeContainer.addValidationNotice(new DuplicateKeyError(gtfsFilename(), newEntity.csvRowNumber(), oldEntity.csvRowNumber(), GtfsAttributionTableLoader.ATTRIBUTION_ID_FIELD_NAME, newEntity.attributionId()));
      } else {
        byAttributionIdMap.put(newEntity.attributionId(), newEntity);
      }
    }
  }
```