### PR TITLE
fix: equal distance generate notice

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -43,7 +43,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
         GtfsShape curr = shapeList.get(i);
         if (prev.hasShapeDistTraveled()
             && curr.hasShapeDistTraveled()
-            && prev.shapeDistTraveled() > curr.shapeDistTraveled()) {
+            && prev.shapeDistTraveled() >= curr.shapeDistTraveled()) {
           noticeContainer.addValidationNotice(
               new DecreasingShapeDistanceNotice(
                   curr.shapeId(),

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidatorTest.java
@@ -99,4 +99,22 @@ public class ShapeIncreasingDistanceValidatorTest {
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(new DecreasingShapeDistanceNotice("first shape", 2, 9.0d, 2, 1, 10.0d, 1));
   }
+
+  @Test
+  public void shapeWithEqualDistanceAlongShapeShouldGenerateNotice() {
+    ShapeIncreasingDistanceValidator underTest = new ShapeIncreasingDistanceValidator();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    underTest.table =
+        createShapeTable(
+            noticeContainer,
+            ImmutableList.of(
+                createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
+                createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
+                createShapePoint(3, "first shape", 29.0d, 46, 3, 45.0)));
+
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new DecreasingShapeDistanceNotice("first shape", 3, 45.0d, 3, 2, 45.0d, 2));
+  }
 }


### PR DESCRIPTION
closes #757 

**Summary:**

This PR provides support to fix #757

**Expected behavior:** 

A `DecreasingShapeDistanceNotice` should be issued in the case described by the following table:

`shapes.txt` 

| `shape_id` 	| `shape_pt_lat` 	| `shape_pt_lon` 	| `shape_pt_sequence` 	| `shape_dist_traveled` 	|
|------------	|----------------	|----------------	|---------------------	|-----------------------	|
| s1         	| 0.0              	| 34.5              	| 2                   	| 45.0                  	|
| s1         	| 0.0              	| 56              	| 3                   	| 45.0                    	|



Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
