### PR TITLE
refactor: make StoptimeOutOfOrderTimesValidator extend SingleFileValidator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
@@ -22,7 +22,6 @@ import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StopTimeWithArrivalBeforePreviousDepartureTimeNotice;
-import org.mobilitydata.gtfsvalidator.notice.StopTimeWithDepartureBeforeArrivalTimeNotice;
 import org.mobilitydata.gtfsvalidator.notice.StopTimeWithOnlyArrivalOrDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
@@ -36,7 +35,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader;
  * <ul>
  *   <li>{@link StopTimeWithOnlyArrivalOrDepartureTimeNotice} - a single departure_time or
  *       arrival_time is defined for a row (both or none are expected)
- *   <li>{@link StopTimeWithDepartureBeforeArrivalTimeNotice} - departure_time &lt; arrival_time
  *   <li>{@link StopTimeWithArrivalBeforePreviousDepartureTimeNotice} - prev(arrival_time) &lt;
  *       curr(departure_time)
  * </ul>
@@ -62,17 +60,6 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
                   hasArrival
                       ? GtfsStopTimeTableLoader.ARRIVAL_TIME_FIELD_NAME
                       : GtfsStopTimeTableLoader.DEPARTURE_TIME_FIELD_NAME));
-        }
-        if (hasDeparture && hasArrival) {
-          if (stopTime.departureTime().isBefore(stopTime.arrivalTime())) {
-            noticeContainer.addValidationNotice(
-                new StopTimeWithDepartureBeforeArrivalTimeNotice(
-                    stopTime.csvRowNumber(),
-                    stopTime.tripId(),
-                    stopTime.stopSequence(),
-                    stopTime.departureTime(),
-                    stopTime.arrivalTime()));
-          }
         }
         if (hasArrival
             && previousDepartureRow != -1

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StoptimeOutOfOrderTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StoptimeOutOfOrderTimesValidator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopTimeWithDepartureBeforeArrivalTimeNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+
+/**
+ * Validates departure_time after arrival_time in "stop_times.txt".
+ *
+ * <p>Generated notices:
+ *
+ * <ul>
+ *   <li>{@link StopTimeWithDepartureBeforeArrivalTimeNotice} - departure_time &lt; arrival_time
+ * </ul>
+ */
+@GtfsValidator
+public class StoptimeOutOfOrderTimesValidator extends SingleEntityValidator<GtfsStopTime> {
+
+  @Override
+  public void validate(GtfsStopTime stopTime, NoticeContainer noticeContainer) {
+    if (stopTime.hasDepartureTime() && stopTime.hasArrivalTime()) {
+      if (stopTime.departureTime().isBefore(stopTime.arrivalTime())) {
+        noticeContainer.addValidationNotice(
+            new StopTimeWithDepartureBeforeArrivalTimeNotice(
+                stopTime.csvRowNumber(),
+                stopTime.tripId(),
+                stopTime.stopSequence(),
+                stopTime.departureTime(),
+                stopTime.arrivalTime()));
+      }
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidatorTest.java
@@ -67,55 +67,6 @@ public class StopTimeArrivalAndDepartureTimeValidatorTest {
   }
 
   @Test
-  public void departureTimeAfterArrivalTimeShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    0,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(340),
-                    GtfsTime.fromSecondsSinceMidnight(518),
-                    "stop id",
-                    2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
-  }
-
-  @Test
-  public void departureTimeBeforeArrivalTimeShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    1,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(518),
-                    GtfsTime.fromSecondsSinceMidnight(340),
-                    "stop id",
-                    2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(
-            new StopTimeWithDepartureBeforeArrivalTimeNotice(
-                1,
-                "first trip id",
-                2,
-                GtfsTime.fromSecondsSinceMidnight(340),
-                GtfsTime.fromSecondsSinceMidnight(518)));
-  }
-
-  @Test
   public void stopTimeWithArrivalBeforePreviousDepartureTimeShouldGenerateNotice() {
     NoticeContainer noticeContainer = new NoticeContainer();
     StopTimeArrivalAndDepartureTimeValidator underTest =

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StoptimeOutOfOrderTimesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StoptimeOutOfOrderTimesValidatorTest.java
@@ -1,0 +1,63 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.StopTimeWithDepartureBeforeArrivalTimeNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+public class StoptimeOutOfOrderTimesValidatorTest {
+
+  private static GtfsStopTime createStopTime(
+      long csvRowNumber,
+      GtfsTime arrivalTime,
+      GtfsTime departureTime) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId("first trip id")
+        .setArrivalTime(arrivalTime)
+        .setDepartureTime(departureTime)
+        .setStopSequence(2)
+        .setStopId("stop id")
+        .build();
+  }
+
+  @Test
+  public void departureTimeAfterArrivalTimeShouldNotGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    StoptimeOutOfOrderTimesValidator underTest = new StoptimeOutOfOrderTimesValidator();
+
+    underTest.validate(
+        createStopTime(
+            0,
+            GtfsTime.fromSecondsSinceMidnight(340),
+            GtfsTime.fromSecondsSinceMidnight(518)
+        ),
+        noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void departureTimeBeforeArrivalTimeShouldGenerateNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    StoptimeOutOfOrderTimesValidator underTest = new StoptimeOutOfOrderTimesValidator();
+
+    underTest.validate(
+        createStopTime(
+            1,
+            GtfsTime.fromSecondsSinceMidnight(518),
+            GtfsTime.fromSecondsSinceMidnight(340)
+        ),
+        noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new StopTimeWithDepartureBeforeArrivalTimeNotice(
+                1,
+                "first trip id",
+                2,
+                GtfsTime.fromSecondsSinceMidnight(340),
+                GtfsTime.fromSecondsSinceMidnight(518)));
+  }
+}


### PR DESCRIPTION
**Summary:**

This PR provides changes to extract the rule that checks the order of times in `stop_times.txt` as a new rule that extends `SingleFileValidator`  class. 

**Expected behavior:** 

Unit tests have been adapted to this refactor, but no logic has changed. Therefore the same logic for existing tests should pass. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
