### PR TITLE
feat: Report errors for new lines and carriage returns in field values

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NewLineInValueNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NewLineInValueNotice.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * A value in CSV file has a new line or carriage return.
+ *
+ * <p>This error is usually found when the CSV file does not close double quotes properly, so the
+ * next line is considered as a continuation of the previous line.
+ *
+ * <p>Example. The following file was intended to have fields "f11", "f12", "f21", "f22", but it
+ * actually parses as two fields: "f11", "f12\nf21,\"f22\"".
+ *
+ * <pre>
+ *   f11,"f12
+ *   f21,"f22"
+ * </pre>
+ */
+public class NewLineInValueNotice extends ValidationNotice {
+
+  public NewLineInValueNotice(
+      String filename, long csvRowNumber, String fieldName, String fieldValue) {
+    super(
+        ImmutableMap.of(
+            "filename",
+            filename,
+            "csvRowNumber",
+            csvRowNumber,
+            "fieldName",
+            fieldName,
+            "fieldValue",
+            fieldValue),
+        SeverityLevel.ERROR);
+  }
+
+  @Override
+  public String getCode() {
+    return "new_line_in_value";
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -29,6 +29,7 @@ import org.mobilitydata.gtfsvalidator.notice.FieldParsingError;
 import org.mobilitydata.gtfsvalidator.notice.InvalidRowLengthError;
 import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
+import org.mobilitydata.gtfsvalidator.notice.NewLineInValueNotice;
 import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.NumberOutOfRangeError;
@@ -211,6 +212,11 @@ public class RowParser {
               row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex)));
     }
     if (s != null) {
+      if (s.indexOf('\n') != -1 || s.indexOf('\r') != -1) {
+        addNoticeInRow(
+            new NewLineInValueNotice(
+                row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex), s));
+      }
       final String stripped = s.strip();
       if (stripped.length() < s.length()) {
         addNoticeInRow(

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -27,6 +27,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
 import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NewLineInValueNotice;
 import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
@@ -233,7 +234,7 @@ public class RowParserTest {
   }
 
   @Test
-  public void whitespaces() {
+  public void whitespaceInValue() {
     // Protected whitespaces are stripped. This is an error but GTFS consumers may patch it to be a
     // warning.
     RowParser parser = createParser(" 1\t");
@@ -243,5 +244,23 @@ public class RowParserTest {
     assertThat(parser.hasParseErrorsInRow())
         .isEqualTo(notice.getSeverityLevel() == SeverityLevel.ERROR);
     assertThat(parser.getNoticeContainer().getValidationNotices()).containsExactly(notice);
+  }
+
+  @Test
+  public void newLineInValue() {
+    RowParser parser = createParser("a\nb");
+    assertThat(parser.asText(0, true)).isEqualTo("a\nb");
+    assertThat(parser.hasParseErrorsInRow()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices())
+        .containsExactly(new NewLineInValueNotice("filename", 8, "column name", "a\nb"));
+  }
+
+  @Test
+  public void carriageReturnInValue() {
+    RowParser parser = createParser("a\rb");
+    assertThat(parser.asText(0, true)).isEqualTo("a\rb");
+    assertThat(parser.hasParseErrorsInRow()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices())
+        .containsExactly(new NewLineInValueNotice("filename", 8, "column name", "a\rb"));
   }
 }


### PR DESCRIPTION
GTFS reference requires that field values do not contain new lines or
carriage returns (\n or \r).

RFC4180 CSV allows to spread a value between multiple lines if it is
surrounded by double quotes. But on practice, the feeds that have
multiline values are actually omitting the closing quote. That makes
different parsers interpret the file in different ways, so we need to
detect such ambiguous data in the validator.