### PR TITLE
chore: Downgrade to Java 8

### DIFF
--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -24,10 +24,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -24,10 +24,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/end_to_end_big.yml
+++ b/.github/workflows/end_to_end_big.yml
@@ -24,10 +24,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -32,10 +32,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -83,10 +83,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -124,10 +124,10 @@ jobs:
             VERSION_TAG=v${VERSION_TAG}-sha-${GITHUB_SHA::8}-SNAPSHOT
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
-      - name: Set up JDK 1.11
+      - name: Set up JDK 1.8
         uses: actions/setup-java@v1
         with:
-          java-version: 1.11
+          java-version: 1.8
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -21,7 +21,7 @@ plugins {
 group 'org.mobilitydata'
 version "gtfs-validator-${System.getenv("versionTag")}"
 
-sourceCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_1_8
 compileTestJava.options.encoding = "UTF-8"
 
 repositories {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
@@ -16,6 +16,13 @@ import java.util.TreeSet;
  * <p>This class is immutable.
  */
 public class ServicePeriod {
+  /**
+   * The epoch year LocalDate, '1970-01-01'.
+   *
+   * <p>{@code LocalDate.EPOCH} is not available in Java 8, so we have to define it here.
+   */
+  public static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
+
   private final LocalDate serviceStart;
   private final LocalDate serviceEnd;
   private final byte weeklyPattern;
@@ -50,13 +57,13 @@ public class ServicePeriod {
   /**
    * Creates a service period from the given dates.
    *
-   * <p>serviceStart and serviceEnd will be set to {@code LocalDate.EPOCH}.
+   * <p>serviceStart and serviceEnd will be set to {@link #EPOCH}.
    *
    * @param dates service dates
    */
   public ServicePeriod(Set<LocalDate> dates) {
-    this.serviceStart = LocalDate.EPOCH;
-    this.serviceEnd = LocalDate.EPOCH;
+    this.serviceStart = EPOCH;
+    this.serviceEnd = EPOCH;
     this.weeklyPattern = 0;
     this.addedDays = Preconditions.checkNotNull(dates);
     this.removedDays = ImmutableSet.of();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
@@ -92,8 +92,8 @@ public class ServicePeriodTest {
   public void addedAndRemovedDays() {
     assertThat(
             new ServicePeriod(
-                    LocalDate.EPOCH,
-                    LocalDate.EPOCH,
+                    ServicePeriod.EPOCH,
+                    ServicePeriod.EPOCH,
                     (byte) 0,
                     ImmutableSortedSet.of(
                         LocalDate.of(2021, 1, 3),

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -52,7 +52,7 @@ shadowJar {
     archiveVersion = project.version
 }
 
-sourceCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_1_8
 mainClassName = 'org.mobilitydata.gtfsvalidator.cli.Main'
 
 repositories {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
@@ -52,8 +52,8 @@ public final class CalendarUtil {
               calendar.saturdayValue(),
               calendar.sundayValue());
     } else {
-      serviceStart = LocalDate.EPOCH;
-      serviceEnd = LocalDate.EPOCH;
+      serviceStart = ServicePeriod.EPOCH;
+      serviceEnd = ServicePeriod.EPOCH;
       weeklyPattern = 0;
     }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
@@ -13,7 +13,7 @@ import java.util.SortedSet;
  * <p>This class is not thread-safe.
  */
 public class ServiceIdIntersectionCache {
-  private static final LocalDate NO_OVERLAP = LocalDate.EPOCH;
+  private static final LocalDate NO_OVERLAP = ServicePeriod.EPOCH;
   private final Map<String, SortedSet<LocalDate>> serviceDates;
   // The cache stores LocalDate instead of Optional<LocalDate> for size
   // efficiency. If services do not overlap, we store null.

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
@@ -94,8 +94,8 @@ public class CalendarUtilTest {
   @Test
   public void CreateServicePeriodEmpty() {
     ServicePeriod servicePeriod = CalendarUtil.createServicePeriod(null, ImmutableList.of());
-    assertThat(servicePeriod.getServiceStart()).isEqualTo(LocalDate.EPOCH);
-    assertThat(servicePeriod.getServiceEnd()).isEqualTo(LocalDate.EPOCH);
+    assertThat(servicePeriod.getServiceStart()).isEqualTo(ServicePeriod.EPOCH);
+    assertThat(servicePeriod.getServiceEnd()).isEqualTo(ServicePeriod.EPOCH);
     assertThat(servicePeriod.getWeeklyPattern()).isEqualTo(0);
     assertThat(servicePeriod.getAddedDays()).isEmpty();
     assertThat(servicePeriod.getRemovedDays()).isEmpty();
@@ -150,8 +150,8 @@ public class CalendarUtilTest {
                 ImmutableSet.of()),
             "s3",
             new ServicePeriod(
-                LocalDate.EPOCH,
-                LocalDate.EPOCH,
+                ServicePeriod.EPOCH,
+                ServicePeriod.EPOCH,
                 (byte) 0,
                 ImmutableSet.of(LocalDate.of(2021, 3, 8)),
                 ImmutableSet.of(LocalDate.of(2021, 3, 9))));
@@ -178,8 +178,8 @@ public class CalendarUtilTest {
                         ImmutableSet.of()),
                     "s3",
                     new ServicePeriod(
-                        LocalDate.EPOCH,
-                        LocalDate.EPOCH,
+                        ServicePeriod.EPOCH,
+                        ServicePeriod.EPOCH,
                         (byte) 0,
                         ImmutableSet.of(LocalDate.of(2021, 3, 8)),
                         ImmutableSet.of(LocalDate.of(2021, 3, 9))))))

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -74,10 +74,9 @@ public class DuplicateRouteNameValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactlyElementsIn(
-            List.of(
-                new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"),
-                new DuplicateRouteNameNotice("route_long_name", 8, "3rd route id value")));
+        .containsExactly(
+            new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"),
+            new DuplicateRouteNameNotice("route_long_name", 8, "3rd route id value"));
   }
 
   @Test
@@ -120,10 +119,9 @@ public class DuplicateRouteNameValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactlyElementsIn(
-            List.of(
-                new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
-                new DuplicateRouteNameNotice("route_short_name", 8, "3rd route id value")));
+        .containsExactly(
+            new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
+            new DuplicateRouteNameNotice("route_short_name", 8, "3rd route id value"));
   }
 
   @Test
@@ -178,9 +176,8 @@ public class DuplicateRouteNameValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactlyElementsIn(
-            List.of(
-                new DuplicateRouteNameNotice(
-                    "route_short_name and route_long_name", 4, "2nd route id value")));
+        .containsExactly(
+            new DuplicateRouteNameNotice(
+                "route_short_name and route_long_name", 4, "2nd route id value"));
   }
 }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -5,7 +5,7 @@ plugins {
 group 'org.mobilitydata'
 version "${System.getenv("versionTag")}"
 
-sourceCompatibility = JavaVersion.VERSION_11
+sourceCompatibility = JavaVersion.VERSION_1_8
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Google is still using the old Java.

The updated code was tested on OpenJDK 1.8.
