### PR TITLE
chore: improve efficiency of DuplicateRouteNameValidator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -52,24 +52,21 @@ public class DuplicateRouteNameValidator extends FileValidator {
         .getEntities()
         .forEach(
             route -> {
-              int hash;
+              int hash = getLongNameAndTypeHash(route);
               GtfsRoute otherRoute;
               if (route.hasRouteLongName()) {
-                hash = getLongNameAndTypeHash(route);
-                otherRoute = routeByLongName.get(hash);
+                otherRoute = routeByLongName.putIfAbsent(hash, route);
                 if (otherRoute != null) {
                   if (areRoutesFromSameAgency(route, otherRoute)) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_long_name", route.csvRowNumber(), route.routeId()));
                   }
-                } else {
-                  routeByLongName.put(hash, route);
                 }
               }
               if (route.hasRouteShortName()) {
                 hash = getShortNameAndTypeHash(route);
-                otherRoute = routeByShortName.get(hash);
+                otherRoute = routeByShortName.putIfAbsent(hash, route);
                 if (otherRoute != null) {
                   if (areRoutesFromSameAgency(route, otherRoute)) {
                     noticeContainer.addValidationNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -31,8 +31,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
  *
  * <p>When a {@code GtfsRoute} short and/or long names are found to be duplicate a {@code
  * DuplicateRouteNameNotice} is generated and added to the {@code NoticeContainer} except if routes
- * are from the same agency (values for `route.agency_id` are case-sensitive) or routes have
- * different `routes.route_type`.
+ * are from the same agency (values for "route.agency_id" are case-sensitive) or routes have
+ * different "routes.route_type".
  *
  * <p>Generated notice:
  *
@@ -95,24 +95,24 @@ public class DuplicateRouteNameValidator extends FileValidator {
   }
 
   /**
-   * Generate an hash associated to `routes.route_long_name` and `routes.route_type`. This hash is
+   * Generate an hash associated to "routes.route_long_name" and "routes.route_type". This hash is
    * used to interact with routeByLongName (variable defined in this class' validate method) to
    * store and retrieve routes by short name.
    *
    * @param route the {@code GtfsRoute} to generate the hash from
-   * @return the hash associated to `routes.route_long_name` and `routes.route_type`.
+   * @return the hash associated to "routes.route_long_name" and "routes.route_type".
    */
   private int getLongNameAndTypeHash(GtfsRoute route) {
     return Objects.hash(route.routeLongName(), route.routeType());
   }
 
   /**
-   * Generate an hash associated to `routes.route_short_name` and `routes.route_type`. This hash is
+   * Generate an hash associated to "routes.route_short_name" and "routes.route_type". This hash is
    * used to interact with routeByShortName (variable defined in this class' validate method) to
    * store and retrieve routes by short name.
    *
    * @param route the {@code GtfsRoute} to generate the hash from
-   * @return the hash associated to `routes.route_short_name` and `routes.route_type`.
+   * @return the hash associated to "routes.route_short_name" and "routes.route_type".
    */
   private int getShortNameAndTypeHash(GtfsRoute route) {
     return Objects.hash(route.routeShortName(), route.routeType());

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -54,7 +54,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
         .forEach(
             route -> {
               if (route.hasRouteShortName() && route.hasRouteLongName()) {
-                if (routeByShortAndLongName.containsKey(getShortAndLongNameHash(route))) {
+                if (routeByShortAndLongName.containsKey(getShortAndLongNameRouteTypeHash(route))) {
                   noticeContainer.addValidationNotice(
                       new DuplicateRouteNameNotice(
                           "route_short_name and route_long_name",
@@ -62,34 +62,34 @@ public class DuplicateRouteNameValidator extends FileValidator {
                           route.routeId()));
                   return;
                 } else {
-                  routeByShortAndLongName.put(getShortAndLongNameHash(route), route);
+                  routeByShortAndLongName.put(getShortAndLongNameRouteTypeHash(route), route);
                 }
               }
               if (route.hasRouteLongName()) {
-                if (routeByLongName.containsKey(getRouteLongNameHash(route))) {
+                if (routeByLongName.containsKey(getRouteLongNameRouteTypeHash(route))) {
                   if (areRoutesFromSameAgency(
                       route.agencyId(),
-                      routeByLongName.get(getRouteLongNameHash(route)).agencyId())) {
+                      routeByLongName.get(getRouteLongNameRouteTypeHash(route)).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_long_name", route.csvRowNumber(), route.routeId()));
                   }
                   return;
                 } else {
-                  routeByLongName.put(getRouteLongNameHash(route), route);
+                  routeByLongName.put(getRouteLongNameRouteTypeHash(route), route);
                 }
               }
               if (route.hasRouteShortName()) {
-                if (routeByShortName.containsKey(getRouteShortNameHash(route))) {
+                if (routeByShortName.containsKey(getRouteShortNameRouteTypeHash(route))) {
                   if (areRoutesFromSameAgency(
                       route.agencyId(),
-                      routeByShortName.get(getRouteShortNameHash(route)).agencyId())) {
+                      routeByShortName.get(getRouteShortNameRouteTypeHash(route)).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_short_name", route.csvRowNumber(), route.routeId()));
                   }
                 } else {
-                  routeByShortName.put(getRouteShortNameHash(route), route);
+                  routeByShortName.put(getRouteShortNameRouteTypeHash(route), route);
                 }
               }
             });
@@ -115,7 +115,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @param route the {@code GtfsRoute} to generate the hash from
    * @return the hash associated to `routes.route_long_name` and `routes.route_type`.
    */
-  private int getRouteLongNameHash(GtfsRoute route) {
+  private int getRouteLongNameRouteTypeHash(GtfsRoute route) {
     return Objects.hash(route.routeLongName(), route.routeType());
   }
 
@@ -127,7 +127,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @param route the {@code GtfsRoute} to generate the hash from
    * @return the hash associated to `routes.route_short_name` and `routes.route_type`.
    */
-  private int getRouteShortNameHash(GtfsRoute route) {
+  private int getRouteShortNameRouteTypeHash(GtfsRoute route) {
     return Objects.hash(route.routeShortName(), route.routeType());
   }
 
@@ -140,7 +140,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @return the hash associated to `routes.route_long_name`, `routes.route_short_name` and
    *     `routes.route_type`.
    */
-  private int getShortAndLongNameHash(GtfsRoute route) {
+  private int getShortAndLongNameRouteTypeHash(GtfsRoute route) {
     return Objects.hash(route.routeShortName(), route.routeLongName(), route.routeType());
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -52,10 +52,9 @@ public class DuplicateRouteNameValidator extends FileValidator {
         .getEntities()
         .forEach(
             route -> {
-              int hash = getLongNameAndTypeHash(route);
               GtfsRoute otherRoute;
               if (route.hasRouteLongName()) {
-                otherRoute = routeByLongName.putIfAbsent(hash, route);
+                otherRoute = routeByLongName.putIfAbsent(getLongNameAndTypeHash(route), route);
                 if (otherRoute != null) {
                   if (areRoutesFromSameAgency(route, otherRoute)) {
                     noticeContainer.addValidationNotice(
@@ -65,16 +64,13 @@ public class DuplicateRouteNameValidator extends FileValidator {
                 }
               }
               if (route.hasRouteShortName()) {
-                hash = getShortNameAndTypeHash(route);
-                otherRoute = routeByShortName.putIfAbsent(hash, route);
+                otherRoute = routeByShortName.putIfAbsent(getShortNameAndTypeHash(route), route);
                 if (otherRoute != null) {
                   if (areRoutesFromSameAgency(route, otherRoute)) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_short_name", route.csvRowNumber(), route.routeId()));
                   }
-                } else {
-                  routeByShortName.put(hash, route);
                 }
               }
             });

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -54,7 +54,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
         .forEach(
             route -> {
               if (route.hasRouteShortName() && route.hasRouteLongName()) {
-                if (routeByShortAndLongName.containsKey(getShortAndLongNameKey(route))) {
+                if (routeByShortAndLongName.containsKey(getShortAndLongNameHash(route))) {
                   noticeContainer.addValidationNotice(
                       new DuplicateRouteNameNotice(
                           "route_short_name and route_long_name",
@@ -62,34 +62,34 @@ public class DuplicateRouteNameValidator extends FileValidator {
                           route.routeId()));
                   return;
                 } else {
-                  routeByShortAndLongName.put(getShortAndLongNameKey(route), route);
+                  routeByShortAndLongName.put(getShortAndLongNameHash(route), route);
                 }
               }
               if (route.hasRouteLongName()) {
-                if (routeByLongName.containsKey(getRouteLongNameKey(route))) {
+                if (routeByLongName.containsKey(getRouteLongNameHash(route))) {
                   if (areRoutesFromSameAgency(
                       route.agencyId(),
-                      routeByLongName.get(getRouteLongNameKey(route)).agencyId())) {
+                      routeByLongName.get(getRouteLongNameHash(route)).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_long_name", route.csvRowNumber(), route.routeId()));
                   }
                   return;
                 } else {
-                  routeByLongName.put(getRouteLongNameKey(route), route);
+                  routeByLongName.put(getRouteLongNameHash(route), route);
                 }
               }
               if (route.hasRouteShortName()) {
-                if (routeByShortName.containsKey(getRouteShortNameKey(route))) {
+                if (routeByShortName.containsKey(getRouteShortNameHash(route))) {
                   if (areRoutesFromSameAgency(
                       route.agencyId(),
-                      routeByShortName.get(getRouteShortNameKey(route)).agencyId())) {
+                      routeByShortName.get(getRouteShortNameHash(route)).agencyId())) {
                     noticeContainer.addValidationNotice(
                         new DuplicateRouteNameNotice(
                             "route_short_name", route.csvRowNumber(), route.routeId()));
                   }
                 } else {
-                  routeByShortName.put(getRouteShortNameKey(route), route);
+                  routeByShortName.put(getRouteShortNameHash(route), route);
                 }
               }
             });
@@ -115,7 +115,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @param route the {@code GtfsRoute} to generate the hash from
    * @return the hash associated to `routes.route_long_name` and `routes.route_type`.
    */
-  private int getRouteLongNameKey(GtfsRoute route) {
+  private int getRouteLongNameHash(GtfsRoute route) {
     return Objects.hash(route.routeLongName(), route.routeType());
   }
 
@@ -127,7 +127,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @param route the {@code GtfsRoute} to generate the hash from
    * @return the hash associated to `routes.route_short_name` and `routes.route_type`.
    */
-  private int getRouteShortNameKey(GtfsRoute route) {
+  private int getRouteShortNameHash(GtfsRoute route) {
     return Objects.hash(route.routeShortName(), route.routeType());
   }
 
@@ -140,7 +140,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * @return the hash associated to `routes.route_long_name`, `routes.route_short_name` and
    *     `routes.route_type`.
    */
-  private int getShortAndLongNameKey(GtfsRoute route) {
+  private int getShortAndLongNameHash(GtfsRoute route) {
     return Objects.hash(route.routeShortName(), route.routeLongName(), route.routeType());
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.DuplicateRouteNameNotice;
@@ -45,9 +46,9 @@ public class DuplicateRouteNameValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    final Map<String, GtfsRoute> routeByLongName = new HashMap<>(routeTable.entityCount());
-    final Map<String, GtfsRoute> routeByShortName = new HashMap<>(routeTable.entityCount());
-    final Map<String, GtfsRoute> routeByShortAndLongName = new HashMap<>(routeTable.entityCount());
+    final Map<Integer, GtfsRoute> routeByLongName = new HashMap<>(routeTable.entityCount());
+    final Map<Integer, GtfsRoute> routeByShortName = new HashMap<>(routeTable.entityCount());
+    final Map<Integer, GtfsRoute> routeByShortAndLongName = new HashMap<>(routeTable.entityCount());
     routeTable
         .getEntities()
         .forEach(
@@ -107,33 +108,39 @@ public class DuplicateRouteNameValidator extends FileValidator {
   }
 
   /**
-   * Generate a key used to store {@code GtfsRoute} by `routes.route_long_name`.
+   * Generate an hash associated to `routes.route_long_name` and `routes.route_type`. This hash is
+   * used to interact with routeByLongName (variable defined in this class' validate method) to
+   * store and retrieve routes by short name.
    *
-   * @param route the {@code GtfsRoute} to generate the key from
-   * @return `routes.route_long_name`+`route.routeType`
+   * @param route the {@code GtfsRoute} to generate the hash from
+   * @return the hash associated to `routes.route_long_name` and `routes.route_type`.
    */
-  private String getRouteLongNameKey(GtfsRoute route) {
-    return route.routeLongName() + route.routeType();
+  private int getRouteLongNameKey(GtfsRoute route) {
+    return Objects.hash(route.routeLongName(), route.routeType());
   }
 
   /**
-   * Generate a key used to store {@code GtfsRoute} by `routes.route_short_name`.
+   * Generate an hash associated to `routes.route_short_name` and `routes.route_type`. This hash is
+   * used to interact with routeByShortName (variable defined in this class' validate method) to
+   * store and retrieve routes by short name.
    *
-   * @param route the {@code GtfsRoute} to generate the key from
-   * @return `routes.route_short_name`+`route.routeType`
+   * @param route the {@code GtfsRoute} to generate the hash from
+   * @return the hash associated to `routes.route_short_name` and `routes.route_type`.
    */
-  private String getRouteShortNameKey(GtfsRoute route) {
-    return route.routeShortName() + route.routeType();
+  private int getRouteShortNameKey(GtfsRoute route) {
+    return Objects.hash(route.routeShortName(), route.routeType());
   }
 
   /**
-   * Generate a key used to store {@code GtfsRoute} by both `routes.route_short_name` and
-   * `routes.route_long_name`.
+   * Generate an hash associated to `routes.route_long_name`, `routes.route_short_name` and
+   * `routes.route_type`. This hash is used to interact with routeByShortAndLongName (variable
+   * defined in this class' validate method) to store and retrieve routes by short and long name.
    *
-   * @param route the {@code GtfsRoute} to generate the key from
-   * @return `routes.route_short_name`+`routes.route_long_name`+`route.routeType`
+   * @param route the {@code GtfsRoute} to generate the hash from
+   * @return the hash associated to `routes.route_long_name`, `routes.route_short_name` and
+   *     `routes.route_type`.
    */
-  private String getShortAndLongNameKey(GtfsRoute route) {
-    return route.routeShortName() + route.routeLongName() + route.routeType();
+  private int getShortAndLongNameKey(GtfsRoute route) {
+    return Objects.hash(route.routeShortName(), route.routeLongName(), route.routeType());
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -182,7 +182,7 @@ public class DuplicateRouteNameValidatorTest {
     underTest.validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(
-            new DuplicateRouteNameNotice(
-                "route_short_name and route_long_name", 4, "2nd route id value"));
+            new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
+            new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"));
   }
 }


### PR DESCRIPTION
closes #805 

**Summary:**

This PR provides changes to improve `DuplicateRouteNameValidator`

**Expected behavior:** 

Routes are stored by the hashcode associated to:
- route_short_name, route_type instead of the concatenation of both fields
- route_long_name, route_type instead of the concatenation of both fields
- route_long_name, route_short_name, route_type instead of the concatenation of these 3 fields

Same tests should pass as there is no other logic change. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
