### PR TITLE
fix: Use String.trim instead of String.strip

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -136,12 +136,12 @@ public class RowParser {
             new NewLineInValueNotice(
                 row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex), s));
       }
-      final String stripped = s.strip();
-      if (stripped.length() < s.length()) {
+      final String trimmed = s.trim();
+      if (trimmed.length() < s.length()) {
         addNoticeInRow(
             new LeadingOrTrailingWhitespacesNotice(
                 row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex), s));
-        s = stripped;
+        s = trimmed;
       }
     }
     return s;


### PR DESCRIPTION
String.strip is available only from Java 11 while String.trim is more
portable.

The difference is tiny and we can neglect it in our context:
* trim() removes all characters that are less than or equal to 'U+0020'
  (the space character)
* strip() uses Character.isWhitespace function, so it removes fewer
  characters
