### PR TITLE
feat: Show a big error when parsing failed

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -105,6 +105,13 @@ public class Main {
     // Output
     exportReport(args.getOutputBase(), noticeContainer);
     final long endNanos = System.nanoTime();
+    if (!feedContainer.isParsedSuccessfully()) {
+      System.out.println(" ----------------------------------------- ");
+      System.out.println("|       !!!    PARSING FAILED    !!!      |");
+      System.out.println("|   Most validators were never invoked.   |");
+      System.out.println("|   Please see report.json for details.   |");
+      System.out.println(" ----------------------------------------- ");
+    }
     System.out.printf("Validation took %.3f seconds%n", (endNanos - startNanos) / 1e9);
     System.out.println(feedContainer.tableTotals());
   }


### PR DESCRIPTION
If the feed failed to parse, then most validators are not invoked
because when they operate on an incomplete feed, they may produce
misleading messages. That is why we need to show a big error box to
attract user's attention to that.

```
 -----------------------------------------
|       !!!    PARSING FAILED    !!!      |
|   Most validators were never invoked.   |
|   Please see report.json for details.   |
 -----------------------------------------
```
