### PR TITLE
refactor: notice classes names and codes

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUriSyntax.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUriSyntax.java
@@ -23,14 +23,14 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class URISyntaxError extends SystemError {
+public class InvalidUriSyntax extends SystemError {
 
-  public URISyntaxError(String message) {
+  public InvalidUriSyntax(String message) {
     super(ImmutableMap.of("message", message));
   }
 
   @Override
   public String getCode() {
-    return "uri_syntax_error";
+    return "invalid_uri_syntax";
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingFeedInfoDateNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingFeedInfoDateNotice.java
@@ -33,6 +33,6 @@ public class MissingFeedInfoDateNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "missing_feed_info_start_date_or_end_date";
+    return "missing_feed_info_date";
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
@@ -40,6 +40,6 @@ public class NonAsciiOrNonPrintableCharNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "id_contains_non_ascii_characters";
+    return "non_ascii_or_non_printable_char";
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.CaseFormat;
 import com.google.common.base.Joiner;
 import java.util.Collections;
 import java.util.Map;
@@ -44,7 +45,9 @@ public abstract class Notice {
    *
    * @return notice code, e.g., "foreign_key_error".
    */
-  public abstract String getCode();
+  public String getCode() {
+    return CaseFormat.LOWER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, getClass().getSimpleName());
+  };
 
   @Override
   public boolean equals(Object other) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnexpectedEnumValueNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnexpectedEnumValueNotice.java
@@ -23,8 +23,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
-public class UnexpectedEnumValueError extends ValidationNotice {
-  public UnexpectedEnumValueError(
+public class UnexpectedEnumValueNotice extends ValidationNotice {
+  public UnexpectedEnumValueNotice(
       String filename, long csvRowNumber, String fieldName, int fieldValue) {
     super(
         ImmutableMap.of(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownFileNotice.java
@@ -30,6 +30,6 @@ public class UnknownFileNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "unexpected_file";
+    return "unknown_file";
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -48,7 +48,7 @@ import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.NumberOutOfRangeError;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
-import org.mobilitydata.gtfsvalidator.notice.UnexpectedEnumValueError;
+import org.mobilitydata.gtfsvalidator.notice.UnexpectedEnumValueNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -341,7 +341,7 @@ public class RowParser {
     }
     if (enumCreator.convert(i) == null) {
       addNoticeInRow(
-          new UnexpectedEnumValueError(
+          new UnexpectedEnumValueNotice(
               row.getFileName(), row.getRowNumber(), row.getColumnName(columnIndex), i));
     }
     return i;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -33,7 +33,7 @@ import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.IOError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ThreadInterruptedError;
-import org.mobilitydata.gtfsvalidator.notice.URISyntaxError;
+import org.mobilitydata.gtfsvalidator.notice.InvalidUriSyntax;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
 import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
@@ -85,7 +85,7 @@ public class Main {
       noticeContainer.addSystemError(new IOError(e.getMessage()));
     } catch (URISyntaxException e) {
       logger.atSevere().withCause(e).log("Syntax error in URI");
-      noticeContainer.addSystemError(new URISyntaxError(e.getMessage()));
+      noticeContainer.addSystemError(new InvalidUriSyntax(e.getMessage()));
     } catch (InterruptedException e) {
       logger.atSevere().withCause(e).log("Interrupted thread");
       noticeContainer.addSystemError(new ThreadInterruptedError(e.getMessage()));

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyLangInconsistencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyLangInconsistencyNotice.java
@@ -19,22 +19,22 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Inconsistent Timezone among agencies.
+ * Inconsistent language among agencies.
  *
- * <p>Severity: {@code SeverityLevel.ERROR}
+ * <p>Severity: {@code SeverityLevel.WARNING}
  */
-public class InconsistentAgencyTimezoneNotice extends ValidationNotice {
-  public InconsistentAgencyTimezoneNotice(long csvRowNumber, String expected, String actual) {
+public class AgencyLangInconsistencyNotice extends ValidationNotice {
+  public AgencyLangInconsistencyNotice(long csvRowNumber, String expected, String actual) {
     super(
         ImmutableMap.of(
             "csvRowNumber", csvRowNumber,
             "expected", expected,
             "actual", actual),
-        SeverityLevel.ERROR);
+        SeverityLevel.WARNING);
   }
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_timezone";
+    return "inconsistent_agency_lang";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyTimezoneInconsistencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyTimezoneInconsistencyNotice.java
@@ -19,22 +19,22 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Inconsistent language among agencies.
+ * Inconsistent Timezone among agencies.
  *
- * <p>Severity: {@code SeverityLevel.WARNING}
+ * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class InconsistentAgencyLangNotice extends ValidationNotice {
-  public InconsistentAgencyLangNotice(long csvRowNumber, String expected, String actual) {
+public class AgencyTimezoneInconsistencyNotice extends ValidationNotice {
+  public AgencyTimezoneInconsistencyNotice(long csvRowNumber, String expected, String actual) {
     super(
         ImmutableMap.of(
             "csvRowNumber", csvRowNumber,
             "expected", expected,
             "actual", actual),
-        SeverityLevel.WARNING);
+        SeverityLevel.ERROR);
   }
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_lang";
+    return "inconsistent_agency_timezone";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DecreasingOrEqualShapeDistanceNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/DecreasingOrEqualShapeDistanceNotice.java
@@ -48,9 +48,4 @@ public class DecreasingOrEqualShapeDistanceNotice extends ValidationNotice {
             .build(),
         SeverityLevel.ERROR);
   }
-
-  @Override
-  public String getCode() {
-    return "decreasing_or_equal_shape_distance";
-  }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/FeedExpiresSoonNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/FeedExpiresSoonNotice.java
@@ -27,8 +27,8 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
  *
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
-public class FeedExpirationDateNotice extends ValidationNotice {
-  public FeedExpirationDateNotice(
+public class FeedExpiresSoonNotice extends ValidationNotice {
+  public FeedExpiresSoonNotice(
       long csvRowNumber,
       GtfsDate currentDate,
       GtfsDate feedEndDate,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/OverlappingFrequenciesNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/OverlappingFrequenciesNotice.java
@@ -11,8 +11,8 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class OverlappingFrequencyNotice extends ValidationNotice {
-  public OverlappingFrequencyNotice(
+public class OverlappingFrequenciesNotice extends ValidationNotice {
+  public OverlappingFrequenciesNotice(
       long prevCsvRowNumber,
       GtfsTime prevEndTime,
       long currCsvRowNumber,
@@ -30,6 +30,6 @@ public class OverlappingFrequencyNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "overlapping_frequency";
+    return "overlapping_frequencies";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteSameNameAndDescriptionNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteSameNameAndDescriptionNotice.java
@@ -29,8 +29,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
-  public SameNameAndDescriptionForRouteNotice(
+public class RouteSameNameAndDescriptionNotice extends ValidationNotice {
+  public RouteSameNameAndDescriptionNotice(
       long csvRowNumber, String routeId, String routeDesc, String routeShortOrLongName) {
     super(
         new ImmutableMap.Builder<String, Object>()
@@ -45,6 +45,6 @@ public class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "same_route_name_and_description";
+    return "route_same_name_and_description_notice";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopLocationWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopLocationWithoutParentStationNotice.java
@@ -26,8 +26,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class LocationWithoutParentStationNotice extends ValidationNotice {
-  public LocationWithoutParentStationNotice(
+public class StopLocationWithoutParentStationNotice extends ValidationNotice {
+  public StopLocationWithoutParentStationNotice(
       long csvRowNumber, String stopId, String stopName, int locationType) {
     super(
         ImmutableMap.of(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopPlatformWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopPlatformWithoutParentStationNotice.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
-public class PlatformWithoutParentStationNotice extends ValidationNotice {
-  public PlatformWithoutParentStationNotice(long csvRowNumber, String stopId, String stopName) {
+public class StopPlatformWithoutParentStationNotice extends ValidationNotice {
+  public StopPlatformWithoutParentStationNotice(long csvRowNumber, String stopId, String stopName) {
     super(
         ImmutableMap.of("csvRowNumber", csvRowNumber, "stopId", stopId, "stopName", stopName),
         SeverityLevel.WARNING);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopWithWrongParentLocationTypeNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopWithWrongParentLocationTypeNotice.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class WrongParentLocationTypeNotice extends ValidationNotice {
-  public WrongParentLocationTypeNotice(
+public class StopWithWrongParentLocationTypeNotice extends ValidationNotice {
+  public StopWithWrongParentLocationTypeNotice(
       long csvRowNumber,
       String stopId,
       String stopName,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -20,8 +20,8 @@ import java.time.ZoneId;
 import java.util.Locale;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyLangNotice;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyTimezoneNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyLangInconsistencyNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyTimezoneInconsistencyNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
@@ -36,8 +36,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
  *
  * <ul>
  *   <li>{@link MissingRequiredFieldError} - multiple agencies present but no agency_id set
- *   <li>{@link InconsistentAgencyTimezoneNotice} - inconsistent timezone among the agencies
- *   <li>{@link InconsistentAgencyLangNotice} - inconsistent language among the agencies
+ *   <li>{@link AgencyTimezoneInconsistencyNotice} - inconsistent timezone among the agencies
+ *   <li>{@link AgencyLangInconsistencyNotice} - inconsistent language among the agencies
  * </ul>
  */
 @GtfsValidator
@@ -69,7 +69,7 @@ public class AgencyConsistencyValidator extends FileValidator {
       GtfsAgency agency = agencyTable.getEntities().get(i);
       if (!commonTimezone.equals(agency.agencyTimezone())) {
         noticeContainer.addValidationNotice(
-            new InconsistentAgencyTimezoneNotice(
+            new AgencyTimezoneInconsistencyNotice(
                 agency.csvRowNumber(), commonTimezone.getId(), agency.agencyTimezone().getId()));
       }
     }
@@ -87,7 +87,7 @@ public class AgencyConsistencyValidator extends FileValidator {
         commonLanguage = agency.agencyLang();
       } else if (!commonLanguage.equals(agency.agencyLang())) {
         noticeContainer.addValidationNotice(
-            new InconsistentAgencyLangNotice(
+            new AgencyLangInconsistencyNotice(
                 agency.csvRowNumber(),
                 commonLanguage.getLanguage(),
                 agency.agencyLang().getLanguage()));

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -19,7 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import java.time.LocalDate;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.notice.FeedExpirationDateNotice;
+import org.mobilitydata.gtfsvalidator.notice.FeedExpiresSoonNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -32,7 +32,7 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
  * <p>Generated notice:
  *
  * <ul>
- *   <li>{@link FeedExpirationDateNotice}
+ *   <li>{@link FeedExpiresSoonNotice}
  * </ul>
  */
 @GtfsValidator
@@ -49,7 +49,7 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
       GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(now.plusDays(30));
       if (entity.feedEndDate().isBefore(currentDatePlusSevenDays)) {
         noticeContainer.addValidationNotice(
-            new FeedExpirationDateNotice(
+            new FeedExpiresSoonNotice(
                 entity.csvRowNumber(),
                 currentDate,
                 entity.feedEndDate(),
@@ -58,7 +58,7 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
       }
       if (entity.feedEndDate().compareTo(currentDatePlusThirtyDays) <= 0) {
         noticeContainer.addValidationNotice(
-            new FeedExpirationDateNotice(
+            new FeedExpiresSoonNotice(
                 entity.csvRowNumber(),
                 currentDate,
                 entity.feedEndDate(),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
@@ -17,9 +17,9 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.notice.LocationWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopLocationWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.PlatformWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopPlatformWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.StationWithParentStationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
@@ -31,8 +31,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStop;
  *
  * <ul>
  *   <li>{@link StationWithParentStationNotice}
- *   <li>{@link PlatformWithoutParentStationNotice}
- *   <li>{@link LocationWithoutParentStationNotice}
+ *   <li>{@link StopPlatformWithoutParentStationNotice}
+ *   <li>{@link StopLocationWithoutParentStationNotice}
  * </ul>
  */
 @GtfsValidator
@@ -57,12 +57,12 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
         // This is a platform since it has platform_code. This is a separate notice from
         // LocationWithoutParentStationNotice because it is less severe.
         noticeContainer.addValidationNotice(
-            new PlatformWithoutParentStationNotice(
+            new StopPlatformWithoutParentStationNotice(
                 location.csvRowNumber(), location.stopId(), location.stopName()));
       }
     } else if (requiresParentStation(location.locationType())) {
       noticeContainer.addValidationNotice(
-          new LocationWithoutParentStationNotice(
+          new StopLocationWithoutParentStationNotice(
               location.csvRowNumber(), location.stopId(),
               location.stopName(), location.locationTypeValue()));
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
@@ -8,7 +8,7 @@ import java.util.List;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.OverlappingFrequencyNotice;
+import org.mobilitydata.gtfsvalidator.notice.OverlappingFrequenciesNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFrequency;
 import org.mobilitydata.gtfsvalidator.table.GtfsFrequencyTableContainer;
 
@@ -21,7 +21,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFrequencyTableContainer;
  * <p>Time complexity: <i>O(n log n)</i> where <i>n</i> is the number of entries in
  * <i>frequencies.txt</i>.
  *
- * <p>Generated notice: {@link OverlappingFrequencyNotice}.
+ * <p>Generated notice: {@link OverlappingFrequenciesNotice}.
  */
 @GtfsValidator
 public class OverlappingFrequencyValidator extends FileValidator {
@@ -42,7 +42,7 @@ public class OverlappingFrequencyValidator extends FileValidator {
         GtfsFrequency curr = frequencyList.get(i);
         if (curr.startTime().isBefore(prev.endTime())) {
           noticeContainer.addValidationNotice(
-              new OverlappingFrequencyNotice(
+              new OverlappingFrequenciesNotice(
                   prev.csvRowNumber(),
                   prev.endTime(),
                   curr.csvRowNumber(),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -19,7 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.WrongParentLocationTypeNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopWithWrongParentLocationTypeNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
@@ -27,7 +27,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 /**
  * Validates `location_type` of the referenced `parent_station`.
  *
- * <p>Generated notice: {@link WrongParentLocationTypeNotice}.
+ * <p>Generated notice: {@link StopWithWrongParentLocationTypeNotice}.
  */
 @GtfsValidator
 public class ParentLocationTypeValidator extends FileValidator {
@@ -56,7 +56,7 @@ public class ParentLocationTypeValidator extends FileValidator {
       GtfsLocationType expected = expectedParentLocationType(location.locationType());
       if (expected != GtfsLocationType.UNRECOGNIZED && parentLocation.locationType() != expected) {
         noticeContainer.addValidationNotice(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 location.csvRowNumber(),
                 location.stopId(),
                 location.stopName(),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -21,7 +21,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
-import org.mobilitydata.gtfsvalidator.notice.SameNameAndDescriptionForRouteNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteSameNameAndDescriptionNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
 /**
@@ -33,7 +33,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
  *   <li>{@link RouteBothShortAndLongNameMissingNotice}
  *   <li>{@link RouteShortAndLongNameEqualNotice}
  *   <li>{@link RouteShortNameTooLongNotice}
- *   <li>{@link SameNameAndDescriptionForRouteNotice}
+ *   <li>{@link RouteSameNameAndDescriptionNotice}
  * </ul>
  */
 @GtfsValidator
@@ -69,13 +69,13 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
       String routeId = entity.routeId();
       if (hasShortName && !isValidRouteDesc(routeDesc, entity.routeShortName())) {
         noticeContainer.addValidationNotice(
-            new SameNameAndDescriptionForRouteNotice(
+            new RouteSameNameAndDescriptionNotice(
                 entity.csvRowNumber(), routeId, routeDesc, "route_short_name"));
         return;
       }
       if (hasLongName && !isValidRouteDesc(routeDesc, entity.routeLongName())) {
         noticeContainer.addValidationNotice(
-            new SameNameAndDescriptionForRouteNotice(
+            new RouteSameNameAndDescriptionNotice(
                 entity.csvRowNumber(), routeId, routeDesc, "route_long_name"));
       }
     }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyLangNotice;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyTimezoneNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyLangInconsistencyNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyTimezoneInconsistencyNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
@@ -109,7 +109,7 @@ public class AgencyConsistencyValidatorTest {
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(
-            new InconsistentAgencyTimezoneNotice(1, "America/Bogota", "America/Montreal"));
+            new AgencyTimezoneInconsistencyNotice(1, "America/Bogota", "America/Montreal"));
   }
 
   @Test
@@ -164,7 +164,7 @@ public class AgencyConsistencyValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new InconsistentAgencyLangNotice(1, "en", "fr"));
+        .containsExactly(new AgencyLangInconsistencyNotice(1, "en", "fr"));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -24,7 +24,7 @@ import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.input.GtfsFeedName;
-import org.mobilitydata.gtfsvalidator.notice.FeedExpirationDateNotice;
+import org.mobilitydata.gtfsvalidator.notice.FeedExpiresSoonNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -62,7 +62,7 @@ public class FeedExpirationDateValidatorTest {
             validateFeedInfo(
                 createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(3)))))
         .containsExactly(
-            new FeedExpirationDateNotice(
+            new FeedExpiresSoonNotice(
                 1,
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(3)),
@@ -75,7 +75,7 @@ public class FeedExpirationDateValidatorTest {
             validateFeedInfo(
                 createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7)))))
         .containsExactly(
-            new FeedExpirationDateNotice(
+            new FeedExpiresSoonNotice(
                 1,
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7)),
@@ -88,7 +88,7 @@ public class FeedExpirationDateValidatorTest {
             validateFeedInfo(
                 createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(23)))))
         .containsExactly(
-            new FeedExpirationDateNotice(
+            new FeedExpiresSoonNotice(
                 1,
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(23)),
@@ -101,7 +101,7 @@ public class FeedExpirationDateValidatorTest {
             validateFeedInfo(
                 createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30)))))
         .containsExactly(
-            new FeedExpirationDateNotice(
+            new FeedExpiresSoonNotice(
                 1,
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
                 GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30)),

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mobilitydata.gtfsvalidator.notice.LocationWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopLocationWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.PlatformWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopPlatformWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.StationWithParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
@@ -71,7 +71,7 @@ public class LocationTypeSingleEntityValidatorTest {
 
     builder.setParentStation(null);
     assertThat(validateStop(builder.build()))
-        .containsExactly(new PlatformWithoutParentStationNotice(1, "s0", "Stop 0"));
+        .containsExactly(new StopPlatformWithoutParentStationNotice(1, "s0", "Stop 0"));
 
     // A GTFS stop without platform_code may be an isolated stop and may have no parent_station.
     builder.setPlatformCode(null);
@@ -97,7 +97,7 @@ public class LocationTypeSingleEntityValidatorTest {
       builder.setParentStation(null);
       assertThat(validateStop(builder.build()))
           .containsExactly(
-              new LocationWithoutParentStationNotice(1, "s0", "Stop 0", locationType.getNumber()));
+              new StopLocationWithoutParentStationNotice(1, "s0", "Stop 0", locationType.getNumber()));
     }
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
@@ -8,7 +8,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.OverlappingFrequencyNotice;
+import org.mobilitydata.gtfsvalidator.notice.OverlappingFrequenciesNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFrequency;
 import org.mobilitydata.gtfsvalidator.table.GtfsFrequencyTableContainer;
@@ -79,7 +79,7 @@ public class OverlappingFrequencyValidatorTest {
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "06:00:00", "10:00:00", 300)))
         .containsExactly(
-            new OverlappingFrequencyNotice(
+            new OverlappingFrequenciesNotice(
                 2, GtfsTime.fromString("07:00:00"), 3, GtfsTime.fromString("06:00:00"), "t0"));
   }
 
@@ -90,7 +90,7 @@ public class OverlappingFrequencyValidatorTest {
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "05:00:00", "06:30:00", 300)))
         .containsExactly(
-            new OverlappingFrequencyNotice(
+            new OverlappingFrequenciesNotice(
                 3, GtfsTime.fromString("06:30:00"), 2, GtfsTime.fromString("05:00:00"), "t0"));
   }
 
@@ -101,7 +101,7 @@ public class OverlappingFrequencyValidatorTest {
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "06:30:00", "07:00:00", 300)))
         .containsExactly(
-            new OverlappingFrequencyNotice(
+            new OverlappingFrequenciesNotice(
                 2, GtfsTime.fromString("07:00:00"), 3, GtfsTime.fromString("06:30:00"), "t0"));
   }
 
@@ -112,7 +112,7 @@ public class OverlappingFrequencyValidatorTest {
                 createFrequency(2, "t0", "07:00:00", "12:00:00", 600),
                 createFrequency(3, "t0", "08:00:00", "11:00:00", 300)))
         .containsExactly(
-            new OverlappingFrequencyNotice(
+            new OverlappingFrequenciesNotice(
                 2, GtfsTime.fromString("12:00:00"), 3, GtfsTime.fromString("08:00:00"), "t0"));
   }
 
@@ -124,9 +124,9 @@ public class OverlappingFrequencyValidatorTest {
                 createFrequency(3, "t0", "05:00:00", "05:15:00", 300),
                 createFrequency(4, "t0", "05:20:00", "05:40:00", 300)))
         .containsExactly(
-            new OverlappingFrequencyNotice(
+            new OverlappingFrequenciesNotice(
                 3, GtfsTime.fromString("05:15:00"), 2, GtfsTime.fromString("05:00:00"), "t0"),
-            new OverlappingFrequencyNotice(
+            new OverlappingFrequenciesNotice(
                 2, GtfsTime.fromString("05:25:00"), 4, GtfsTime.fromString("05:20:00"), "t0"));
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
-import org.mobilitydata.gtfsvalidator.notice.WrongParentLocationTypeNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopWithWrongParentLocationTypeNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
@@ -79,7 +79,7 @@ public class ParentLocationTypeValidatorTest {
     assertThat(validateChildAndParent(GtfsLocationType.STOP, GtfsLocationType.STATION)).isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.STOP, GtfsLocationType.ENTRANCE))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",
@@ -97,7 +97,7 @@ public class ParentLocationTypeValidatorTest {
         .isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE, GtfsLocationType.STOP))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",
@@ -115,7 +115,7 @@ public class ParentLocationTypeValidatorTest {
         .isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE, GtfsLocationType.STOP))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",
@@ -133,7 +133,7 @@ public class ParentLocationTypeValidatorTest {
         .isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.BOARDING_AREA, GtfsLocationType.STATION))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
@@ -26,7 +26,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
-import org.mobilitydata.gtfsvalidator.notice.SameNameAndDescriptionForRouteNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteSameNameAndDescriptionNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
@@ -81,22 +81,22 @@ public class RouteNameValidatorTest {
   public void equalRouteShortNameAndRouteDescShouldGenerateNotice() {
     assertThat(validateRoute(createRoute("duplicate", null, "duplicate")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
     // include difference with lower case and upper case characters
     assertThat(validateRoute(createRoute("DuplicATE", null, "duplicate")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
   }
 
   @Test
   public void equalRouteLongNameAndRouteDescShouldGenerateNotice() {
     assertThat(validateRoute(createRoute(null, "duplicate", "duplicate")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_long_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_long_name"));
     // include difference with lower case and upper case characters
     assertThat(validateRoute(createRoute(null, "duplicate", "DuplicATE")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "DuplicATE", "route_long_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "DuplicATE", "route_long_name"));
   }
 
   @Test
@@ -120,6 +120,6 @@ public class RouteNameValidatorTest {
         .contains(new RouteShortAndLongNameEqualNotice("r1", 1, "duplicate", "duplicate"));
     assertThat(validateRoute(createRoute("duplicate", "duplicate", "duplicate")))
         .contains(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
   }
 }


### PR DESCRIPTION
closes #784 

**Summary:**

This PR refactors notice class names and codes so that they are all the same. It implements getCode() in the base Notice class.

**Expected behavior:** 

Notice code should be derived from the notice class name.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
