### PR TITLE
fix: remove requirement on feed_info.start_date and feed_info.end_date

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -10,7 +10,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 
 | Error ID (v2.0+) | Error ID (v1.x) 	| Error Title                                                             	|
 |--------------------------	|--------------------	|-------------------------------------------------------------------------	|
-| [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [E015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E015), [W010](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010), [W011](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011), [E029](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E029)      	| Missing required `field`. `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided. Missing field `agency_id` for file `agency.txt` with more than 1 record.                                                	|
+| [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [E015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E015), [E029](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E029)      	| Missing required `field`. Missing field `agency_id` for file `agency.txt` with more than 1 record.|
 | [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)  |        	            | Duplicated column                                                      	|
 | [`MissingRequiredColumn`](#MissingRequiredColumn)   | [E001](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E001)          | Missing required column                                                  	|
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice) |        	            | More than one row in CSV                                                 	|
@@ -67,9 +67,12 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                           | [W006](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W006)        	| Missing route short name                                                        	|
 |                           | [W007](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W007)        	| Missing route long name                                                         	|
 |                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W008)        	| Route long name contains short name                                             	|
+|                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010)        	| `feed_end_date` should be provided if `feed_start_date` is provided.  |
+|                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011)        	| `feed_start_date` should be provided if `feed_end_date` is provided.  |
 |[`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)| [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 || [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 
+ 
 ## Notices
 
 <a name="MissingRequiredFieldError"/>

--- a/RULES.md
+++ b/RULES.md
@@ -10,7 +10,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 
 | Error ID (v2.0+) | Error ID (v1.x) 	| Error Title                                                             	|
 |--------------------------	|--------------------	|-------------------------------------------------------------------------	|
-| [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [E015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E015), [E029](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E029)      	| Missing required `field`. Missing field `agency_id` for file `agency.txt` with more than 1 record.|
+| [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [E015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E015), [W010](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010), [W011](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011), [E029](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E029)      	| Missing required `field`. `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided. Missing field `agency_id` for file `agency.txt` with more than 1 record.                                                	|
 | [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)  |        	            | Duplicated column                                                      	|
 | [`MissingRequiredColumn`](#MissingRequiredColumn)   | [E001](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E001)          | Missing required column                                                  	|
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice) |        	            | More than one row in CSV                                                 	|
@@ -67,12 +67,9 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                           | [W006](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W006)        	| Missing route short name                                                        	|
 |                           | [W007](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W007)        	| Missing route long name                                                         	|
 |                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W008)        	| Route long name contains short name                                             	|
-|                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010)        	| `feed_end_date` should be provided if `feed_start_date` is provided.  |
-|                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011)        	| `feed_start_date` should be provided if `feed_end_date` is provided.  |
 |[`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)| [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 || [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 
- 
 ## Notices
 
 <a name="MissingRequiredFieldError"/>

--- a/RULES.md
+++ b/RULES.md
@@ -10,7 +10,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 
 | Error ID (v2.0+) | Error ID (v1.x) 	| Error Title                                                             	|
 |--------------------------	|--------------------	|-------------------------------------------------------------------------	|
-| [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [E015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E015), [W010](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010), [W011](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011), [E029](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E029)      	| Missing required `field`. `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided. Missing field `agency_id` for file `agency.txt` with more than 1 record.                                                	|
+| [`MissingRequiredFieldError`](#MissingRequiredFieldError) | [E015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E015), [E029](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E029)      	| Missing required `field`. Missing field `agency_id` for file `agency.txt` with more than 1 record.                                                	|
 | [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)  |        	            | Duplicated column                                                      	|
 | [`MissingRequiredColumn`](#MissingRequiredColumn)   | [E001](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E001)          | Missing required column                                                  	|
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice) |        	            | More than one row in CSV                                                 	|
@@ -67,6 +67,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 |                           | [W006](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W006)        	| Missing route short name                                                        	|
 |                           | [W007](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W007)        	| Missing route long name                                                         	|
 |                           | [W008](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W008)        	| Route long name contains short name                                             	|
+|[`MissingFeedInfoDateNotice`](#MissingFeedInfoDateNotice)| [W010](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010), [W011](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011)| `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided. |
 |[`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)| [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 || [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 
@@ -394,3 +395,9 @@ Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100
 ### DuplicateFareRuleZoneIdFieldsNotice
 
 The combination of `fare_rules.route_id`, `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id` fields should be unique in GTFS file `fare_rules.txt`.
+
+<a name="MissingFeedInfoDateNotice"/>
+
+### MissingFeedInfoDateNotice
+
+Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one field is provided the second one should also be provided.

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingFeedInfoDateNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingFeedInfoDateNotice.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one field is
+ * provided the second one should also be provided.
+ *
+ * <p>Severity: {@code SeverityLevel.WARNING}
+ */
+public class MissingFeedInfoDateNotice extends ValidationNotice {
+  public MissingFeedInfoDateNotice(long csvRowNumber, String fieldName) {
+    super(
+        ImmutableMap.of("csvRowNumber", csvRowNumber, "fieldName", fieldName),
+        SeverityLevel.WARNING);
+  }
+
+  @Override
+  public String getCode() {
+    return "missing_feed_info_start_date_or_end_date";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -18,7 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.annotation.Inject;
-import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
+import org.mobilitydata.gtfsvalidator.notice.MissingFeedInfoDateNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -40,12 +40,10 @@ public class FeedServiceDateValidator extends FileValidator {
     for (GtfsFeedInfo feedInfo : feedInfoTable.getEntities()) {
       if (feedInfo.hasFeedStartDate() && !feedInfo.hasFeedEndDate()) {
         noticeContainer.addValidationNotice(
-            new MissingRequiredFieldError(
-                feedInfoTable.gtfsFilename(), feedInfo.csvRowNumber(), "feed_end_date"));
+            new MissingFeedInfoDateNotice(feedInfo.csvRowNumber(), "feed_end_date"));
       } else if (!feedInfo.hasFeedStartDate() && feedInfo.hasFeedEndDate()) {
         noticeContainer.addValidationNotice(
-            new MissingRequiredFieldError(
-                feedInfoTable.gtfsFilename(), feedInfo.csvRowNumber(), "feed_start_date"));
+            new MissingFeedInfoDateNotice(feedInfo.csvRowNumber(), "feed_start_date"));
       }
       if (feedInfo.hasFeedStartDate()
           && feedInfo.hasFeedEndDate()

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -18,16 +18,13 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.annotation.Inject;
-import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
 
 /**
- * Validates 3 rules: 1) start_date <= end_date for all rows in "feed_info.txt" 2)
- * feed_info.start_date is provided if feed_info.end_date is provided 3) feed_info.end_date is
- * provided if feed_info.start_date is provided.
+ * Validates: start_date <= end_date for all rows in "feed_info.txt"
  *
  * <p>Generated notice: {@link StartAndEndDateOutOfOrderNotice}.
  */
@@ -38,15 +35,6 @@ public class FeedServiceDateValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsFeedInfo feedInfo : feedInfoTable.getEntities()) {
-      if (feedInfo.hasFeedStartDate() && !feedInfo.hasFeedEndDate()) {
-        noticeContainer.addValidationNotice(
-            new MissingRequiredFieldError(
-                feedInfoTable.gtfsFilename(), feedInfo.csvRowNumber(), "feed_end_date"));
-      } else if (!feedInfo.hasFeedStartDate() && feedInfo.hasFeedEndDate()) {
-        noticeContainer.addValidationNotice(
-            new MissingRequiredFieldError(
-                feedInfoTable.gtfsFilename(), feedInfo.csvRowNumber(), "feed_start_date"));
-      }
       if (feedInfo.hasFeedStartDate()
           && feedInfo.hasFeedEndDate()
           && feedInfo.feedStartDate().isAfter(feedInfo.feedEndDate())) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -18,13 +18,16 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.annotation.Inject;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
 
 /**
- * Validates: start_date <= end_date for all rows in "feed_info.txt"
+ * Validates 3 rules: 1) start_date <= end_date for all rows in "feed_info.txt" 2)
+ * feed_info.start_date is provided if feed_info.end_date is provided 3) feed_info.end_date is
+ * provided if feed_info.start_date is provided.
  *
  * <p>Generated notice: {@link StartAndEndDateOutOfOrderNotice}.
  */
@@ -35,6 +38,15 @@ public class FeedServiceDateValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsFeedInfo feedInfo : feedInfoTable.getEntities()) {
+      if (feedInfo.hasFeedStartDate() && !feedInfo.hasFeedEndDate()) {
+        noticeContainer.addValidationNotice(
+            new MissingRequiredFieldError(
+                feedInfoTable.gtfsFilename(), feedInfo.csvRowNumber(), "feed_end_date"));
+      } else if (!feedInfo.hasFeedStartDate() && feedInfo.hasFeedEndDate()) {
+        noticeContainer.addValidationNotice(
+            new MissingRequiredFieldError(
+                feedInfoTable.gtfsFilename(), feedInfo.csvRowNumber(), "feed_start_date"));
+      }
       if (feedInfo.hasFeedStartDate()
           && feedInfo.hasFeedEndDate()
           && feedInfo.feedStartDate().isAfter(feedInfo.feedEndDate())) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
+import org.mobilitydata.gtfsvalidator.notice.MissingFeedInfoDateNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -108,7 +108,7 @@ public class FeedServiceDateValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new MissingRequiredFieldError("feed_info.txt", 1, "feed_start_date"));
+        .containsExactly(new MissingFeedInfoDateNotice(1, "feed_start_date"));
   }
 
   @Test
@@ -131,7 +131,7 @@ public class FeedServiceDateValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new MissingRequiredFieldError("feed_info.txt", 1, "feed_end_date"));
+        .containsExactly(new MissingFeedInfoDateNotice(1, "feed_end_date"));
   }
 
   @Test
@@ -142,7 +142,7 @@ public class FeedServiceDateValidatorTest {
             noticeContainer,
             ImmutableList.of(
                 createFeedInfo(
-                    1, "name value", "www.mobilitydata.org", Locale.CANADA, null, null)));
+                    1, "name value", "https://www.mobilitydata.org", Locale.CANADA, null, null)));
 
     FeedServiceDateValidator underTest = new FeedServiceDateValidator();
     underTest.feedInfoTable = gtfsFeedInfoTable;
@@ -161,7 +161,7 @@ public class FeedServiceDateValidatorTest {
                 createFeedInfo(
                     1,
                     "name value",
-                    "www.mobilitydata.org",
+                    "https://www.mobilitydata.org",
                     Locale.CANADA,
                     GtfsDate.fromEpochDay(450),
                     GtfsDate.fromEpochDay(555))));

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -88,7 +89,7 @@ public class FeedServiceDateValidatorTest {
   }
 
   @Test
-  public void noStartDateShouldNotGenerateNotice() {
+  public void noStartDateShouldGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsFeedInfoTableContainer gtfsFeedInfoTable =
         createFeedInfoTable(
@@ -106,11 +107,12 @@ public class FeedServiceDateValidatorTest {
     underTest.feedInfoTable = gtfsFeedInfoTable;
 
     underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingRequiredFieldError("feed_info.txt", 1, "feed_start_date"));
   }
 
   @Test
-  public void noEndDateShouldNotGenerateNotice() {
+  public void noEndDateShouldGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsFeedInfoTableContainer gtfsFeedInfoTable =
         createFeedInfoTable(
@@ -128,7 +130,8 @@ public class FeedServiceDateValidatorTest {
     underTest.feedInfoTable = gtfsFeedInfoTable;
 
     underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingRequiredFieldError("feed_info.txt", 1, "feed_end_date"));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
@@ -6,7 +6,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -89,7 +88,7 @@ public class FeedServiceDateValidatorTest {
   }
 
   @Test
-  public void noStartDateShouldGenerateNotice() {
+  public void noStartDateShouldNotGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsFeedInfoTableContainer gtfsFeedInfoTable =
         createFeedInfoTable(
@@ -107,12 +106,11 @@ public class FeedServiceDateValidatorTest {
     underTest.feedInfoTable = gtfsFeedInfoTable;
 
     underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new MissingRequiredFieldError("feed_info.txt", 1, "feed_start_date"));
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
   }
 
   @Test
-  public void noEndDateShouldGenerateNotice() {
+  public void noEndDateShouldNotGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsFeedInfoTableContainer gtfsFeedInfoTable =
         createFeedInfoTable(
@@ -130,8 +128,7 @@ public class FeedServiceDateValidatorTest {
     underTest.feedInfoTable = gtfsFeedInfoTable;
 
     underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new MissingRequiredFieldError("feed_info.txt", 1, "feed_end_date"));
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
closes #733 
**Summary:**

This PR removes the requirements on feed_info.start_date and feed_info.end_date

**Expected behavior:** 

No notice should be generated if  `feed_info.start_date` and `feed_info.end_date` is missing Also, both fields can be blank.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: -new feature short description-" (PR title must follow the [conventional commit specification](https://www.conventionalcommits.org/en/v1.0.0/))
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
