### PR TITLE
fix: route name validator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -26,8 +26,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 
 /**
- * Validates unicity of short and long name for all routes. A {@code GtfsRoute}'s `route_short_name`
- * and `route_long_name` should be unique.
+ * Validates unicity of short and long name for all routes.
  *
  * <p>When a {@code GtfsRoute} names are found to be duplicate a {@code DuplicateRouteNameNotice} is
  * generated and added to the {@code NoticeContainer} except if routes are from the same agency

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -109,7 +109,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
   }
 
   /**
-   * Generate a key used to store {@code GtfsRoute} by `routes.route_long_name`
+   * Generate a key used to store {@code GtfsRoute} by `routes.route_long_name`.
    *
    * @param route the {@code GtfsRoute} to generate the key from
    * @return `routes.route_long_name`+`route.routeType`
@@ -119,7 +119,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
   }
 
   /**
-   * Generate a key used to store {@code GtfsRoute} by `routes.route_short_name`
+   * Generate a key used to store {@code GtfsRoute} by `routes.route_short_name`.
    *
    * @param route the {@code GtfsRoute} to generate the key from
    * @return `routes.route_short_name`+`route.routeType`
@@ -130,7 +130,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
 
   /**
    * Generate a key used to store {@code GtfsRoute} by both `routes.route_short_name` and
-   * `routes.route_long_name`
+   * `routes.route_long_name`.
    *
    * @param route the {@code GtfsRoute} to generate the key from
    * @return `routes.route_short_name`+`routes.route_long_name`+`route.routeType`

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -49,7 +49,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
             route -> {
               if (route.hasRouteShortName() && route.hasRouteLongName()) {
                 if (routeByShortAndLongName.containsKey(
-                    route.routeShortName() + route.routeLongName())) {
+                    route.routeShortName() + route.routeLongName() + route.routeType())) {
                   noticeContainer.addValidationNotice(
                       new DuplicateRouteNameNotice(
                           "route_short_name and route_long_name",
@@ -58,32 +58,32 @@ public class DuplicateRouteNameValidator extends FileValidator {
                   return;
                 } else {
                   routeByShortAndLongName.put(
-                      route.routeShortName() + route.routeLongName(), route);
+                      route.routeShortName() + route.routeLongName() + route.routeType(), route);
                 }
               }
               if (route.hasRouteLongName()) {
-                if (routeByLongName.containsKey(route.routeLongName())) {
+                if (routeByLongName.containsKey(route.routeLongName() + route.routeType())) {
                   if (areRoutesFromSameAgency(
-                      route.agencyId(), routeByLongName.get(route.routeLongName()).agencyId())) {
+                      route.agencyId(), routeByLongName.get(route.routeLongName() + route.routeType()).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_long_name", route.csvRowNumber(), route.routeId()));
                   }
                   return;
                 } else {
-                  routeByLongName.put(route.routeLongName(), route);
+                  routeByLongName.put(route.routeLongName() + route.routeType(), route);
                 }
               }
               if (route.hasRouteShortName()) {
-                if (routeByShortName.containsKey(route.routeShortName())) {
+                if (routeByShortName.containsKey(route.routeShortName() + route.routeType())) {
                   if (areRoutesFromSameAgency(
-                      route.agencyId(), routeByShortName.get(route.routeShortName()).agencyId())) {
+                      route.agencyId(), routeByShortName.get(route.routeShortName() + route.routeType()).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_short_name", route.csvRowNumber(), route.routeId()));
                   }
                 } else {
-                  routeByShortName.put(route.routeShortName(), route);
+                  routeByShortName.put(route.routeShortName() + route.routeType(), route);
                 }
               }
             });

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -98,6 +98,6 @@ public class DuplicateRouteNameValidator extends FileValidator {
    */
   private boolean areRoutesFromSameAgency(
       final String routeAgencyId, final String otherRouteAgencyId) {
-    return routeAgencyId.equalsIgnoreCase(otherRouteAgencyId);
+    return routeAgencyId.equals(otherRouteAgencyId);
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -97,7 +97,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
   }
 
   /**
-   * Determines if two routes are from the same agency
+   * Determines if two routes are from the same agency: ids are case-sensitive.
    *
    * @param routeAgencyId first agency_id
    * @param otherRouteAgencyId second agency_id

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -28,9 +28,10 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 /**
  * Validates unicity of short and long name for all routes.
  *
- * <p>When a {@code GtfsRoute} names are found to be duplicate a {@code DuplicateRouteNameNotice} is
- * generated and added to the {@code NoticeContainer} except if routes are from the same agency
- * (values for `route.agency_id` are case-sensitive) or routes have different `routes.route_type`.
+ * <p>When a {@code GtfsRoute} short and/or long names are found to be duplicate a {@code
+ * DuplicateRouteNameNotice} is generated and added to the {@code NoticeContainer} except if routes
+ * are from the same agency (values for `route.agency_id` are case-sensitive) or routes have
+ * different `routes.route_type`.
  *
  * <p>Generated notice:
  *

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -68,7 +68,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
                 if (routeByLongName.containsKey(getRouteLongNameKey(route))) {
                   if (areRoutesFromSameAgency(
                       route.agencyId(),
-                      routeByLongName.get(route.routeLongName() + route.routeType()).agencyId())) {
+                      routeByLongName.get(getRouteLongNameKey(route)).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_long_name", route.csvRowNumber(), route.routeId()));
@@ -83,7 +83,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
                   if (areRoutesFromSameAgency(
                       route.agencyId(),
                       routeByShortName
-                          .get(route.routeShortName() + route.routeType())
+                          .get(getRouteShortNameKey(route))
                           .agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -68,9 +68,9 @@ public class DuplicateRouteNameValidatorTest {
                 createRoute(
                     2, "1st route id value", "agency id", "short name", "duplicate value", 2),
                 createRoute(
-                    4, "2nd route id value", "agency id", "other short name", "duplicate value", 3),
+                    4, "2nd route id value", "agency id", "other short name", "duplicate value", 2),
                 createRoute(
-                    8, "3rd route id value", "agency id", "another one", "duplicate value", 3)));
+                    8, "3rd route id value", "agency id", "another one", "duplicate value", 2)));
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
@@ -113,9 +113,9 @@ public class DuplicateRouteNameValidatorTest {
                 createRoute(
                     2, "1st route id value", "agency id", "duplicate value", "1st long name", 2),
                 createRoute(
-                    4, "2nd route id value", "agency id", "duplicate value", "2nd long name", 3),
+                    4, "2nd route id value", "agency id", "duplicate value", "2nd long name", 2),
                 createRoute(
-                    8, "3rd route id value", "agency id", "duplicate value", "3rd long name", 3)));
+                    8, "3rd route id value", "agency id", "duplicate value", "3rd long name", 2)));
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
@@ -133,6 +133,7 @@ public class DuplicateRouteNameValidatorTest {
             noticeContainer,
             ImmutableList.of(
                 createRoute(2, "1st route id value", "agency id", null, "1st value", 2),
+                createRoute(5, "4th route id value", "agency id", null, "1st value", 3),
                 createRoute(4, "2nd route id value", "another agency id", null, "2nd value", 3),
                 createRoute(8, "3rd route id value", "another one", null, "3rd value", 3)));
 
@@ -149,6 +150,7 @@ public class DuplicateRouteNameValidatorTest {
             noticeContainer,
             ImmutableList.of(
                 createRoute(2, "1st route id value", "agency id", "1st value", null, 2),
+                createRoute(5, "4th route id value", "agency id", "1st value", null, 3),
                 createRoute(4, "2nd route id value", "another agency id", "2nd value", null, 3),
                 createRoute(8, "3rd route id value", "another one", "3rd value", null, 3)));
 
@@ -165,7 +167,8 @@ public class DuplicateRouteNameValidatorTest {
             noticeContainer,
             ImmutableList.of(
                 createRoute(2, "1st route id value", "agency id", "short name", "long name", 2),
-                createRoute(4, "2nd route id value", "agency id", "short name", "long name", 3),
+                createRoute(5, "4th route id value", "agency id", "short name", "long value", 3),
+                createRoute(4, "2nd route id value", "agency id", "short name", "long name", 2),
                 createRoute(
                     8,
                     "3rd route id value",

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -51,7 +51,9 @@ public class DuplicateRouteNameValidatorTest {
                     "other short name",
                     "duplicate value",
                     3),
-                createRoute(8, "3rd route id value", null, "another one", "duplicate value", 3)));
+                createRoute(8, "3rd route id value", null, "another one", "duplicate value", 2),
+                createRoute(
+                    8, "4th route id value", "agenCY ID", "other sname", "duplicate value", 2)));
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices()).isEmpty();


### PR DESCRIPTION
closes #754 

**Summary:**

This PR provides changes to rework rue implemented in `DuplicateRouteNameValidator`.

**Expected behavior:** 

- `route.route_type` should be taken into consideration when checking for duplicate route names
- the validator is case sensitive when it comes to check different agency IDs. `agenCY id` and `AgencY id` are different following https://github.com/MobilityData/gtfs-validator/pull/689#discussion_r577701672

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
