### PR TITLE
fix: Remove Set.of()

### DIFF
--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -677,10 +677,16 @@ public class StopTooFarFromTripShapeValidatorTest {
 
     // Note that the contents of the cache are the final state, not the state at specific invocation
     // because it's passed by reference and not value
+    Set<String> expected = new java.util.HashSet<>();
+    expected.add("shape11001");
+    expected.add("shape11002");
+    expected.add("shape11003");
+    expected.add("shape21005");
+    expected.add("shape21004");
     assertThat(cacheCapture.getAllValues().get(0))
-        .isEqualTo(Set.of("shape11001", "shape11002", "shape11003", "shape21005", "shape21004"));
+        .isEqualTo(expected);
     assertThat(cacheCapture.getAllValues().get(1))
-        .isEqualTo(Set.of("shape11001", "shape11002", "shape11003", "shape21005", "shape21004"));
+        .isEqualTo(expected);
 
     Mockito.verifyNoMoreInteractions(underTest);
   }


### PR DESCRIPTION
**Summary:**

The PRs for the switch to Java 8 (https://github.com/MobilityData/gtfs-validator/pull/759) and the changes to the rule for StopTooFarFromTripShape (https://github.com/MobilityData/gtfs-validator/pull/750) were open simultanouesly, so some Java 9 features snuck in as part of the changes to that rule.

Here's the build that failed on CI:
https://github.com/MobilityData/gtfs-validator/runs/1962540197

This PR removes the Java 9 feature (`Set.of()`) that caused the failure.

**Expected behavior:** 

Only Java 8 compatible language features should be used.


- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
