### PR TITLE
fix: Inherit AttributionWithoutRoleValidator from SingleEntityValidator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AttributionWithoutRoleNotice.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/notice/AttributionWithoutRoleNotice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 MobilityData IO
+ * Copyright 2021 Google LLC, MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,9 +25,10 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
 public class AttributionWithoutRoleNotice extends ValidationNotice {
-  public AttributionWithoutRoleNotice(long csvRowNumber) {
+
+  public AttributionWithoutRoleNotice(long csvRowNumber, String attributionId) {
     super(
-        new ImmutableMap.Builder<String, Object>().put("csvRowNumber", csvRowNumber).build(),
+        ImmutableMap.of("csvRowNumber", csvRowNumber, "attributionId", attributionId),
         SeverityLevel.WARNING);
   }
 


### PR DESCRIPTION
AttributionWithoutRoleValidator validates a single attribution. It does
not need the whole file to be scanned.

* SingleEntityValidators are invoked just after a row is parsed.
* FileValidators need the whole file to be scanned. They are skipped if
  any row failed to parse or primary keys are non-unique.