### PR TITLE
refactor: make CalendarServiceDateValidator extend SingleEntityValidator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/CalendarServiceDateValidator.java
@@ -22,6 +22,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableLoader;
 
 /**
  * Validates that start_date &lt;= end_date for all rows in "calendar.txt".
@@ -29,23 +30,20 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
  * <p>Generated notice: {@link StartAndEndDateOutOfOrderNotice}.
  */
 @GtfsValidator
-public class CalendarServiceDateValidator extends FileValidator {
-  @Inject GtfsCalendarTableContainer calendarTable;
+public class CalendarServiceDateValidator extends SingleEntityValidator<GtfsCalendar> {
 
   @Override
-  public void validate(NoticeContainer noticeContainer) {
-    for (GtfsCalendar calendar : calendarTable.getEntities()) {
-      if (calendar.hasStartDate()
-          && calendar.hasEndDate()
-          && calendar.startDate().isAfter(calendar.endDate())) {
-        noticeContainer.addValidationNotice(
-            new StartAndEndDateOutOfOrderNotice(
-                calendarTable.gtfsFilename(),
-                calendar.serviceId(),
-                calendar.csvRowNumber(),
-                calendar.startDate(),
-                calendar.endDate()));
-      }
+  public void validate(GtfsCalendar calendar, NoticeContainer noticeContainer) {
+    if (calendar.hasStartDate()
+        && calendar.hasEndDate()
+        && calendar.startDate().isAfter(calendar.endDate())) {
+      noticeContainer.addValidationNotice(
+          new StartAndEndDateOutOfOrderNotice(
+              GtfsCalendarTableLoader.FILENAME,
+              calendar.serviceId(),
+              calendar.csvRowNumber(),
+              calendar.startDate(),
+              calendar.endDate()));
     }
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/CalendarServiceDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/CalendarServiceDateValidatorTest.java
@@ -18,17 +18,13 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StartAndEndDateOutOfOrderNotice;
-import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
-import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
 
@@ -41,23 +37,15 @@ public class CalendarServiceDateValidatorTest {
           DayOfWeek.THURSDAY,
           DayOfWeek.FRIDAY);
 
-  private static GtfsCalendarTableContainer createCalendarTable(
-      NoticeContainer noticeContainer, List<GtfsCalendar> entities) {
-    return GtfsCalendarTableContainer.forEntities(entities, noticeContainer);
-  }
-
   @Test
   public void startDateBeforeEndDateShouldNotGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     CalendarServiceDateValidator underTest = new CalendarServiceDateValidator();
-    underTest.calendarTable =
-        createCalendarTable(
-            noticeContainer,
-            ImmutableList.of(
-                CalendarUtilTest.createGtfsCalendar(
-                    "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 10), weekDays)));
 
-    underTest.validate(noticeContainer);
+    underTest.validate(
+        CalendarUtilTest.createGtfsCalendar(
+            "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 10), weekDays),
+        noticeContainer);
     assertThat(noticeContainer.getValidationNotices().isEmpty());
   }
 
@@ -65,14 +53,11 @@ public class CalendarServiceDateValidatorTest {
   public void startDateAfterEndDateShouldGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     CalendarServiceDateValidator underTest = new CalendarServiceDateValidator();
-    underTest.calendarTable =
-        createCalendarTable(
-            noticeContainer,
-            ImmutableList.of(
-                CalendarUtilTest.createGtfsCalendar(
-                    "WEEK", LocalDate.of(2021, 1, 14), LocalDate.of(2021, 1, 10), weekDays)));
 
-    underTest.validate(noticeContainer);
+    underTest.validate(
+        CalendarUtilTest.createGtfsCalendar(
+            "WEEK", LocalDate.of(2021, 1, 14), LocalDate.of(2021, 1, 10), weekDays),
+        noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
         .containsExactly(
             new StartAndEndDateOutOfOrderNotice(
@@ -87,14 +72,11 @@ public class CalendarServiceDateValidatorTest {
   public void sameStartAndEndDateShouldNotGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     CalendarServiceDateValidator underTest = new CalendarServiceDateValidator();
-    underTest.calendarTable =
-        createCalendarTable(
-            noticeContainer,
-            ImmutableList.of(
-                CalendarUtilTest.createGtfsCalendar(
-                    "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 4), weekDays)));
 
-    underTest.validate(noticeContainer);
+    underTest.validate(
+        CalendarUtilTest.createGtfsCalendar(
+            "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 1, 4), weekDays),
+        noticeContainer);
     assertThat(noticeContainer.getValidationNotices().isEmpty());
   }
 }


### PR DESCRIPTION
**Summary:**

This PR provides changes to make CalendarServiceDateValidator extend `SingleFileValidator` instead of `FileValidator` class. 

**Expected behavior:** 

Unit tests have been adapted to this refactor, but no logic has changed. Therefore the same logic for existing tests should pass. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
