### PR TITLE
feat: Handle final row that does not end with a newline

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * A row in the input file has only spaces.
+ * <p>
+ * Some CSV parsers, such as Univocity, may misinterpret it as a non-empty row that has a single
+ * column which is empty, hence we show a warning.
+ */
+public class EmptyRowNotice extends ValidationNotice {
+
+  public EmptyRowNotice(String filename, long csvRowNumber) {
+    super(
+        ImmutableMap.of(
+            "filename", filename,
+            "csvRowNumber", csvRowNumber),
+        SeverityLevel.WARNING);
+  }
+
+  @Override
+  public String getCode() {
+    return "empty_row";
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
@@ -20,8 +20,8 @@ import com.google.common.collect.ImmutableMap;
 
 /**
  * A row in the input file has only spaces.
- * <p>
- * Some CSV parsers, such as Univocity, may misinterpret it as a non-empty row that has a single
+ *
+ * <p>Some CSV parsers, such as Univocity, may misinterpret it as a non-empty row that has a single
  * column which is empty, hence we show a warning.
  */
 public class EmptyRowNotice extends ValidationNotice {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvRow.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvRow.java
@@ -19,9 +19,7 @@ package org.mobilitydata.gtfsvalidator.parsing;
 import com.google.common.base.Strings;
 import javax.annotation.Nullable;
 
-/**
- * Read access to a data row in a CSV file.
- */
+/** Read access to a data row in a CSV file. */
 public class CsvRow {
   private final CsvFile csvFile;
   private final long rowNumber;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvRow.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvRow.java
@@ -19,7 +19,9 @@ package org.mobilitydata.gtfsvalidator.parsing;
 import com.google.common.base.Strings;
 import javax.annotation.Nullable;
 
-/** Read access to a data row in a CSV file. */
+/**
+ * Read access to a data row in a CSV file.
+ */
 public class CsvRow {
   private final CsvFile csvFile;
   private final long rowNumber;
@@ -29,6 +31,10 @@ public class CsvRow {
     this.csvFile = csvFile;
     this.rowNumber = rowNumber;
     this.columnValues = columnValues;
+  }
+
+  public CsvFile getCsvFile() {
+    return csvFile;
   }
 
   public long getRowNumber() {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -196,7 +196,7 @@ public class RowParser {
   /**
    * Checks whether the row lengths (cell count) is the same as the amount of file headers.
    *
-   * This function may add notices to {@code noticeContainer}.
+   * <p>This function may add notices to {@code noticeContainer}.
    *
    * @return true if the row length is equal to column count
    */

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -282,14 +282,14 @@ public class RowParserTest {
     // The final row in this test contains only spaces and does not end with a new line. Univocity
     // parser treats it as a non-empty row that contains a single column which holds null.
     InputStream inputStream = toInputStream("stop_id,stop_name\n  ");
-    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvFile csvFile = new CsvFile(inputStream, TEST_FILENAME);
 
     assertThat(csvFile.isEmpty()).isFalse();
     assertThat(csvFile.getColumnCount()).isEqualTo(2);
 
     CsvRow csvRow = csvFile.iterator().next();
-    RowParser parser = new RowParser(GtfsFeedName.parseString(TEST_FEED_NAME),
-        new NoticeContainer());
+    RowParser parser =
+        new RowParser(GtfsFeedName.parseString(TEST_FEED_NAME), new NoticeContainer());
     parser.setRow(csvRow);
 
     assertThat(parser.checkRowLength()).isFalse();
@@ -303,14 +303,14 @@ public class RowParserTest {
   @Test
   public void checkRowLengthInvalidRowLength() throws IOException {
     InputStream inputStream = toInputStream("stop_id,stop_name\n" + "s1");
-    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvFile csvFile = new CsvFile(inputStream, TEST_FILENAME);
 
     assertThat(csvFile.isEmpty()).isFalse();
     assertThat(csvFile.getColumnCount()).isEqualTo(2);
 
     CsvRow csvRow = csvFile.iterator().next();
-    RowParser parser = new RowParser(GtfsFeedName.parseString(TEST_FEED_NAME),
-        new NoticeContainer());
+    RowParser parser =
+        new RowParser(GtfsFeedName.parseString(TEST_FEED_NAME), new NoticeContainer());
     parser.setRow(csvRow);
 
     assertThat(parser.checkRowLength()).isFalse();
@@ -320,5 +320,4 @@ public class RowParserTest {
 
     inputStream.close();
   }
-
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -132,22 +132,22 @@ public class TableLoaderGenerator {
 
     typeSpec.addField(
         FieldSpec.builder(
-            FluentLogger.class, "logger", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
+                FluentLogger.class, "logger", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
             .initializer("$T.forEnclosingClass()", FluentLogger.class)
             .build());
     typeSpec.addField(
         FieldSpec.builder(
-            String.class, "FILENAME", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+                String.class, "FILENAME", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
             .initializer("$S", fileDescriptor.filename())
             .build());
     for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
       typeSpec.addField(
           FieldSpec.builder(
-              String.class,
-              fieldNameField(field.name()),
-              Modifier.PUBLIC,
-              Modifier.STATIC,
-              Modifier.FINAL)
+                  String.class,
+                  fieldNameField(field.name()),
+                  Modifier.PUBLIC,
+                  Modifier.STATIC,
+                  Modifier.FINAL)
               .initializer("$S", gtfsColumnName(field.name()))
               .build());
     }


### PR DESCRIPTION
A CSV file may end with a row that contains only spaces and does not end
with a new line, so that row is actually empty. Univocity parser treats
that row as non-empty: it interprets it as a row with a single empty
column. It is unclear whether this is a bug or a feature.

RFC 4180 does not give a hint on how to treat such rows.

Here we handle such rows gracefully and show a warning since that CSV is
ambiguous.