### PR TITLE
feat: Emit a warning for empty column name

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * A column name is empty. Such columns are skipped by the validator.
+ *
+ * <p>Severity: {@code SeverityLevel.WARNING}
+ */
+public class EmptyColumnNameNotice extends ValidationNotice {
+  public EmptyColumnNameNotice(String filename, int index) {
+    super(
+        ImmutableMap.of(
+            "filename", filename,
+            "index", index),
+        SeverityLevel.WARNING);
+  }
+
+  @Override
+  public String getCode() {
+    return "empty_column_name";
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
@@ -16,11 +16,13 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
+import com.google.common.base.Strings;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import org.mobilitydata.gtfsvalidator.notice.DuplicatedColumnNotice;
+import org.mobilitydata.gtfsvalidator.notice.EmptyColumnNameNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.UnknownColumnNotice;
@@ -43,8 +45,12 @@ public class TableHeaderValidator {
     TreeSet<String> missingColumns = new TreeSet<>(requiredColumns);
     for (int i = 0; i < actualColumns.length; ++i) {
       String column = actualColumns[i];
-      Integer prev = columnIndices.putIfAbsent(column, i);
       // Column indices are zero-based. We add 1 to make them 1-based.
+      if (Strings.isNullOrEmpty(column)) {
+        noticeContainer.addValidationNotice(new EmptyColumnNameNotice(filename, i + 1));
+        continue;
+      }
+      Integer prev = columnIndices.putIfAbsent(column, i);
       if (prev != null) {
         noticeContainer.addValidationNotice(
             new DuplicatedColumnNotice(filename, column, prev + 1, i + 1));

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.DuplicatedColumnNotice;
+import org.mobilitydata.gtfsvalidator.notice.EmptyColumnNameNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.UnknownColumnNotice;
@@ -110,5 +111,23 @@ public class TableHeaderValidatorTest {
                     container))
         .isTrue();
     assertThat(container.getValidationNotices().isEmpty()).isTrue();
+  }
+
+  @Test
+  public void emptyColumnNameShouldGenerateNotice() {
+    NoticeContainer container = new NoticeContainer();
+
+    assertThat(
+            new TableHeaderValidator()
+                .validate(
+                    "stops.txt",
+                    new String[] {"stop_id", null, "stop_name", ""},
+                    ImmutableSet.of("stop_id", "stop_name"),
+                    ImmutableSet.of("stop_id"),
+                    container))
+        .isTrue();
+    assertThat(container.getValidationNotices())
+        .containsExactly(
+            new EmptyColumnNameNotice("stops.txt", 2), new EmptyColumnNameNotice("stops.txt", 4));
   }
 }


### PR DESCRIPTION
Consider a header row:
stop_id,stop_name,

Its third column does not have a name. We ignore it in the same way as
we ignore unknown columns but we need to emit a clear warning for that.
