### PR TITLE
docs: Add auto-gen Javadocs for Lists of @SequenceKey fields

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
 import org.mobilitydata.gtfsvalidator.annotation.Generated;
 import org.mobilitydata.gtfsvalidator.notice.DuplicateKeyError;
@@ -64,7 +65,7 @@ public class TableContainerGenerator {
   }
 
   private static void addListMultimapWithGetters(
-      TypeSpec.Builder typeSpec, GtfsFieldDescriptor indexField, GtfsFieldDescriptor sequenceField,
+      TypeSpec.Builder typeSpec, GtfsFieldDescriptor indexField, @Nullable GtfsFieldDescriptor sequenceField,
       TypeName entityTypeName) {
     TypeName keyMapType =
         ParameterizedTypeName.get(
@@ -75,7 +76,7 @@ public class TableContainerGenerator {
         FieldSpec.builder(keyMapType, fieldName, Modifier.PRIVATE)
             .initializer("$T.create()", ParameterizedTypeName.get(ArrayListMultimap.class))
             .build());
-    String sortedBy = sequenceField != null ? " sorted by " + sequenceField.name() : "";
+    String sortedBy = sequenceField != null ? " sorted by " + FieldNameConverter.gtfsColumnName(sequenceField.name()) : "";
     typeSpec.addMethod(
         MethodSpec.methodBuilder(methodName)
             .addModifiers(Modifier.PUBLIC)
@@ -89,7 +90,7 @@ public class TableContainerGenerator {
             .addModifiers(Modifier.PUBLIC)
             .returns(keyMapType)
             .addStatement("return $L", fieldName)
-            .addJavadoc("@return ListMultimap keyed on " + indexField.name() + " with values that are Lists of " + entityTypeName + sortedBy)
+            .addJavadoc("@return ListMultimap keyed on " + FieldNameConverter.gtfsColumnName(indexField.name()) + " with values that are Lists of " + entityTypeName + sortedBy)
             .build());
   }
 

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -60,6 +60,12 @@ public class TableContainerGenerator {
 
   private static void addListMultimapWithGetters(
       TypeSpec.Builder typeSpec, GtfsFieldDescriptor indexField, TypeName entityTypeName) {
+    addListMultimapWithGetters(typeSpec, indexField, null, entityTypeName);
+  }
+
+  private static void addListMultimapWithGetters(
+      TypeSpec.Builder typeSpec, GtfsFieldDescriptor indexField, GtfsFieldDescriptor sequenceField,
+      TypeName entityTypeName) {
     TypeName keyMapType =
         ParameterizedTypeName.get(
             ClassName.get(ListMultimap.class), TypeName.get(indexField.javaType()), entityTypeName);
@@ -69,18 +75,21 @@ public class TableContainerGenerator {
         FieldSpec.builder(keyMapType, fieldName, Modifier.PRIVATE)
             .initializer("$T.create()", ParameterizedTypeName.get(ArrayListMultimap.class))
             .build());
+    String sortedBy = sequenceField != null ? " sorted by " + sequenceField.name() : "";
     typeSpec.addMethod(
         MethodSpec.methodBuilder(methodName)
             .addModifiers(Modifier.PUBLIC)
             .addParameter(TypeName.get(indexField.javaType()), "key")
             .returns(ParameterizedTypeName.get(ClassName.get(List.class), entityTypeName))
             .addStatement("return $L.get(key)", fieldName)
+            .addJavadoc("@return List of " + entityTypeName + sortedBy)
             .build());
     typeSpec.addMethod(
         MethodSpec.methodBuilder(methodName + "Map")
             .addModifiers(Modifier.PUBLIC)
             .returns(keyMapType)
             .addStatement("return $L", fieldName)
+            .addJavadoc("@return ListMultimap keyed on " + indexField.name() + " with values that are Lists of " + entityTypeName + sortedBy)
             .build());
   }
 
@@ -163,7 +172,7 @@ public class TableContainerGenerator {
               .build());
     } else if (fileDescriptor.sequenceKey().isPresent()) {
       addListMultimapWithGetters(
-          typeSpec, fileDescriptor.firstKey().get(), classNames.entityImplementationTypeName());
+          typeSpec, fileDescriptor.firstKey().get(), fileDescriptor.sequenceKey().get(), classNames.entityImplementationTypeName());
     } else if (fileDescriptor.primaryKey().isPresent()) {
       addMapWithGetter(
           typeSpec, fileDescriptor.primaryKey().get(), classNames.entityImplementationTypeName());


### PR DESCRIPTION
**Summary:**

Closes https://github.com/MobilityData/gtfs-validator/issues/508

The goal of this PR is to make the sorting of GTFS entities that have been annotated with `@SequenceKey` more transparent in List data structures. Currently for a developer writing a new rule it's not clear whether they are responsible for sorting entities like GtfsShape by shapePtSequence in the rule implementation or if those entities have already be sorted in preprocessing.

This PR adds code to auto-generate Javadocs for methods in auto-generated container classes that return Lists of GTFS entities to make it clear which have been sorted, and by what field. This should hopefully result in less uncertainty for developers implementing new rules and should avoid potential performance pitfalls of sorting being unnecessarily implemented within validation rules.

Example auto-generated Javadocs from `GtfsShapeTableContainer`, which has sorted entities:

```java
  /**
   * @return List of org.mobilitydata.gtfsvalidator.table.GtfsShape sorted by shapePtSequence
   */
  public List<GtfsShape> byShapeId(String key) {
    return byShapeIdMap.get(key);
  }

  /**
   * @return ListMultimap keyed on shapeId with values that are Lists of org.mobilitydata.gtfsvalidator.table.GtfsShape sorted by shapePtSequence
   */
  public ListMultimap<String, GtfsShape> byShapeIdMap() {
    return byShapeIdMap;
  }
```

...and for `GtfsCalendarDateTableContainer`, which does not have sorted entities:

```java
  /**
   * @return List of org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate
   */
  public List<GtfsCalendarDate> byServiceId(String key) {
    return byServiceIdMap.get(key);
  }

  /**
   * @return ListMultimap keyed on serviceId with values that are Lists of org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate
   */
  public ListMultimap<String, GtfsCalendarDate> byServiceIdMap() {
    return byServiceIdMap;
  }
```

@aababilov I'd love to get your feedback on this - I haven't worked with AutoValue before so I don't know if there is a better way to do this.

**Expected behavior:** 

In auto-generated table container classes like `GtfsShapeTableContainer`, the methods that return `Lists` of entities now have auto-generated Javadocs that call out when these lists are sorted, and by which field. See above for examples.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
