### PR TITLE
feat: check all attributions have a role

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -78,6 +78,7 @@ Notices are split into three categories: `INFO`, `WARNING`, `ERROR`.
 |[`MissingFeedInfoDateNotice`](#MissingFeedInfoDateNotice)| [W010](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W010), [W011](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W011)| `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided. |
 |[`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)| [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
 || [W014](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W014), [W015](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W015), [W016](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#W016)| Duplicate `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name` and `routes.route_short_name` |
+|[`AttributionWithoutRoleNotice`](#AttributionWithoutRoleNotice)| [E019](https://github.com/MobilityData/gtfs-validator/blob/v1.4.0/RULES.md#E019)| Attribution with no role |
 
 ## Notices
 
@@ -419,3 +420,12 @@ Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one
 ### TooFastTravelNotice
 
 As implemented in the original [Google Python GTFS validator](https://github.com/google/transitfeed/wiki/FeedValidator), the calculated speed between stops should not be greater than 150 km/h (42 m/s SI or 93 mph). 
+
+<a name="AttributionWithoutRoleNotice"/>
+
+### AttributionWithoutRoleNotice
+
+At least one of the fields is_producer, is_operator, or is_authority should be set at 1.
+
+#### References:
+* [attributions.txt specification](https://gtfs.org/best-practices/#attributionsstxt)

--- a/RULES.md
+++ b/RULES.md
@@ -425,7 +425,7 @@ As implemented in the original [Google Python GTFS validator](https://github.com
 
 ### AttributionWithoutRoleNotice
 
-At least one of the fields is_producer, is_operator, or is_authority should be set at 1.
+At least one of the fields `is_producer`, `is_operator`, or `is_authority` should be set to 1.
 
 #### References:
-* [attributions.txt specification](https://gtfs.org/best-practices/#attributionsstxt)
+* [attributions.txt specification](https://gtfs.org/reference/static#attributionstxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AttributionWithoutRoleNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AttributionWithoutRoleNotice.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * A row from GTFS file `attributions.txt` has fields `attributions.is_producer`,
+ * `attributions.is_operator`, and `attributions.is_authority` not defined or set at 0.
+ *
+ * <p>Severity: {@code SeverityLevel.WARNING}
+ */
+public class AttributionWithoutRoleNotice extends ValidationNotice {
+  public AttributionWithoutRoleNotice(long csvRowNumber) {
+    super(
+        new ImmutableMap.Builder<String, Object>().put("csvRowNumber", csvRowNumber).build(),
+        SeverityLevel.WARNING);
+  }
+
+  @Override
+  public String getCode() {
+    return "attribution_without_role";
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.AttributionWithoutRoleNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsAttribution;
+import org.mobilitydata.gtfsvalidator.table.GtfsAttributionRole;
+import org.mobilitydata.gtfsvalidator.table.GtfsAttributionTableContainer;
+
+/**
+ * Validates that for all attributions from GTFS file `attributions.txt`: at least one of the fields
+ * is_producer, is_operator, or is_authority is set at 1
+ * (http://gtfs.org/reference/static#attributionstxt).
+ *
+ * <p>Generated notices:
+ *
+ * <ul>
+ *   <li>{@link AttributionWithoutRoleNotice} - is_producer, is_operator, and is_authority and
+ *       undefined or set to 0
+ * </ul>
+ */
+@GtfsValidator
+public class AttributionWithoutRoleValidator extends FileValidator {
+
+  @Inject GtfsAttributionTableContainer attributionTable;
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    for (GtfsAttribution attribution : attributionTable.getEntities()) {
+      if (attribution.isAuthority().equals(GtfsAttributionRole.NOT_ASSIGNED)
+          && attribution.isProducer().equals(GtfsAttributionRole.NOT_ASSIGNED)
+          && attribution.isOperator().equals(GtfsAttributionRole.NOT_ASSIGNED)) {
+        noticeContainer.addValidationNotice(
+            new AttributionWithoutRoleNotice(attribution.csvRowNumber()));
+      }
+    }
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -44,14 +44,14 @@ public class AttributionWithoutRoleValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsAttribution attribution : attributionTable.getEntities()) {
-      if (hasRole(attribution)) {
+      if (isMissingRole(attribution)) {
         noticeContainer.addValidationNotice(
             new AttributionWithoutRoleNotice(attribution.csvRowNumber()));
       }
     }
   }
 
-  private boolean hasRole(GtfsAttribution attribution) {
+  private boolean isMissingRole(GtfsAttribution attribution) {
     return (attribution.isProducer() != GtfsAttributionRole.ASSIGNED)
         && (attribution.isAuthority() != GtfsAttributionRole.ASSIGNED)
         && (attribution.isOperator() != GtfsAttributionRole.ASSIGNED);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -44,12 +44,16 @@ public class AttributionWithoutRoleValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsAttribution attribution : attributionTable.getEntities()) {
-      if ((attribution.isAuthority().equals(GtfsAttributionRole.NOT_ASSIGNED) || attribution.isAuthority().equals(GtfsAttributionRole.UNRECOGNIZED))
-      && (attribution.isProducer().equals(GtfsAttributionRole.NOT_ASSIGNED) || attribution.isProducer().equals(GtfsAttributionRole.UNRECOGNIZED))
-          && (attribution.isOperator().equals(GtfsAttributionRole.NOT_ASSIGNED) || attribution.isOperator().equals(GtfsAttributionRole.UNRECOGNIZED))) {
+      if (hasRole(attribution)) {
         noticeContainer.addValidationNotice(
             new AttributionWithoutRoleNotice(attribution.csvRowNumber()));
       }
     }
+  }
+
+  private boolean hasRole(GtfsAttribution attribution) {
+    return (attribution.isProducer() != GtfsAttributionRole.ASSIGNED)
+        && (attribution.isAuthority() != GtfsAttributionRole.ASSIGNED)
+        && (attribution.isOperator() != GtfsAttributionRole.ASSIGNED);
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -44,9 +44,9 @@ public class AttributionWithoutRoleValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsAttribution attribution : attributionTable.getEntities()) {
-      if (attribution.isAuthority().equals(GtfsAttributionRole.NOT_ASSIGNED)
-          && attribution.isProducer().equals(GtfsAttributionRole.NOT_ASSIGNED)
-          && attribution.isOperator().equals(GtfsAttributionRole.NOT_ASSIGNED)) {
+      if ((attribution.isAuthority().equals(GtfsAttributionRole.NOT_ASSIGNED) || attribution.isAuthority().equals(GtfsAttributionRole.UNRECOGNIZED))
+      && (attribution.isProducer().equals(GtfsAttributionRole.NOT_ASSIGNED) || attribution.isProducer().equals(GtfsAttributionRole.UNRECOGNIZED))
+          && (attribution.isOperator().equals(GtfsAttributionRole.NOT_ASSIGNED) || attribution.isOperator().equals(GtfsAttributionRole.UNRECOGNIZED))) {
         noticeContainer.addValidationNotice(
             new AttributionWithoutRoleNotice(attribution.csvRowNumber()));
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -32,7 +32,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAttributionTableContainer;
  * <p>Generated notices:
  *
  * <ul>
- *   <li>{@link AttributionWithoutRoleNotice} - is_producer, is_operator, and is_authority and
+ *   <li>{@link AttributionWithoutRoleNotice} - is_producer, is_operator, and is_authority are
  *       undefined or set to 0
  * </ul>
  */

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
@@ -53,12 +53,12 @@ public class AttributionWithoutRoleValidatorTest {
         createAttributionTable(
             noticeContainer,
             ImmutableList.of(
-                createAttribution(3, 0, 0, 0), createAttribution(8, null, null, null)));
+                createAttribution(3, 0, 0, 0), createAttribution(8, null, null, null), createAttribution(13, 5, 0, 0)));
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactlyElementsIn(
             new AttributionWithoutRoleNotice[] {
-              new AttributionWithoutRoleNotice(3), new AttributionWithoutRoleNotice(8)
+              new AttributionWithoutRoleNotice(3), new AttributionWithoutRoleNotice(8),  new AttributionWithoutRoleNotice(13)
             });
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
@@ -47,31 +47,37 @@ public class AttributionWithoutRoleValidatorTest {
   @Test
   public void attributionWithoutRoleShouldGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
-    AttributionWithoutRoleValidator underTest = new AttributionWithoutRoleValidator();
+    AttributionWithoutRoleValidator attributionWithoutRouteValidator =
+        new AttributionWithoutRoleValidator();
 
-    underTest.attributionTable =
+    attributionWithoutRouteValidator.attributionTable =
         createAttributionTable(
             noticeContainer,
             ImmutableList.of(
-                createAttribution(3, 0, 0, 0), createAttribution(8, null, null, null), createAttribution(13, 5, 0, 0)));
-    underTest.validate(noticeContainer);
+                createAttribution(3, 0, 0, 0),
+                createAttribution(8, null, null, null),
+                createAttribution(13, 5, 0, 0)));
+    attributionWithoutRouteValidator.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactlyElementsIn(
             new AttributionWithoutRoleNotice[] {
-              new AttributionWithoutRoleNotice(3), new AttributionWithoutRoleNotice(8),  new AttributionWithoutRoleNotice(13)
+              new AttributionWithoutRoleNotice(3),
+              new AttributionWithoutRoleNotice(8),
+              new AttributionWithoutRoleNotice(13)
             });
   }
 
   @Test
   public void attributionWithRoleShouldNotGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
-    AttributionWithoutRoleValidator underTest = new AttributionWithoutRoleValidator();
+    AttributionWithoutRoleValidator attributionWithoutRouteValidator =
+        new AttributionWithoutRoleValidator();
 
-    underTest.attributionTable =
+    attributionWithoutRouteValidator.attributionTable =
         createAttributionTable(
             noticeContainer,
             ImmutableList.of(createAttribution(3, 1, 0, 0), createAttribution(8, null, 1, null)));
-    underTest.validate(noticeContainer);
+    attributionWithoutRouteValidator.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.AttributionWithoutRoleNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsAttribution;
+import org.mobilitydata.gtfsvalidator.table.GtfsAttributionTableContainer;
+
+public class AttributionWithoutRoleValidatorTest {
+
+  private static GtfsAttributionTableContainer createAttributionTable(
+      NoticeContainer noticeContainer, List<GtfsAttribution> entities) {
+    return GtfsAttributionTableContainer.forEntities(entities, noticeContainer);
+  }
+
+  public static GtfsAttribution createAttribution(
+      long csvRowNumber, Integer isProducer, Integer isAuthority, Integer isOperator) {
+    return new GtfsAttribution.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setOrganizationName("organization name value")
+        .setIsProducer(isProducer)
+        .setIsAuthority(isAuthority)
+        .setIsOperator(isOperator)
+        .build();
+  }
+
+  @Test
+  public void attributionWithoutRoleShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    AttributionWithoutRoleValidator underTest = new AttributionWithoutRoleValidator();
+
+    underTest.attributionTable =
+        createAttributionTable(
+            noticeContainer,
+            ImmutableList.of(
+                createAttribution(3, 0, 0, 0), createAttribution(8, null, null, null)));
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactlyElementsIn(
+            new AttributionWithoutRoleNotice[] {
+              new AttributionWithoutRoleNotice(3), new AttributionWithoutRoleNotice(8)
+            });
+  }
+
+  @Test
+  public void attributionWithRoleShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    AttributionWithoutRoleValidator underTest = new AttributionWithoutRoleValidator();
+
+    underTest.attributionTable =
+        createAttributionTable(
+            noticeContainer,
+            ImmutableList.of(createAttribution(3, 1, 0, 0), createAttribution(8, null, 1, null)));
+    underTest.validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+}


### PR DESCRIPTION
closes #785 

**Summary:**

This PR implements the rule from `v1.4.0`which checked that all rows from GTFS file `attributions.txt` set a value to 1 to at least one of the following fields: 
- is_producer
- is_authority
- is_operator

**Expected behavior:** 

- Attributions with no role defined should generate a notice
- Attributions with all roles set to 0 should generate a notice
- Attribution with a role (at least one of the aforementioned fields is set to 1) should not generate a notice

New notice: `AttributionWithoutRoleNotice`(with SeverityLevel set to `WARNING`)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
