### PR TITLE
refactor: rename notices

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyLangInconsistencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyLangInconsistencyNotice.java
@@ -19,22 +19,22 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Inconsistent Timezone among agencies.
+ * Inconsistent language among agencies.
  *
- * <p>Severity: {@code SeverityLevel.ERROR}
+ * <p>Severity: {@code SeverityLevel.WARNING}
  */
-public class InconsistentAgencyTimezoneNotice extends ValidationNotice {
-  public InconsistentAgencyTimezoneNotice(long csvRowNumber, String expected, String actual) {
+public class AgencyLangInconsistencyNotice extends ValidationNotice {
+  public AgencyLangInconsistencyNotice(long csvRowNumber, String expected, String actual) {
     super(
         ImmutableMap.of(
             "csvRowNumber", csvRowNumber,
             "expected", expected,
             "actual", actual),
-        SeverityLevel.ERROR);
+        SeverityLevel.WARNING);
   }
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_timezone";
+    return "inconsistent_agency_lang";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyLangInconsistencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyLangInconsistencyNotice.java
@@ -35,6 +35,6 @@ public class AgencyLangInconsistencyNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_lang";
+    return "agency_lang_inconsistency";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyTimezoneInconsistencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyTimezoneInconsistencyNotice.java
@@ -19,22 +19,22 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Inconsistent language among agencies.
+ * Inconsistent Timezone among agencies.
  *
- * <p>Severity: {@code SeverityLevel.WARNING}
+ * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class InconsistentAgencyLangNotice extends ValidationNotice {
-  public InconsistentAgencyLangNotice(long csvRowNumber, String expected, String actual) {
+public class AgencyTimezoneInconsistencyNotice extends ValidationNotice {
+  public AgencyTimezoneInconsistencyNotice(long csvRowNumber, String expected, String actual) {
     super(
         ImmutableMap.of(
             "csvRowNumber", csvRowNumber,
             "expected", expected,
             "actual", actual),
-        SeverityLevel.WARNING);
+        SeverityLevel.ERROR);
   }
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_lang";
+    return "inconsistent_agency_timezone";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyTimezoneInconsistencyNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AgencyTimezoneInconsistencyNotice.java
@@ -35,6 +35,6 @@ public class AgencyTimezoneInconsistencyNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "inconsistent_agency_timezone";
+    return "agency_timezone_inconsistency";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteSameNameAndDescriptionNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteSameNameAndDescriptionNotice.java
@@ -29,8 +29,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
-  public SameNameAndDescriptionForRouteNotice(
+public class RouteSameNameAndDescriptionNotice extends ValidationNotice {
+  public RouteSameNameAndDescriptionNotice(
       long csvRowNumber, String routeId, String routeDesc, String routeShortOrLongName) {
     super(
         new ImmutableMap.Builder<String, Object>()
@@ -45,6 +45,6 @@ public class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "same_route_name_and_description";
+    return "route_same_name_and_description_notice";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteWithSameNameAndDescriptionNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/RouteWithSameNameAndDescriptionNotice.java
@@ -29,8 +29,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class RouteSameNameAndDescriptionNotice extends ValidationNotice {
-  public RouteSameNameAndDescriptionNotice(
+public class RouteWithSameNameAndDescriptionNotice extends ValidationNotice {
+  public RouteWithSameNameAndDescriptionNotice(
       long csvRowNumber, String routeId, String routeDesc, String routeShortOrLongName) {
     super(
         new ImmutableMap.Builder<String, Object>()
@@ -45,6 +45,6 @@ public class RouteSameNameAndDescriptionNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "route_same_name_and_description_notice";
+    return "route_with_same_name_and_description";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopLocationWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopLocationWithoutParentStationNotice.java
@@ -26,8 +26,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class LocationWithoutParentStationNotice extends ValidationNotice {
-  public LocationWithoutParentStationNotice(
+public class StopLocationWithoutParentStationNotice extends ValidationNotice {
+  public StopLocationWithoutParentStationNotice(
       long csvRowNumber, String stopId, String stopName, int locationType) {
     super(
         ImmutableMap.of(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopLocationWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopLocationWithoutParentStationNotice.java
@@ -44,6 +44,6 @@ public class StopLocationWithoutParentStationNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "location_without_parent_station";
+    return "stop_location_without_parent_station";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopPlatformWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopPlatformWithoutParentStationNotice.java
@@ -34,6 +34,6 @@ public class StopPlatformWithoutParentStationNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "platform_without_parent_station";
+    return "stop_platform_without_parent_station";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopPlatformWithoutParentStationNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopPlatformWithoutParentStationNotice.java
@@ -25,8 +25,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
-public class PlatformWithoutParentStationNotice extends ValidationNotice {
-  public PlatformWithoutParentStationNotice(long csvRowNumber, String stopId, String stopName) {
+public class StopPlatformWithoutParentStationNotice extends ValidationNotice {
+  public StopPlatformWithoutParentStationNotice(long csvRowNumber, String stopId, String stopName) {
     super(
         ImmutableMap.of("csvRowNumber", csvRowNumber, "stopId", stopId, "stopName", stopName),
         SeverityLevel.WARNING);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopWithWrongParentLocationTypeNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopWithWrongParentLocationTypeNotice.java
@@ -24,8 +24,8 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
-public class WrongParentLocationTypeNotice extends ValidationNotice {
-  public WrongParentLocationTypeNotice(
+public class StopWithWrongParentLocationTypeNotice extends ValidationNotice {
+  public StopWithWrongParentLocationTypeNotice(
       long csvRowNumber,
       String stopId,
       String stopName,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopWithWrongParentLocationTypeNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/StopWithWrongParentLocationTypeNotice.java
@@ -52,6 +52,6 @@ public class StopWithWrongParentLocationTypeNotice extends ValidationNotice {
 
   @Override
   public String getCode() {
-    return "wrong_parent_location_type";
+    return "stop_with_wrong_parent_location_type";
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -20,8 +20,8 @@ import java.time.ZoneId;
 import java.util.Locale;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyLangNotice;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyTimezoneNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyLangInconsistencyNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyTimezoneInconsistencyNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
@@ -36,8 +36,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
  *
  * <ul>
  *   <li>{@link MissingRequiredFieldError} - multiple agencies present but no agency_id set
- *   <li>{@link InconsistentAgencyTimezoneNotice} - inconsistent timezone among the agencies
- *   <li>{@link InconsistentAgencyLangNotice} - inconsistent language among the agencies
+ *   <li>{@link AgencyTimezoneInconsistencyNotice} - inconsistent timezone among the agencies
+ *   <li>{@link AgencyLangInconsistencyNotice} - inconsistent language among the agencies
  * </ul>
  */
 @GtfsValidator
@@ -69,7 +69,7 @@ public class AgencyConsistencyValidator extends FileValidator {
       GtfsAgency agency = agencyTable.getEntities().get(i);
       if (!commonTimezone.equals(agency.agencyTimezone())) {
         noticeContainer.addValidationNotice(
-            new InconsistentAgencyTimezoneNotice(
+            new AgencyTimezoneInconsistencyNotice(
                 agency.csvRowNumber(), commonTimezone.getId(), agency.agencyTimezone().getId()));
       }
     }
@@ -87,7 +87,7 @@ public class AgencyConsistencyValidator extends FileValidator {
         commonLanguage = agency.agencyLang();
       } else if (!commonLanguage.equals(agency.agencyLang())) {
         noticeContainer.addValidationNotice(
-            new InconsistentAgencyLangNotice(
+            new AgencyLangInconsistencyNotice(
                 agency.csvRowNumber(),
                 commonLanguage.getLanguage(),
                 agency.agencyLang().getLanguage()));

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
@@ -17,9 +17,9 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.notice.LocationWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopLocationWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.PlatformWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopPlatformWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.StationWithParentStationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
@@ -31,8 +31,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStop;
  *
  * <ul>
  *   <li>{@link StationWithParentStationNotice}
- *   <li>{@link PlatformWithoutParentStationNotice}
- *   <li>{@link LocationWithoutParentStationNotice}
+ *   <li>{@link StopPlatformWithoutParentStationNotice}
+ *   <li>{@link StopLocationWithoutParentStationNotice}
  * </ul>
  */
 @GtfsValidator
@@ -57,12 +57,12 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
         // This is a platform since it has platform_code. This is a separate notice from
         // LocationWithoutParentStationNotice because it is less severe.
         noticeContainer.addValidationNotice(
-            new PlatformWithoutParentStationNotice(
+            new StopPlatformWithoutParentStationNotice(
                 location.csvRowNumber(), location.stopId(), location.stopName()));
       }
     } else if (requiresParentStation(location.locationType())) {
       noticeContainer.addValidationNotice(
-          new LocationWithoutParentStationNotice(
+          new StopLocationWithoutParentStationNotice(
               location.csvRowNumber(), location.stopId(),
               location.stopName(), location.locationTypeValue()));
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -19,7 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.WrongParentLocationTypeNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopWithWrongParentLocationTypeNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
@@ -27,7 +27,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 /**
  * Validates `location_type` of the referenced `parent_station`.
  *
- * <p>Generated notice: {@link WrongParentLocationTypeNotice}.
+ * <p>Generated notice: {@link StopWithWrongParentLocationTypeNotice}.
  */
 @GtfsValidator
 public class ParentLocationTypeValidator extends FileValidator {
@@ -56,7 +56,7 @@ public class ParentLocationTypeValidator extends FileValidator {
       GtfsLocationType expected = expectedParentLocationType(location.locationType());
       if (expected != GtfsLocationType.UNRECOGNIZED && parentLocation.locationType() != expected) {
         noticeContainer.addValidationNotice(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 location.csvRowNumber(),
                 location.stopId(),
                 location.stopName(),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -21,7 +21,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
-import org.mobilitydata.gtfsvalidator.notice.RouteSameNameAndDescriptionNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteWithSameNameAndDescriptionNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
 /**
@@ -33,7 +33,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
  *   <li>{@link RouteBothShortAndLongNameMissingNotice}
  *   <li>{@link RouteShortAndLongNameEqualNotice}
  *   <li>{@link RouteShortNameTooLongNotice}
- *   <li>{@link RouteSameNameAndDescriptionNotice}
+ *   <li>{@link RouteWithSameNameAndDescriptionNotice}
  * </ul>
  */
 @GtfsValidator
@@ -69,13 +69,13 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
       String routeId = entity.routeId();
       if (hasShortName && !isValidRouteDesc(routeDesc, entity.routeShortName())) {
         noticeContainer.addValidationNotice(
-            new RouteSameNameAndDescriptionNotice(
+            new RouteWithSameNameAndDescriptionNotice(
                 entity.csvRowNumber(), routeId, routeDesc, "route_short_name"));
         return;
       }
       if (hasLongName && !isValidRouteDesc(routeDesc, entity.routeLongName())) {
         noticeContainer.addValidationNotice(
-            new RouteSameNameAndDescriptionNotice(
+            new RouteWithSameNameAndDescriptionNotice(
                 entity.csvRowNumber(), routeId, routeDesc, "route_long_name"));
       }
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -21,7 +21,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
-import org.mobilitydata.gtfsvalidator.notice.SameNameAndDescriptionForRouteNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteSameNameAndDescriptionNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
 /**
@@ -33,7 +33,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
  *   <li>{@link RouteBothShortAndLongNameMissingNotice}
  *   <li>{@link RouteShortAndLongNameEqualNotice}
  *   <li>{@link RouteShortNameTooLongNotice}
- *   <li>{@link SameNameAndDescriptionForRouteNotice}
+ *   <li>{@link RouteSameNameAndDescriptionNotice}
  * </ul>
  */
 @GtfsValidator
@@ -69,13 +69,13 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
       String routeId = entity.routeId();
       if (hasShortName && !isValidRouteDesc(routeDesc, entity.routeShortName())) {
         noticeContainer.addValidationNotice(
-            new SameNameAndDescriptionForRouteNotice(
+            new RouteSameNameAndDescriptionNotice(
                 entity.csvRowNumber(), routeId, routeDesc, "route_short_name"));
         return;
       }
       if (hasLongName && !isValidRouteDesc(routeDesc, entity.routeLongName())) {
         noticeContainer.addValidationNotice(
-            new SameNameAndDescriptionForRouteNotice(
+            new RouteSameNameAndDescriptionNotice(
                 entity.csvRowNumber(), routeId, routeDesc, "route_long_name"));
       }
     }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.Locale;
 import javax.annotation.Nullable;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyLangNotice;
-import org.mobilitydata.gtfsvalidator.notice.InconsistentAgencyTimezoneNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyLangInconsistencyNotice;
+import org.mobilitydata.gtfsvalidator.notice.AgencyTimezoneInconsistencyNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
@@ -109,7 +109,7 @@ public class AgencyConsistencyValidatorTest {
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(
-            new InconsistentAgencyTimezoneNotice(1, "America/Bogota", "America/Montreal"));
+            new AgencyTimezoneInconsistencyNotice(1, "America/Bogota", "America/Montreal"));
   }
 
   @Test
@@ -164,7 +164,7 @@ public class AgencyConsistencyValidatorTest {
 
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new InconsistentAgencyLangNotice(1, "en", "fr"));
+        .containsExactly(new AgencyLangInconsistencyNotice(1, "en", "fr"));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
@@ -22,9 +22,9 @@ import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mobilitydata.gtfsvalidator.notice.LocationWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopLocationWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.notice.PlatformWithoutParentStationNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopPlatformWithoutParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.StationWithParentStationNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
@@ -71,7 +71,7 @@ public class LocationTypeSingleEntityValidatorTest {
 
     builder.setParentStation(null);
     assertThat(validateStop(builder.build()))
-        .containsExactly(new PlatformWithoutParentStationNotice(1, "s0", "Stop 0"));
+        .containsExactly(new StopPlatformWithoutParentStationNotice(1, "s0", "Stop 0"));
 
     // A GTFS stop without platform_code may be an isolated stop and may have no parent_station.
     builder.setPlatformCode(null);
@@ -97,7 +97,7 @@ public class LocationTypeSingleEntityValidatorTest {
       builder.setParentStation(null);
       assertThat(validateStop(builder.build()))
           .containsExactly(
-              new LocationWithoutParentStationNotice(1, "s0", "Stop 0", locationType.getNumber()));
+              new StopLocationWithoutParentStationNotice(1, "s0", "Stop 0", locationType.getNumber()));
     }
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
@@ -25,7 +25,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
-import org.mobilitydata.gtfsvalidator.notice.WrongParentLocationTypeNotice;
+import org.mobilitydata.gtfsvalidator.notice.StopWithWrongParentLocationTypeNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
@@ -79,7 +79,7 @@ public class ParentLocationTypeValidatorTest {
     assertThat(validateChildAndParent(GtfsLocationType.STOP, GtfsLocationType.STATION)).isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.STOP, GtfsLocationType.ENTRANCE))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",
@@ -97,7 +97,7 @@ public class ParentLocationTypeValidatorTest {
         .isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE, GtfsLocationType.STOP))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",
@@ -115,7 +115,7 @@ public class ParentLocationTypeValidatorTest {
         .isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE, GtfsLocationType.STOP))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",
@@ -133,7 +133,7 @@ public class ParentLocationTypeValidatorTest {
         .isEmpty();
     assertThat(validateChildAndParent(GtfsLocationType.BOARDING_AREA, GtfsLocationType.STATION))
         .contains(
-            new WrongParentLocationTypeNotice(
+            new StopWithWrongParentLocationTypeNotice(
                 1,
                 "child",
                 "Child location",

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
@@ -26,7 +26,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
-import org.mobilitydata.gtfsvalidator.notice.SameNameAndDescriptionForRouteNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteSameNameAndDescriptionNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
@@ -81,22 +81,22 @@ public class RouteNameValidatorTest {
   public void equalRouteShortNameAndRouteDescShouldGenerateNotice() {
     assertThat(validateRoute(createRoute("duplicate", null, "duplicate")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
     // include difference with lower case and upper case characters
     assertThat(validateRoute(createRoute("DuplicATE", null, "duplicate")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
   }
 
   @Test
   public void equalRouteLongNameAndRouteDescShouldGenerateNotice() {
     assertThat(validateRoute(createRoute(null, "duplicate", "duplicate")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_long_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_long_name"));
     // include difference with lower case and upper case characters
     assertThat(validateRoute(createRoute(null, "duplicate", "DuplicATE")))
         .containsExactly(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "DuplicATE", "route_long_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "DuplicATE", "route_long_name"));
   }
 
   @Test
@@ -120,6 +120,6 @@ public class RouteNameValidatorTest {
         .contains(new RouteShortAndLongNameEqualNotice("r1", 1, "duplicate", "duplicate"));
     assertThat(validateRoute(createRoute("duplicate", "duplicate", "duplicate")))
         .contains(
-            new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
@@ -26,7 +26,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.RouteBothShortAndLongNameMissingNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.notice.RouteShortNameTooLongNotice;
-import org.mobilitydata.gtfsvalidator.notice.RouteSameNameAndDescriptionNotice;
+import org.mobilitydata.gtfsvalidator.notice.RouteWithSameNameAndDescriptionNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 
@@ -81,22 +81,22 @@ public class RouteNameValidatorTest {
   public void equalRouteShortNameAndRouteDescShouldGenerateNotice() {
     assertThat(validateRoute(createRoute("duplicate", null, "duplicate")))
         .containsExactly(
-            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteWithSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
     // include difference with lower case and upper case characters
     assertThat(validateRoute(createRoute("DuplicATE", null, "duplicate")))
         .containsExactly(
-            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteWithSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
   }
 
   @Test
   public void equalRouteLongNameAndRouteDescShouldGenerateNotice() {
     assertThat(validateRoute(createRoute(null, "duplicate", "duplicate")))
         .containsExactly(
-            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_long_name"));
+            new RouteWithSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_long_name"));
     // include difference with lower case and upper case characters
     assertThat(validateRoute(createRoute(null, "duplicate", "DuplicATE")))
         .containsExactly(
-            new RouteSameNameAndDescriptionNotice(1, "r1", "DuplicATE", "route_long_name"));
+            new RouteWithSameNameAndDescriptionNotice(1, "r1", "DuplicATE", "route_long_name"));
   }
 
   @Test
@@ -120,6 +120,6 @@ public class RouteNameValidatorTest {
         .contains(new RouteShortAndLongNameEqualNotice("r1", 1, "duplicate", "duplicate"));
     assertThat(validateRoute(createRoute("duplicate", "duplicate", "duplicate")))
         .contains(
-            new RouteSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
+            new RouteWithSameNameAndDescriptionNotice(1, "r1", "duplicate", "route_short_name"));
   }
 }


### PR DESCRIPTION
closes #793 

**Summary:**

This PR revisits some notice class names as suggested by https://github.com/MobilityData/gtfs-validator/pull/781#discussion_r585866237

> Also, I'd suggest we put the entity name first when it makes sense for consistency, and because if we list the rules in the table alphabetically then, for example, most of the Route rules should be grouped together. So, for example, this class and code could be renamed to RouteSameNameAndDescriptionNotice and route_same_name_and_description. Then it would appear right after RouteBothShortAndLongNameMissingNotice.


**Expected behavior:** 

No code logic change. Tests should pass.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
