### PR TITLE
docs: Align SeverityLevel Javadocs with RULES.md

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -9,7 +9,7 @@ Note that the notice ID naming conventions changed in `v2` to make contributions
 ## Definitions
 Notices are split into three categories: `INFO`, `WARNING`, `ERROR`.
 
-* `ERROR` notices are for items that the [GTFS reference specification](https://github.com/google/transit/tree/master/gtfs/spec/en) explictly requires or prohibits (e.g., using the language "must"). The validator uses [RFC2119](https://tools.ietf.org/html/rfc2119) to interpret the language in the GTFS spec.
+* `ERROR` notices are for items that the [GTFS reference specification](https://github.com/google/transit/tree/master/gtfs/spec/en) explicitly requires or prohibits (e.g., using the language "must"). The validator uses [RFC2119](https://tools.ietf.org/html/rfc2119) to interpret the language in the GTFS spec.
 * `WARNING` notices are for items that will affect the quality of GTFS datasets but the GTFS spec does expressly require or prohibit. For example, these might be items recommended using the language "should" or "should not" in the GTFS spec, or items recommended in the MobilityData [GTFS Best Practices](https://gtfs.org/best-practices/).
 * `INFO` notices are for items that do not affect the feed's quality, such as unknown files or unknown fields.
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/SeverityLevel.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/SeverityLevel.java
@@ -19,17 +19,20 @@ package org.mobilitydata.gtfsvalidator.notice;
 /** Describes the level of severity of a notice generated during validation. */
 public enum SeverityLevel {
   /**
-   * INFO - is used for things that do not affect the feed's quality, such as unknown files or
-   * unknown fields
+   * INFO - for items that do not affect the feed's quality, such as unknown files or unknown fields.
    */
   INFO,
 
   /**
-   * WARNING - is used for things that affects the feed's quality (e.g., insufficient color
-   * contrast) but the feed remains functional
+   * WARNING - for items that will affect the quality of GTFS datasets but the GTFS spec does
+   * expressly require or prohibit. For example, these might be items recommended using the language
+   * "should" or "should not" in the GTFS spec, or items recommended in the MobilityData GTFS Best
+   * Practices (https://gtfs.org/best-practices/).
    */
   WARNING,
 
-  /** ERROR - is used when the feed cannot function (e.g., broken foreign key reference) */
+  /** ERROR - for items that the GTFS spec (https://github.com/google/transit/tree/master/gtfs/spec/en)
+   * explicitly requires or prohibits (e.g., using the language "must"). The validator uses RFC2119
+   * (https://tools.ietf.org/html/rfc2119) to interpret the language in the GTFS spec. */
   ERROR
 }


### PR DESCRIPTION
**Summary:**

Closes https://github.com/MobilityData/gtfs-validator/issues/762

Align SeverityLevel docs with RULES.md . Also fix a typo.

**Expected behavior:** 

Definition of ERRORS, WARNINGS, and INFO in SeverityLevel Javadocs should match what we've implemented in code (see https://github.com/MobilityData/gtfs-validator/pull/726) and the documentation in RULES.md.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
