### PR TITLE
feat: Switch all validators to injectable constructors

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -42,8 +42,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
  */
 @GtfsValidator
 public class AgencyConsistencyValidator extends FileValidator {
+  @Inject
+  AgencyConsistencyValidator(GtfsAgencyTableContainer agencyTable) {
+    this.agencyTable = agencyTable;
+  }
 
-  @Inject GtfsAgencyTableContainer agencyTable;
+  private final GtfsAgencyTableContainer agencyTable;
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -42,12 +42,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
  */
 @GtfsValidator
 public class AgencyConsistencyValidator extends FileValidator {
+  private final GtfsAgencyTableContainer agencyTable;
+
   @Inject
   AgencyConsistencyValidator(GtfsAgencyTableContainer agencyTable) {
     this.agencyTable = agencyTable;
   }
-
-  private final GtfsAgencyTableContainer agencyTable;
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -32,10 +32,22 @@ import org.mobilitydata.gtfsvalidator.util.ServiceIdIntersectionCache;
  */
 @GtfsValidator
 public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
-  @Inject GtfsTripTableContainer tripTable;
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
-  @Inject GtfsCalendarTableContainer calendarTable;
-  @Inject GtfsCalendarDateTableContainer calendarDateTable;
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsStopTimeTableContainer stopTimeTable;
+  private final GtfsCalendarTableContainer calendarTable;
+  private final GtfsCalendarDateTableContainer calendarDateTable;
+
+  @Inject
+  BlockTripsWithOverlappingStopTimesValidator(
+      GtfsTripTableContainer tripTable,
+      GtfsStopTimeTableContainer stopTimeTable,
+      GtfsCalendarTableContainer calendarTable,
+      GtfsCalendarDateTableContainer calendarDateTable) {
+    this.tripTable = tripTable;
+    this.stopTimeTable = stopTimeTable;
+    this.calendarTable = calendarTable;
+    this.calendarDateTable = calendarDateTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
@@ -38,7 +38,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
  */
 @GtfsValidator
 public class DuplicateFareRuleZoneIdFieldsValidator extends FileValidator {
-  @Inject GtfsFareRuleTableContainer fareRuleTable;
+  private final GtfsFareRuleTableContainer fareRuleTable;
+
+  @Inject
+  DuplicateFareRuleZoneIdFieldsValidator(GtfsFareRuleTableContainer fareRuleTable) {
+    this.fareRuleTable = fareRuleTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -41,7 +41,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
  */
 @GtfsValidator
 public class DuplicateRouteNameValidator extends FileValidator {
-  @Inject GtfsRouteTableContainer routeTable;
+  private final GtfsRouteTableContainer routeTable;
+
+  @Inject
+  DuplicateRouteNameValidator(GtfsRouteTableContainer routeTable) {
+    this.routeTable = routeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -37,8 +37,12 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
  */
 @GtfsValidator
 public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedInfo> {
+  private final ValidationContext context;
 
-  @Inject ValidationContext context;
+  @Inject
+  FeedExpirationDateValidator(ValidationContext context) {
+    this.context = context;
+  }
 
   @Override
   public void validate(GtfsFeedInfo entity, NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -32,7 +32,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
 @GtfsValidator
 public class FeedServiceDateValidator extends FileValidator {
 
-  @Inject GtfsFeedInfoTableContainer feedInfoTable;
+  private final GtfsFeedInfoTableContainer feedInfoTable;
+
+  @Inject
+  FeedServiceDateValidator(GtfsFeedInfoTableContainer feedInfoTable) {
+    this.feedInfoTable = feedInfoTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsTripServiceIdForeignKeyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsTripServiceIdForeignKeyValidator.java
@@ -36,9 +36,19 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableLoader;
  */
 @GtfsValidator
 public class GtfsTripServiceIdForeignKeyValidator extends FileValidator {
-  @Inject GtfsTripTableContainer tripContainer;
-  @Inject GtfsCalendarTableContainer calendarContainer;
-  @Inject GtfsCalendarDateTableContainer calendarDateContainer;
+  private final GtfsTripTableContainer tripContainer;
+  private final GtfsCalendarTableContainer calendarContainer;
+  private final GtfsCalendarDateTableContainer calendarDateContainer;
+
+  @Inject
+  GtfsTripServiceIdForeignKeyValidator(
+      GtfsTripTableContainer tripContainer,
+      GtfsCalendarTableContainer calendarContainer,
+      GtfsCalendarDateTableContainer calendarDateContainer) {
+    this.tripContainer = tripContainer;
+    this.calendarContainer = calendarContainer;
+    this.calendarDateContainer = calendarDateContainer;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
@@ -49,8 +49,15 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
 @GtfsValidator
 public class MatchingFeedAndAgencyLangValidator extends FileValidator {
 
-  @Inject GtfsFeedInfoTableContainer feedInfoTable;
-  @Inject GtfsAgencyTableContainer agencyTable;
+  private final GtfsFeedInfoTableContainer feedInfoTable;
+  private final GtfsAgencyTableContainer agencyTable;
+
+  @Inject
+  MatchingFeedAndAgencyLangValidator(
+      GtfsAgencyTableContainer agencyTable, GtfsFeedInfoTableContainer feedInfoTable) {
+    this.feedInfoTable = feedInfoTable;
+    this.agencyTable = agencyTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidator.java
@@ -35,8 +35,16 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
  */
 @GtfsValidator
 public class MissingCalendarAndCalendarDateValidator extends FileValidator {
-  @Inject GtfsCalendarTableContainer calendarTable;
-  @Inject GtfsCalendarDateTableContainer calendarDateTable;
+  private final GtfsCalendarTableContainer calendarTable;
+
+  private final GtfsCalendarDateTableContainer calendarDateTable;
+
+  @Inject
+  MissingCalendarAndCalendarDateValidator(
+      GtfsCalendarTableContainer calendarTable, GtfsCalendarDateTableContainer calendarDateTable) {
+    this.calendarTable = calendarTable;
+    this.calendarDateTable = calendarDateTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -37,7 +37,13 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
  */
 @GtfsValidator
 public class MissingTripEdgeValidator extends FileValidator {
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
+
+  private final GtfsStopTimeTableContainer stopTimeTable;
+
+  @Inject
+  MissingTripEdgeValidator(GtfsStopTimeTableContainer stopTimeTable) {
+    this.stopTimeTable = stopTimeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
@@ -25,7 +25,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFrequencyTableContainer;
  */
 @GtfsValidator
 public class OverlappingFrequencyValidator extends FileValidator {
-  @Inject GtfsFrequencyTableContainer table;
+  private final GtfsFrequencyTableContainer table;
+
+  @Inject
+  OverlappingFrequencyValidator(GtfsFrequencyTableContainer table) {
+    this.table = table;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -31,7 +31,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
  */
 @GtfsValidator
 public class ParentLocationTypeValidator extends FileValidator {
-  @Inject GtfsStopTableContainer stopTable;
+  private final GtfsStopTableContainer stopTable;
+
+  @Inject
+  ParentLocationTypeValidator(GtfsStopTableContainer stopTable) {
+    this.stopTable = stopTable;
+  }
 
   private GtfsLocationType expectedParentLocationType(GtfsLocationType locationType) {
     switch (locationType) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -32,7 +32,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
  */
 @GtfsValidator
 public class ShapeIncreasingDistanceValidator extends FileValidator {
-  @Inject GtfsShapeTableContainer table;
+  private final GtfsShapeTableContainer table;
+
+  @Inject
+  ShapeIncreasingDistanceValidator(GtfsShapeTableContainer table) {
+    this.table = table;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeUsageValidator.java
@@ -33,9 +33,14 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
  */
 @GtfsValidator
 public class ShapeUsageValidator extends FileValidator {
-  @Inject GtfsTripTableContainer tripTable;
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsShapeTableContainer shapeTable;
 
-  @Inject GtfsShapeTableContainer shapeTable;
+  @Inject
+  ShapeUsageValidator(GtfsTripTableContainer tripTable, GtfsShapeTableContainer shapeTable) {
+    this.tripTable = tripTable;
+    this.shapeTable = shapeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
@@ -41,7 +41,12 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader;
  */
 @GtfsValidator
 public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
-  @Inject GtfsStopTimeTableContainer table;
+  private final GtfsStopTimeTableContainer table;
+
+  @Inject
+  StopTimeArrivalAndDepartureTimeValidator(GtfsStopTimeTableContainer table) {
+    this.table = table;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -33,7 +33,13 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
  */
 @GtfsValidator
 public class StopTimeIncreasingDistanceValidator extends FileValidator {
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
+
+  private final GtfsStopTimeTableContainer stopTimeTable;
+
+  @Inject
+  StopTimeIncreasingDistanceValidator(GtfsStopTimeTableContainer stopTimeTable) {
+    this.stopTimeTable = stopTimeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
@@ -91,10 +91,22 @@ public class StopTooFarFromTripShapeValidator extends FileValidator {
           * TRIP_BUFFER_METERS
           * GeospatialUtil.METER_TO_KILOMETER_CONVERSION_FACTOR;
 
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
-  @Inject GtfsTripTableContainer tripTable;
-  @Inject GtfsShapeTableContainer shapeTable;
-  @Inject GtfsStopTableContainer stopTable;
+  private final GtfsStopTimeTableContainer stopTimeTable;
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsShapeTableContainer shapeTable;
+  private final GtfsStopTableContainer stopTable;
+
+  @Inject
+  StopTooFarFromTripShapeValidator(
+      GtfsStopTimeTableContainer stopTimeTable,
+      GtfsTripTableContainer tripTable,
+      GtfsShapeTableContainer shapeTable,
+      GtfsStopTableContainer stopTable) {
+    this.stopTimeTable = stopTimeTable;
+    this.tripTable = tripTable;
+    this.shapeTable = shapeTable;
+    this.stopTable = stopTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TooFastTravelValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TooFastTravelValidator.java
@@ -47,9 +47,20 @@ public class TooFastTravelValidator extends FileValidator {
 
   private static final double METER_PER_SECOND_TO_KMH_CONVERSION_FACTOR = 3.6d;
   private static final int MAX_SPEED_METERS_PER_HOUR = 42; // 150 km/h or 93.2 mph
-  @Inject GtfsTripTableContainer tripTable;
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
-  @Inject GtfsStopTableContainer stopTable;
+
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsStopTimeTableContainer stopTimeTable;
+  private final GtfsStopTableContainer stopTable;
+
+  @Inject
+  TooFastTravelValidator(
+      GtfsTripTableContainer tripTable,
+      GtfsStopTimeTableContainer stopTimeTable,
+      GtfsStopTableContainer stopTable) {
+    this.tripTable = tripTable;
+    this.stopTimeTable = stopTimeTable;
+    this.stopTable = stopTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
@@ -33,9 +33,14 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableLoader;
  */
 @GtfsValidator
 public class TripAgencyIdValidator extends FileValidator {
-  @Inject GtfsAgencyTableContainer agencyTable;
+  private final GtfsAgencyTableContainer agencyTable;
+  private final GtfsRouteTableContainer routeTable;
 
-  @Inject GtfsRouteTableContainer routeTable;
+  @Inject
+  TripAgencyIdValidator(GtfsAgencyTableContainer agencyTable, GtfsRouteTableContainer routeTable) {
+    this.agencyTable = agencyTable;
+    this.routeTable = routeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
@@ -31,8 +31,15 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
  */
 @GtfsValidator
 public class TripUsabilityValidator extends FileValidator {
-  @Inject GtfsTripTableContainer tripTable;
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsStopTimeTableContainer stopTimeTable;
+
+  @Inject
+  TripUsabilityValidator(
+      GtfsTripTableContainer tripTable, GtfsStopTimeTableContainer stopTimeTable) {
+    this.tripTable = tripTable;
+    this.stopTimeTable = stopTimeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -34,8 +34,14 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
  */
 @GtfsValidator
 public class TripUsageValidator extends FileValidator {
-  @Inject GtfsTripTableContainer tripTable;
-  @Inject GtfsStopTimeTableContainer stopTimeTable;
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsStopTimeTableContainer stopTimeTable;
+
+  @Inject
+  TripUsageValidator(GtfsTripTableContainer tripTable, GtfsStopTimeTableContainer stopTimeTable) {
+    this.tripTable = tripTable;
+    this.stopTimeTable = stopTimeTable;
+  }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidatorTest.java
@@ -8,17 +8,20 @@ import com.google.common.collect.ImmutableSet;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.BlockTripsWithOverlappingStopTimesNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -28,7 +31,7 @@ import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
 @RunWith(JUnit4.class)
 public class BlockTripsWithOverlappingStopTimesValidatorTest {
 
-  private static GtfsCalendarTableContainer createCalendarTable(NoticeContainer noticeContainer) {
+  private static List<GtfsCalendar> createCalendarTable() {
     final Set<DayOfWeek> weekDays =
         ImmutableSet.of(
             DayOfWeek.MONDAY,
@@ -36,23 +39,21 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
             DayOfWeek.WEDNESDAY,
             DayOfWeek.THURSDAY,
             DayOfWeek.FRIDAY);
-    return GtfsCalendarTableContainer.forEntities(
-        ImmutableList.of(
-            CalendarUtilTest.createGtfsCalendar(
-                "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4), weekDays),
-            CalendarUtilTest.createGtfsCalendar(
-                "WEEK-ALT", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4), weekDays),
-            CalendarUtilTest.createGtfsCalendar(
-                "SAT",
-                LocalDate.of(2021, 1, 4),
-                LocalDate.of(2021, 4, 4),
-                ImmutableSet.of(DayOfWeek.SATURDAY)),
-            CalendarUtilTest.createGtfsCalendar(
-                "SUN",
-                LocalDate.of(2021, 1, 4),
-                LocalDate.of(2021, 4, 4),
-                ImmutableSet.of(DayOfWeek.SUNDAY))),
-        noticeContainer);
+    return ImmutableList.of(
+        CalendarUtilTest.createGtfsCalendar(
+            "WEEK", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4), weekDays),
+        CalendarUtilTest.createGtfsCalendar(
+            "WEEK-ALT", LocalDate.of(2021, 1, 4), LocalDate.of(2021, 4, 4), weekDays),
+        CalendarUtilTest.createGtfsCalendar(
+            "SAT",
+            LocalDate.of(2021, 1, 4),
+            LocalDate.of(2021, 4, 4),
+            ImmutableSet.of(DayOfWeek.SATURDAY)),
+        CalendarUtilTest.createGtfsCalendar(
+            "SUN",
+            LocalDate.of(2021, 1, 4),
+            LocalDate.of(2021, 4, 4),
+            ImmutableSet.of(DayOfWeek.SUNDAY)));
   }
 
   public static GtfsStopTime createStopTime(
@@ -77,8 +78,8 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
         .build();
   }
 
-  private static GtfsTripTableContainer createTripTable(
-      String[] tripIds, String[] serviceIds, String blockId, NoticeContainer noticeContainer) {
+  private static List<GtfsTrip> createTripTable(
+      String[] tripIds, String[] serviceIds, String blockId) {
     Preconditions.checkArgument(
         tripIds.length == serviceIds.length, "tripIds.length must be equal to serviceIds.length");
 
@@ -88,11 +89,11 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
       trips.add(createTrip(trips.size() + 1, tripIds[i], serviceIds[i], blockId));
     }
 
-    return GtfsTripTableContainer.forEntities(trips, noticeContainer);
+    return trips;
   }
 
-  private static GtfsStopTimeTableContainer createStopTimeTable(
-      String[] tripIds, String[] stopIds, String[][] times, NoticeContainer noticeContainer) {
+  private static List<GtfsStopTime> createStopTimeTable(
+      String[] tripIds, String[] stopIds, String[][] times) {
     Preconditions.checkArgument(
         tripIds.length == times.length, "tripIds.length must be equal to times.length");
 
@@ -106,68 +107,64 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
       }
     }
 
-    return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+    return stopTimes;
+  }
+
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsCalendar> calendars,
+      List<GtfsCalendarDate> calendarDates,
+      List<GtfsTrip> trips,
+      List<GtfsStopTime> stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new BlockTripsWithOverlappingStopTimesValidator(
+            GtfsTripTableContainer.forEntities(trips, noticeContainer),
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer),
+            GtfsCalendarTableContainer.forEntities(calendars, noticeContainer),
+            GtfsCalendarDateTableContainer.forEntities(calendarDates, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
   }
 
   @Test
   public void goodFeed() {
-    final NoticeContainer noticeContainer = new NoticeContainer();
-
-    BlockTripsWithOverlappingStopTimesValidator validator =
-        new BlockTripsWithOverlappingStopTimesValidator();
-    validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
-    validator.tripTable =
-        createTripTable(
-            new String[] {"t0", "t1", "t2", "t3", "t4", "t5"},
-            new String[] {"WEEK", "WEEK", "WEEK", "SAT", "SAT", "SAT"},
-            "b1",
-            noticeContainer);
-    validator.stopTimeTable =
-        createStopTimeTable(
-            new String[] {"t0", "t1", "t2", "t3", "t4", "t5"},
-            new String[] {"s0", "s1"},
-            new String[][] {
-              new String[] {"08:00:00", "09:00:00"},
-              new String[] {"10:00:00", "11:00:00"},
-              new String[] {"12:00:00", "13:00:00"},
-              new String[] {"08:00:00", "09:00:00"},
-              new String[] {"10:00:00", "11:00:00"},
-              new String[] {"12:00:00", "13:00:00"},
-            },
-            noticeContainer);
-
-    validator.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                createCalendarTable(),
+                ImmutableList.of(),
+                createTripTable(
+                    new String[] {"t0", "t1", "t2", "t3", "t4", "t5"},
+                    new String[] {"WEEK", "WEEK", "WEEK", "SAT", "SAT", "SAT"},
+                    "b1"),
+                createStopTimeTable(
+                    new String[] {"t0", "t1", "t2", "t3", "t4", "t5"},
+                    new String[] {"s0", "s1"},
+                    new String[][] {
+                      new String[] {"08:00:00", "09:00:00"},
+                      new String[] {"10:00:00", "11:00:00"},
+                      new String[] {"12:00:00", "13:00:00"},
+                      new String[] {"08:00:00", "09:00:00"},
+                      new String[] {"10:00:00", "11:00:00"},
+                      new String[] {"12:00:00", "13:00:00"},
+                    })))
+        .isEmpty();
   }
 
   @Test
   public void overlapWithSameServiceId() {
-    final NoticeContainer noticeContainer = new NoticeContainer();
-
-    BlockTripsWithOverlappingStopTimesValidator validator =
-        new BlockTripsWithOverlappingStopTimesValidator();
-    validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
-    validator.tripTable =
-        createTripTable(
-            new String[] {"t0", "t1", "t2"},
-            new String[] {"WEEK", "WEEK", "WEEK"},
-            "b1",
-            noticeContainer);
-    validator.stopTimeTable =
-        createStopTimeTable(
-            new String[] {"t0", "t1", "t2"},
-            new String[] {"s0", "s1"},
-            new String[][] {
-              new String[] {"08:00:00", "09:00:00"},
-              new String[] {"08:30:00", "09:30:00"},
-              new String[] {"12:00:00", "13:00:00"},
-            },
-            noticeContainer);
-
-    validator.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                createCalendarTable(),
+                ImmutableList.of(),
+                createTripTable(
+                    new String[] {"t0", "t1", "t2"}, new String[] {"WEEK", "WEEK", "WEEK"}, "b1"),
+                createStopTimeTable(
+                    new String[] {"t0", "t1", "t2"},
+                    new String[] {"s0", "s1"},
+                    new String[][] {
+                      new String[] {"08:00:00", "09:00:00"},
+                      new String[] {"08:30:00", "09:30:00"},
+                      new String[] {"12:00:00", "13:00:00"},
+                    })))
         .containsExactly(
             new BlockTripsWithOverlappingStopTimesNotice(
                 1, "t0", "WEEK", 2, "t1", "WEEK", "b1", GtfsDate.fromString("20210104")));
@@ -175,27 +172,18 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
 
   @Test
   public void overlapWithDifferentServiceId() {
-    final NoticeContainer noticeContainer = new NoticeContainer();
-
-    BlockTripsWithOverlappingStopTimesValidator validator =
-        new BlockTripsWithOverlappingStopTimesValidator();
-    validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
-    validator.tripTable =
-        createTripTable(
-            new String[] {"t0", "t1"}, new String[] {"WEEK", "WEEK-ALT"}, "b1", noticeContainer);
-    validator.stopTimeTable =
-        createStopTimeTable(
-            new String[] {"t0", "t1"},
-            new String[] {"s0", "s1"},
-            new String[][] {
-              new String[] {"08:00:00", "09:00:00"},
-              new String[] {"08:30:00", "09:30:00"},
-            },
-            noticeContainer);
-
-    validator.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                createCalendarTable(),
+                ImmutableList.of(),
+                createTripTable(new String[] {"t0", "t1"}, new String[] {"WEEK", "WEEK-ALT"}, "b1"),
+                createStopTimeTable(
+                    new String[] {"t0", "t1"},
+                    new String[] {"s0", "s1"},
+                    new String[][] {
+                      new String[] {"08:00:00", "09:00:00"},
+                      new String[] {"08:30:00", "09:30:00"},
+                    })))
         .containsExactly(
             new BlockTripsWithOverlappingStopTimesNotice(
                 1, "t0", "WEEK", 2, "t1", "WEEK-ALT", "b1", GtfsDate.fromString("20210104")));
@@ -205,24 +193,16 @@ public class BlockTripsWithOverlappingStopTimesValidatorTest {
   public void tripsWith0or1Stop() {
     // Trips with 0 or 1 stop are not useful to end users and should be
     // gracefully handled by this validator.
-    final NoticeContainer noticeContainer = new NoticeContainer();
-
-    BlockTripsWithOverlappingStopTimesValidator validator =
-        new BlockTripsWithOverlappingStopTimesValidator();
-    validator.calendarTable = createCalendarTable(noticeContainer);
-    validator.calendarDateTable = new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE);
-    validator.tripTable =
-        createTripTable(
-            new String[] {"t0", "t1"}, new String[] {"WEEK", "WEEK"}, "b1", noticeContainer);
-    // t0 has 1 stop (s0), t1 has no stops at all.
-    validator.stopTimeTable =
-        createStopTimeTable(
-            new String[] {"t0"},
-            new String[] {"s0"},
-            new String[][] {new String[] {"08:00:00"}},
-            noticeContainer);
-
-    validator.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                createCalendarTable(),
+                ImmutableList.of(),
+                createTripTable(new String[] {"t0", "t1"}, new String[] {"WEEK", "WEEK"}, "b1"),
+                // t0 has 1 stop (s0), t1 has no stops at all.
+                createStopTimeTable(
+                    new String[] {"t0"},
+                    new String[] {"s0"},
+                    new String[][] {new String[] {"08:00:00"}})))
+        .isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidatorTest.java
@@ -23,14 +23,11 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.DuplicateFareRuleZoneIdFieldsNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareRule;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
 
 public class DuplicateFareRuleZoneIdFieldsValidatorTest {
-  private static GtfsFareRuleTableContainer createFareRuleTable(
-      NoticeContainer noticeContainer, List<GtfsFareRule> entities) {
-    return GtfsFareRuleTableContainer.forEntities(entities, noticeContainer);
-  }
 
   public static GtfsFareRule createFareRule(
       long csvRowNumber,
@@ -49,68 +46,56 @@ public class DuplicateFareRuleZoneIdFieldsValidatorTest {
         .build();
   }
 
+  private static List<ValidationNotice> generateNotices(List<GtfsFareRule> fareRules) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new DuplicateFareRuleZoneIdFieldsValidator(
+            GtfsFareRuleTableContainer.forEntities(fareRules, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void duplicateFareRuleZoneIdValuesShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
-    underTest.fareRuleTable =
-        createFareRuleTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFareRule(3, "fare id value", "route id value", "from id", "by id", "to id"),
-                createFareRule(
-                    99, "other fare id value", "route id value", "from id", "by id", "to id")));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFareRule(
+                        3, "fare id value", "route id value", "from id", "by id", "to id"),
+                    createFareRule(
+                        99, "other fare id value", "route id value", "from id", "by id", "to id"))))
         .containsExactly(
             new DuplicateFareRuleZoneIdFieldsNotice(99, "other fare id value", 3, "fare id value"));
   }
 
   @Test
   public void noDuplicateRowValueShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
-    underTest.fareRuleTable =
-        createFareRuleTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFareRule(3, "fare id value", "route id", "from id", "by id", "to id"),
-                createFareRule(
-                    99, "other fare id value", "route id", "other from id", "by id", "to id")));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFareRule(3, "fare id value", "route id", "from id", "by id", "to id"),
+                    createFareRule(
+                        99, "other fare id value", "route id", "other from id", "by id", "to id"))))
+        .isEmpty();
   }
 
   @Test
   public void noDuplicateRowWithEmptyValuesValueShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
-    underTest.fareRuleTable =
-        createFareRuleTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFareRule(3, "fare id value", "route id", null, "by id", "to id"),
-                createFareRule(
-                    99, "other fare id value", "route id", "other from id", null, "to id")));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFareRule(3, "fare id value", "route id", null, "by id", "to id"),
+                    createFareRule(
+                        99, "other fare id value", "route id", "other from id", null, "to id"))))
+        .isEmpty();
   }
 
   @Test
   public void duplicateFareRuleWithSomeEmptyValuesShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateFareRuleZoneIdFieldsValidator underTest = new DuplicateFareRuleZoneIdFieldsValidator();
-    underTest.fareRuleTable =
-        createFareRuleTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFareRule(3, "fare id value", "route id", null, "by id", "to id"),
-                createFareRule(99, "other fare id value", "route id", null, "by id", "to id")));
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFareRule(3, "fare id value", "route id", null, "by id", "to id"),
+                    createFareRule(99, "other fare id value", "route id", null, "by id", "to id"))))
         .containsExactly(
             new DuplicateFareRuleZoneIdFieldsNotice(99, "other fare id value", 3, "fare id value"));
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -7,15 +7,11 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.DuplicateRouteNameNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 
 public class DuplicateRouteNameValidatorTest {
-
-  private static GtfsRouteTableContainer createRouteTable(
-      NoticeContainer noticeContainer, List<GtfsRoute> entities) {
-    return GtfsRouteTableContainer.forEntities(entities, noticeContainer);
-  }
 
   private GtfsRoute createRoute(
       int csvRowNumber,
@@ -34,48 +30,59 @@ public class DuplicateRouteNameValidatorTest {
         .build();
   }
 
+  private static List<ValidationNotice> generateNotices(List<GtfsRoute> routes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new DuplicateRouteNameValidator(GtfsRouteTableContainer.forEntities(routes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void duplicateRouteLongNamesOfRoutesFromDifferentAgenciesShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(
-                    2, "1st route id value", "agency id", "short name", "duplicate value", 2),
-                createRoute(
-                    4,
-                    "2nd route id value",
-                    "other agency id",
-                    "other short name",
-                    "duplicate value",
-                    3),
-                createRoute(8, "3rd route id value", null, "another one", "duplicate value", 2),
-                createRoute(
-                    8, "4th route id value", "agenCY ID", "other sname", "duplicate value", 2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(
+                        2, "1st route id value", "agency id", "short name", "duplicate value", 2),
+                    createRoute(
+                        4,
+                        "2nd route id value",
+                        "other agency id",
+                        "other short name",
+                        "duplicate value",
+                        3),
+                    createRoute(8, "3rd route id value", null, "another one", "duplicate value", 2),
+                    createRoute(
+                        8,
+                        "4th route id value",
+                        "agenCY ID",
+                        "other sname",
+                        "duplicate value",
+                        2))))
+        .isEmpty();
   }
 
   @Test
   public void duplicateRouteLongNamesOfRoutesFromSameAgencyShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(
-                    2, "1st route id value", "agency id", "short name", "duplicate value", 2),
-                createRoute(
-                    4, "2nd route id value", "agency id", "other short name", "duplicate value", 2),
-                createRoute(
-                    8, "3rd route id value", "agency id", "another one", "duplicate value", 2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(
+                        2, "1st route id value", "agency id", "short name", "duplicate value", 2),
+                    createRoute(
+                        4,
+                        "2nd route id value",
+                        "agency id",
+                        "other short name",
+                        "duplicate value",
+                        2),
+                    createRoute(
+                        8,
+                        "3rd route id value",
+                        "agency id",
+                        "another one",
+                        "duplicate value",
+                        2))))
         .containsExactly(
             new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"),
             new DuplicateRouteNameNotice("route_long_name", 8, "3rd route id value"));
@@ -83,44 +90,54 @@ public class DuplicateRouteNameValidatorTest {
 
   @Test
   public void duplicateRouteShortNamesOfRoutesFromDifferentAgenciesShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(2, "1st route id value", null, "duplicate value", "1st long name", 2),
-                createRoute(
-                    4, "2nd route id value", "agency id", "duplicate value", "2nd long name", 3),
-                createRoute(
-                    8,
-                    "3rd route id value",
-                    "other agency id",
-                    "duplicate value",
-                    "3rd long name",
-                    3)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(
+                        2, "1st route id value", null, "duplicate value", "1st long name", 2),
+                    createRoute(
+                        4,
+                        "2nd route id value",
+                        "agency id",
+                        "duplicate value",
+                        "2nd long name",
+                        3),
+                    createRoute(
+                        8,
+                        "3rd route id value",
+                        "other agency id",
+                        "duplicate value",
+                        "3rd long name",
+                        3))))
+        .isEmpty();
   }
 
   @Test
   public void duplicateRouteShortNamesOfRoutesFromSameAgencyShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(
-                    2, "1st route id value", "agency id", "duplicate value", "1st long name", 2),
-                createRoute(
-                    4, "2nd route id value", "agency id", "duplicate value", "2nd long name", 2),
-                createRoute(
-                    8, "3rd route id value", "agency id", "duplicate value", "3rd long name", 2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(
+                        2,
+                        "1st route id value",
+                        "agency id",
+                        "duplicate value",
+                        "1st long name",
+                        2),
+                    createRoute(
+                        4,
+                        "2nd route id value",
+                        "agency id",
+                        "duplicate value",
+                        "2nd long name",
+                        2),
+                    createRoute(
+                        8,
+                        "3rd route id value",
+                        "agency id",
+                        "duplicate value",
+                        "3rd long name",
+                        2))))
         .containsExactly(
             new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
             new DuplicateRouteNameNotice("route_short_name", 8, "3rd route id value"));
@@ -128,59 +145,44 @@ public class DuplicateRouteNameValidatorTest {
 
   @Test
   public void uniqueRouteLongNameShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(2, "1st route id value", "agency id", null, "1st value", 2),
-                createRoute(5, "4th route id value", "agency id", null, "1st value", 3),
-                createRoute(4, "2nd route id value", "another agency id", null, "2nd value", 3),
-                createRoute(8, "3rd route id value", "another one", null, "3rd value", 3)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(2, "1st route id value", "agency id", null, "1st value", 2),
+                    createRoute(5, "4th route id value", "agency id", null, "1st value", 3),
+                    createRoute(4, "2nd route id value", "another agency id", null, "2nd value", 3),
+                    createRoute(8, "3rd route id value", "another one", null, "3rd value", 3))))
+        .isEmpty();
   }
 
   @Test
   public void uniqueRouteShortNameShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(2, "1st route id value", "agency id", "1st value", null, 2),
-                createRoute(5, "4th route id value", "agency id", "1st value", null, 3),
-                createRoute(4, "2nd route id value", "another agency id", "2nd value", null, 3),
-                createRoute(8, "3rd route id value", "another one", "3rd value", null, 3)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(2, "1st route id value", "agency id", "1st value", null, 2),
+                    createRoute(5, "4th route id value", "agency id", "1st value", null, 3),
+                    createRoute(4, "2nd route id value", "another agency id", "2nd value", null, 3),
+                    createRoute(8, "3rd route id value", "another one", "3rd value", null, 3))))
+        .isEmpty();
   }
 
   @Test
   public void duplicateRouteNamesCombinationShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    DuplicateRouteNameValidator underTest = new DuplicateRouteNameValidator();
-    underTest.routeTable =
-        createRouteTable(
-            noticeContainer,
-            ImmutableList.of(
-                createRoute(2, "1st route id value", "agency id", "short name", "long name", 2),
-                createRoute(5, "4th route id value", "agency id", "short name", "long value", 3),
-                createRoute(4, "2nd route id value", "agency id", "short name", "long name", 2),
-                createRoute(
-                    8,
-                    "3rd route id value",
-                    "agency id",
-                    "other short value",
-                    "other long name",
-                    3)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createRoute(2, "1st route id value", "agency id", "short name", "long name", 2),
+                    createRoute(
+                        5, "4th route id value", "agency id", "short name", "long value", 3),
+                    createRoute(4, "2nd route id value", "agency id", "short name", "long name", 2),
+                    createRoute(
+                        8,
+                        "3rd route id value",
+                        "agency id",
+                        "other short value",
+                        "other long name",
+                        3))))
         .containsExactly(
             new DuplicateRouteNameNotice(
                 "route_short_name and route_long_name", 4, "2nd route id value"));

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -40,9 +40,7 @@ public class FeedExpirationDateValidatorTest {
 
   private List<ValidationNotice> validateFeedInfo(GtfsFeedInfo feedInfo) {
     NoticeContainer container = new NoticeContainer();
-    FeedExpirationDateValidator validator = new FeedExpirationDateValidator();
-    validator.context = VALIDATION_CONTEXT;
-    validator.validate(feedInfo, container);
+    new FeedExpirationDateValidator(VALIDATION_CONTEXT).validate(feedInfo, container);
     return container.getValidationNotices();
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidatorTest.java
@@ -8,15 +8,18 @@ import java.util.Locale;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.MissingFeedInfoDateNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 
 public class FeedServiceDateValidatorTest {
 
-  private static GtfsFeedInfoTableContainer createFeedInfoTable(
-      NoticeContainer noticeContainer, List<GtfsFeedInfo> entities) {
-    return GtfsFeedInfoTableContainer.forEntities(entities, noticeContainer);
+  private static List<ValidationNotice> generateNotices(List<GtfsFeedInfo> feedInfos) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new FeedServiceDateValidator(GtfsFeedInfoTableContainer.forEntities(feedInfos, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
   }
 
   public static GtfsFeedInfo createFeedInfo(
@@ -42,86 +45,61 @@ public class FeedServiceDateValidatorTest {
 
   @Test
   public void noStartDateShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsFeedInfoTableContainer gtfsFeedInfoTable =
-        createFeedInfoTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFeedInfo(
-                    1,
-                    "name value",
-                    "url value",
-                    Locale.CANADA,
-                    null,
-                    GtfsDate.fromEpochDay(450))));
-
-    FeedServiceDateValidator underTest = new FeedServiceDateValidator();
-    underTest.feedInfoTable = gtfsFeedInfoTable;
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFeedInfo(
+                        1,
+                        "name value",
+                        "url value",
+                        Locale.CANADA,
+                        null,
+                        GtfsDate.fromEpochDay(450)))))
         .containsExactly(new MissingFeedInfoDateNotice(1, "feed_start_date"));
   }
 
   @Test
   public void noEndDateShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsFeedInfoTableContainer gtfsFeedInfoTable =
-        createFeedInfoTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFeedInfo(
-                    1,
-                    "name value",
-                    "url value",
-                    Locale.CANADA,
-                    GtfsDate.fromEpochDay(450),
-                    null)));
-
-    FeedServiceDateValidator underTest = new FeedServiceDateValidator();
-    underTest.feedInfoTable = gtfsFeedInfoTable;
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFeedInfo(
+                        1,
+                        "name value",
+                        "url value",
+                        Locale.CANADA,
+                        GtfsDate.fromEpochDay(450),
+                        null))))
         .containsExactly(new MissingFeedInfoDateNotice(1, "feed_end_date"));
   }
 
   @Test
   public void bothDatesCanBeBlank() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsFeedInfoTableContainer gtfsFeedInfoTable =
-        createFeedInfoTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFeedInfo(
-                    1, "name value", "https://www.mobilitydata.org", Locale.CANADA, null, null)));
-
-    FeedServiceDateValidator underTest = new FeedServiceDateValidator();
-    underTest.feedInfoTable = gtfsFeedInfoTable;
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices().isEmpty());
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFeedInfo(
+                        1,
+                        "name value",
+                        "https://www.mobilitydata.org",
+                        Locale.CANADA,
+                        null,
+                        null))))
+        .isEmpty();
   }
 
   @Test
   public void bothDatesCanBeProvided() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsFeedInfoTableContainer gtfsFeedInfoTable =
-        createFeedInfoTable(
-            noticeContainer,
-            ImmutableList.of(
-                createFeedInfo(
-                    1,
-                    "name value",
-                    "https://www.mobilitydata.org",
-                    Locale.CANADA,
-                    GtfsDate.fromEpochDay(450),
-                    GtfsDate.fromEpochDay(555))));
-
-    FeedServiceDateValidator underTest = new FeedServiceDateValidator();
-    underTest.feedInfoTable = gtfsFeedInfoTable;
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices().isEmpty());
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createFeedInfo(
+                        1,
+                        "name value",
+                        "https://www.mobilitydata.org",
+                        Locale.CANADA,
+                        GtfsDate.fromEpochDay(450),
+                        GtfsDate.fromEpochDay(555)))))
+        .isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
@@ -23,10 +23,10 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.MissingTripEdgeNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
-import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 
 public class MissingTripEdgeValidatorTest {
@@ -55,134 +55,104 @@ public class MissingTripEdgeValidatorTest {
         .build();
   }
 
-  private static GtfsTripTableContainer createTripTable(
-      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
-    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
-  }
-
-  private static GtfsStopTimeTableContainer createStopTimeTable(
-      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
-    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
+  private static List<ValidationNotice> generateNotices(List<GtfsStopTime> stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new MissingTripEdgeValidator(GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
   }
 
   @Test
   public void tripWithFirstStopMissingArrivalTimeShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(2, "trip id value", null, GtfsTime.fromSecondsSinceMidnight(23), 1),
-                createStopTime(4, "trip id value", null, null, 2),
-                createStopTime(5, "trip id value", null, null, 3),
-                createStopTime(
-                    3,
-                    "trip id value",
-                    GtfsTime.fromSecondsSinceMidnight(28),
-                    GtfsTime.fromSecondsSinceMidnight(35),
-                    4)));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        2, "trip id value", null, GtfsTime.fromSecondsSinceMidnight(23), 1),
+                    createStopTime(4, "trip id value", null, null, 2),
+                    createStopTime(5, "trip id value", null, null, 3),
+                    createStopTime(
+                        3,
+                        "trip id value",
+                        GtfsTime.fromSecondsSinceMidnight(28),
+                        GtfsTime.fromSecondsSinceMidnight(35),
+                        4))))
         .containsExactly(new MissingTripEdgeNotice(2, 1, "trip id value", "arrival_time"));
   }
 
   @Test
   public void tripWithFirstStopMissingDepartureTimeShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(2, "trip id value", GtfsTime.fromSecondsSinceMidnight(23), null, 1),
-                createStopTime(4, "trip id value", null, null, 2),
-                createStopTime(5, "trip id value", null, null, 3),
-                createStopTime(
-                    3,
-                    "trip id value",
-                    GtfsTime.fromSecondsSinceMidnight(28),
-                    GtfsTime.fromSecondsSinceMidnight(35),
-                    5)));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        2, "trip id value", GtfsTime.fromSecondsSinceMidnight(23), null, 1),
+                    createStopTime(4, "trip id value", null, null, 2),
+                    createStopTime(5, "trip id value", null, null, 3),
+                    createStopTime(
+                        3,
+                        "trip id value",
+                        GtfsTime.fromSecondsSinceMidnight(28),
+                        GtfsTime.fromSecondsSinceMidnight(35),
+                        5))))
         .containsExactly(new MissingTripEdgeNotice(2, 1, "trip id value", "departure_time"));
   }
 
   @Test
   public void tripWithLastStopMissingArrivalTimeShouldGenerateNotices() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    2,
-                    "trip id value",
-                    GtfsTime.fromSecondsSinceMidnight(23),
-                    GtfsTime.fromSecondsSinceMidnight(46),
-                    1),
-                createStopTime(4, "trip id value", null, null, 2),
-                createStopTime(5, "trip id value", null, null, 3),
-                createStopTime(
-                    10, "trip id value", null, GtfsTime.fromSecondsSinceMidnight(456), 5)));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        2,
+                        "trip id value",
+                        GtfsTime.fromSecondsSinceMidnight(23),
+                        GtfsTime.fromSecondsSinceMidnight(46),
+                        1),
+                    createStopTime(4, "trip id value", null, null, 2),
+                    createStopTime(5, "trip id value", null, null, 3),
+                    createStopTime(
+                        10, "trip id value", null, GtfsTime.fromSecondsSinceMidnight(456), 5))))
         .containsExactly(new MissingTripEdgeNotice(10, 5, "trip id value", "arrival_time"));
   }
 
   @Test
   public void tripWithLastStopMissingDepartureTimeShouldGenerateNotices() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    2,
-                    "trip id value",
-                    GtfsTime.fromSecondsSinceMidnight(23),
-                    GtfsTime.fromSecondsSinceMidnight(46),
-                    1),
-                createStopTime(4, "trip id value", null, null, 2),
-                createStopTime(5, "trip id value", null, null, 3),
-                createStopTime(
-                    10, "trip id value", GtfsTime.fromSecondsSinceMidnight(456), null, 5)));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        2,
+                        "trip id value",
+                        GtfsTime.fromSecondsSinceMidnight(23),
+                        GtfsTime.fromSecondsSinceMidnight(46),
+                        1),
+                    createStopTime(4, "trip id value", null, null, 2),
+                    createStopTime(5, "trip id value", null, null, 3),
+                    createStopTime(
+                        10, "trip id value", GtfsTime.fromSecondsSinceMidnight(456), null, 5))))
         .containsExactly(new MissingTripEdgeNotice(10, 5, "trip id value", "departure_time"));
   }
 
   @Test
   public void tripWithValidEdgesShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    MissingTripEdgeValidator underTest = new MissingTripEdgeValidator();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    2,
-                    "trip id value",
-                    GtfsTime.fromSecondsSinceMidnight(23),
-                    GtfsTime.fromSecondsSinceMidnight(46),
-                    1),
-                createStopTime(4, "trip id value", null, null, 2),
-                createStopTime(5, "trip id value", null, null, 3),
-                createStopTime(
-                    10,
-                    "trip id value",
-                    GtfsTime.fromSecondsSinceMidnight(456),
-                    GtfsTime.fromSecondsSinceMidnight(3556467),
-                    4)));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        2,
+                        "trip id value",
+                        GtfsTime.fromSecondsSinceMidnight(23),
+                        GtfsTime.fromSecondsSinceMidnight(46),
+                        1),
+                    createStopTime(4, "trip id value", null, null, 2),
+                    createStopTime(5, "trip id value", null, null, 3),
+                    createStopTime(
+                        10,
+                        "trip id value",
+                        GtfsTime.fromSecondsSinceMidnight(456),
+                        GtfsTime.fromSecondsSinceMidnight(3556467),
+                        4))))
+        .isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidatorTest.java
@@ -27,19 +27,18 @@ public class OverlappingFrequencyValidatorTest {
         .build();
   }
 
-  private List<ValidationNotice> validateFrequencies(GtfsFrequency... frequencies) {
+  private List<ValidationNotice> generateNotices(GtfsFrequency... frequencies) {
     NoticeContainer noticeContainer = new NoticeContainer();
-    OverlappingFrequencyValidator validator = new OverlappingFrequencyValidator();
-    validator.table =
-        GtfsFrequencyTableContainer.forEntities(Arrays.asList(frequencies), noticeContainer);
-    validator.validate(noticeContainer);
+    new OverlappingFrequencyValidator(
+            GtfsFrequencyTableContainer.forEntities(Arrays.asList(frequencies), noticeContainer))
+        .validate(noticeContainer);
     return noticeContainer.getValidationNotices();
   }
 
   @Test
   public void validSequentialInOrder() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "07:00:00", "10:00:00", 300)))
         .isEmpty();
@@ -48,7 +47,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void validSequentialReversed() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "07:00:00", "10:00:00", 300),
                 createFrequency(3, "t0", "05:00:00", "07:00:00", 600)))
         .isEmpty();
@@ -57,7 +56,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void validWithGap() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "08:00:00", "10:00:00", 300)))
         .isEmpty();
@@ -66,7 +65,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void validDifferentTrips() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t1", "06:00:00", "10:00:00", 300)))
         .isEmpty();
@@ -75,7 +74,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void overlappingPartially() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "06:00:00", "10:00:00", 300)))
         .containsExactly(
@@ -86,7 +85,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void overlappingIncludedSameStart() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "05:00:00", "06:30:00", 300)))
         .containsExactly(
@@ -97,7 +96,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void overlappingIncludedSameEnd() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "07:00:00", 600),
                 createFrequency(3, "t0", "06:30:00", "07:00:00", 300)))
         .containsExactly(
@@ -108,7 +107,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void overlappingIncluded() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "07:00:00", "12:00:00", 600),
                 createFrequency(3, "t0", "08:00:00", "11:00:00", 300)))
         .containsExactly(
@@ -119,7 +118,7 @@ public class OverlappingFrequencyValidatorTest {
   @Test
   public void overlappingThreeIntervals() {
     assertThat(
-            validateFrequencies(
+            generateNotices(
                 createFrequency(2, "t0", "05:00:00", "05:25:00", 600),
                 createFrequency(3, "t0", "05:00:00", "05:15:00", 300),
                 createFrequency(4, "t0", "05:20:00", "05:40:00", 300)))

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
@@ -36,41 +36,39 @@ public class ParentLocationTypeValidatorTest {
   private List<ValidationNotice> validateChildAndParent(
       GtfsLocationType childType, GtfsLocationType parentType) {
     NoticeContainer noticeContainer = new NoticeContainer();
-    ParentLocationTypeValidator validator = new ParentLocationTypeValidator();
-    validator.stopTable =
-        GtfsStopTableContainer.forEntities(
-            ImmutableList.of(
-                new GtfsStop.Builder()
-                    .setCsvRowNumber(1)
-                    .setStopId("child")
-                    .setStopName("Child location")
-                    .setLocationType(childType.getNumber())
-                    .setParentStation("parent")
-                    .build(),
-                new GtfsStop.Builder()
-                    .setCsvRowNumber(2)
-                    .setStopId("parent")
-                    .setStopName("Parent location")
-                    .setLocationType(parentType.getNumber())
-                    .build()),
-            noticeContainer);
-    validator.validate(noticeContainer);
+    new ParentLocationTypeValidator(
+            GtfsStopTableContainer.forEntities(
+                ImmutableList.of(
+                    new GtfsStop.Builder()
+                        .setCsvRowNumber(1)
+                        .setStopId("child")
+                        .setStopName("Child location")
+                        .setLocationType(childType.getNumber())
+                        .setParentStation("parent")
+                        .build(),
+                    new GtfsStop.Builder()
+                        .setCsvRowNumber(2)
+                        .setStopId("parent")
+                        .setStopName("Parent location")
+                        .setLocationType(parentType.getNumber())
+                        .build()),
+                noticeContainer))
+        .validate(noticeContainer);
     return noticeContainer.getValidationNotices();
   }
 
   private List<ValidationNotice> validateNoParent(GtfsLocationType locationType) {
     NoticeContainer noticeContainer = new NoticeContainer();
-    ParentLocationTypeValidator validator = new ParentLocationTypeValidator();
-    validator.stopTable =
-        GtfsStopTableContainer.forEntities(
-            ImmutableList.of(
-                new GtfsStop.Builder()
-                    .setCsvRowNumber(1)
-                    .setStopId("child")
-                    .setLocationType(locationType.getNumber())
-                    .build()),
-            noticeContainer);
-    validator.validate(noticeContainer);
+    new ParentLocationTypeValidator(
+            GtfsStopTableContainer.forEntities(
+                ImmutableList.of(
+                    new GtfsStop.Builder()
+                        .setCsvRowNumber(1)
+                        .setStopId("child")
+                        .setLocationType(locationType.getNumber())
+                        .build()),
+                noticeContainer))
+        .validate(noticeContainer);
     return noticeContainer.getValidationNotices();
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidatorTest.java
@@ -23,15 +23,11 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.DecreasingOrEqualShapeDistanceNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsShape;
 import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
 
 public class ShapeIncreasingDistanceValidatorTest {
-  private static GtfsShapeTableContainer createShapeTable(
-      NoticeContainer noticeContainer, List<GtfsShape> entities) {
-    return GtfsShapeTableContainer.forEntities(entities, noticeContainer);
-  }
-
   public static GtfsShape createShapePoint(
       long csvRowNumber,
       String shapeId,
@@ -49,72 +45,57 @@ public class ShapeIncreasingDistanceValidatorTest {
         .build();
   }
 
+  private static List<ValidationNotice> generateNotices(List<GtfsShape> shapes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new ShapeIncreasingDistanceValidator(
+            GtfsShapeTableContainer.forEntities(shapes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void increasingDistanceAlongShapeShouldNotGenerateNotice() {
-    ShapeIncreasingDistanceValidator underTest = new ShapeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.table =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
-                createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
-                createShapePoint(3, "first shape", 29.0d, 46, 3, 64.0d)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices().isEmpty());
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
+                    createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
+                    createShapePoint(3, "first shape", 29.0d, 46, 3, 64.0d))))
+        .isEmpty();
   }
 
   @Test
   public void lastShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
-    ShapeIncreasingDistanceValidator underTest = new ShapeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.table =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
-                createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
-                createShapePoint(3, "first shape", 29.0d, 46, 3, 40.0)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
+                    createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
+                    createShapePoint(3, "first shape", 29.0d, 46, 3, 40.0))))
         .containsExactly(
             new DecreasingOrEqualShapeDistanceNotice("first shape", 3, 40.0d, 3, 2, 45.0d, 2));
   }
 
   @Test
   public void oneIntermediateShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
-    ShapeIncreasingDistanceValidator underTest = new ShapeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.table =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
-                createShapePoint(2, "first shape", 31.0d, 42, 2, 9.0d),
-                createShapePoint(3, "first shape", 45.0d, 46, 3, 40.0)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
+                    createShapePoint(2, "first shape", 31.0d, 42, 2, 9.0d),
+                    createShapePoint(3, "first shape", 45.0d, 46, 3, 40.0))))
         .containsExactly(
             new DecreasingOrEqualShapeDistanceNotice("first shape", 2, 9.0d, 2, 1, 10.0d, 1));
   }
 
   @Test
   public void shapeWithEqualDistanceAlongShapeShouldGenerateNotice() {
-    ShapeIncreasingDistanceValidator underTest = new ShapeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.table =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
-                createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
-                createShapePoint(3, "first shape", 29.0d, 46, 3, 45.0)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createShapePoint(1, "first shape", 30.0d, 45, 1, 10.0d),
+                    createShapePoint(2, "first shape", 31.0d, 42, 2, 45.0d),
+                    createShapePoint(3, "first shape", 29.0d, 46, 3, 45.0))))
         .containsExactly(
             new DecreasingOrEqualShapeDistanceNotice("first shape", 3, 45.0d, 3, 2, 45.0d, 2));
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidatorTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StopTimeWithArrivalBeforePreviousDepartureTimeNotice;
 import org.mobilitydata.gtfsvalidator.notice.StopTimeWithOnlyArrivalOrDepartureTimeNotice;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
@@ -51,46 +52,41 @@ public class StopTimeArrivalAndDepartureTimeValidatorTest {
     return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
   }
 
+  private static List<ValidationNotice> generateNotices(List<GtfsStopTime> stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new StopTimeArrivalAndDepartureTimeValidator(
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void departureTimeAndArrivalTimeNotProvidedShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(createStopTime(0, "first trip id", null, null, "stop id", 2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(createStopTime(0, "first trip id", null, null, "stop id", 2))))
+        .isEmpty();
   }
 
   @Test
   public void stopTimeWithArrivalBeforePreviousDepartureTimeShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    1,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(340), // arrival time
-                    GtfsTime.fromSecondsSinceMidnight(518), // departure time
-                    "stop id",
-                    2),
-                createStopTime(
-                    2,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(420), // arrival time
-                    GtfsTime.fromSecondsSinceMidnight(747), // departure time
-                    "stop id",
-                    3)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        1,
+                        "first trip id",
+                        GtfsTime.fromSecondsSinceMidnight(340), // arrival time
+                        GtfsTime.fromSecondsSinceMidnight(518), // departure time
+                        "stop id",
+                        2),
+                    createStopTime(
+                        2,
+                        "first trip id",
+                        GtfsTime.fromSecondsSinceMidnight(420), // arrival time
+                        GtfsTime.fromSecondsSinceMidnight(747), // departure time
+                        "stop id",
+                        3))))
         .containsExactly(
             new StopTimeWithArrivalBeforePreviousDepartureTimeNotice(
                 2,
@@ -102,51 +98,38 @@ public class StopTimeArrivalAndDepartureTimeValidatorTest {
 
   @Test
   public void stopTimeWithArrivalAfterPreviousDepartureTimeShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    1,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(340), // arrival time
-                    GtfsTime.fromSecondsSinceMidnight(420), // departure time
-                    "stop id",
-                    2),
-                createStopTime(
-                    2,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(518), // arrival time
-                    GtfsTime.fromSecondsSinceMidnight(747), // departure time
-                    "stop id",
-                    3)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        1,
+                        "first trip id",
+                        GtfsTime.fromSecondsSinceMidnight(340), // arrival time
+                        GtfsTime.fromSecondsSinceMidnight(420), // departure time
+                        "stop id",
+                        2),
+                    createStopTime(
+                        2,
+                        "first trip id",
+                        GtfsTime.fromSecondsSinceMidnight(518), // arrival time
+                        GtfsTime.fromSecondsSinceMidnight(747), // departure time
+                        "stop id",
+                        3))))
+        .isEmpty();
   }
 
   @Test
   public void missingArrivalTimeShouldGenerateNoticeIfDepartureTimeIsProvided() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    1,
-                    "first trip id",
-                    null,
-                    GtfsTime.fromSecondsSinceMidnight(518), // departure time
-                    "stop id",
-                    2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        1,
+                        "first trip id",
+                        null,
+                        GtfsTime.fromSecondsSinceMidnight(518), // departure time
+                        "stop id",
+                        2))))
         .containsExactly(
             new StopTimeWithOnlyArrivalOrDepartureTimeNotice(
                 1, "first trip id", 2, "departure_time"));
@@ -154,23 +137,16 @@ public class StopTimeArrivalAndDepartureTimeValidatorTest {
 
   @Test
   public void missingDepartureTimeShouldGenerateNoticeIfArrivalTimeIsProvided() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTimeArrivalAndDepartureTimeValidator underTest =
-        new StopTimeArrivalAndDepartureTimeValidator();
-    underTest.table =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    1,
-                    "first trip id",
-                    GtfsTime.fromSecondsSinceMidnight(518), // arrival time
-                    null,
-                    "stop id",
-                    2)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(
+                        1,
+                        "first trip id",
+                        GtfsTime.fromSecondsSinceMidnight(518), // arrival time
+                        null,
+                        "stop id",
+                        2))))
         .containsExactly(
             new StopTimeWithOnlyArrivalOrDepartureTimeNotice(
                 1, "first trip id", 2, "arrival_time"));

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
@@ -23,15 +23,11 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.DecreasingOrEqualStopTimeDistanceNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 
 public class StopTimeIncreasingDistanceValidatorTest {
-  private static GtfsStopTimeTableContainer createStopTimeTable(
-      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
-    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
-  }
-
   public static GtfsStopTime createStopTime(
       long csvRowNumber, String tripId, String stopId, int stopSequence, double shapeDistTraveled) {
     return new GtfsStopTime.Builder()
@@ -43,72 +39,57 @@ public class StopTimeIncreasingDistanceValidatorTest {
         .build();
   }
 
+  private static List<ValidationNotice> generateNotices(List<GtfsStopTime> stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new StopTimeIncreasingDistanceValidator(
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void increasingDistanceAlongShapeShouldNotGenerateNotice() {
-    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(1, "first trip", "s0", 2, 10.0d),
-                createStopTime(2, "first trip", "s1", 42, 45.0d),
-                createStopTime(3, "first trip", "s2", 46, 64.0d)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices().isEmpty());
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(1, "first trip", "s0", 2, 10.0d),
+                    createStopTime(2, "first trip", "s1", 42, 45.0d),
+                    createStopTime(3, "first trip", "s2", 46, 64.0d))))
+        .isEmpty();
   }
 
   @Test
   public void lastShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
-    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(1, "first trip", "s0", 2, 10.0d),
-                createStopTime(2, "first trip", "s1", 42, 45.0d),
-                createStopTime(3, "first trip", "s2", 46, 4.0d)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(1, "first trip", "s0", 2, 10.0d),
+                    createStopTime(2, "first trip", "s1", 42, 45.0d),
+                    createStopTime(3, "first trip", "s2", 46, 4.0d))))
         .containsExactly(
             new DecreasingOrEqualStopTimeDistanceNotice("first trip", 3, 4.0d, 46, 2, 45.0d, 42));
   }
 
   @Test
   public void twoShapesWithTheSameDistanceShouldGenerateNotice() {
-    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(1, "first trip", "s0", 2, 10.0d),
-                createStopTime(2, "first trip", "s1", 42, 45.0d),
-                createStopTime(3, "first trip", "s2", 46, 45.0d)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(1, "first trip", "s0", 2, 10.0d),
+                    createStopTime(2, "first trip", "s1", 42, 45.0d),
+                    createStopTime(3, "first trip", "s2", 46, 45.0d))))
         .containsExactly(
             new DecreasingOrEqualStopTimeDistanceNotice("first trip", 3, 45.0d, 46, 2, 45.0d, 42));
   }
 
   @Test
   public void oneIntermediateShapeWithDecreasingDistanceAlongShapeShouldGenerateNotice() {
-    StopTimeIncreasingDistanceValidator underTest = new StopTimeIncreasingDistanceValidator();
-    NoticeContainer noticeContainer = new NoticeContainer();
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(1, "first trip", "s0", 2, 10.0d),
-                createStopTime(2, "first trip", "s1", 42, 8.6d),
-                createStopTime(3, "first trip", "s2", 46, 46.0d)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTime(1, "first trip", "s0", 2, 10.0d),
+                    createStopTime(2, "first trip", "s1", 42, 8.6d),
+                    createStopTime(3, "first trip", "s2", 46, 46.0d))))
         .containsExactly(
             new DecreasingOrEqualStopTimeDistanceNotice("first trip", 2, 8.6d, 42, 1, 10.0d, 2));
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidatorTest.java
@@ -17,16 +17,13 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Set;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.StopTooFarFromTripShapeNotice;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsShape;
 import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
@@ -35,8 +32,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Mockito;
 
 public class StopTooFarFromTripShapeValidatorTest {
 
@@ -50,16 +45,6 @@ public class StopTooFarFromTripShapeValidatorTest {
         .build();
   }
 
-  private static GtfsStopTimeTableContainer createStopTimeTable(
-      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
-    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
-  }
-
-  private static GtfsTripTableContainer createTripTable(
-      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
-    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
-  }
-
   public static GtfsTrip createTrip(
       long csvRowNumber, String routeId, String serviceId, String tripId, String shapeId) {
     return new GtfsTrip.Builder()
@@ -69,11 +54,6 @@ public class StopTooFarFromTripShapeValidatorTest {
         .setTripId(tripId)
         .setShapeId(shapeId)
         .build();
-  }
-
-  private static GtfsShapeTableContainer createShapeTable(
-      NoticeContainer noticeContainer, List<GtfsShape> entities) {
-    return GtfsShapeTableContainer.forEntities(entities, noticeContainer);
   }
 
   public static GtfsShape createShapePoint(
@@ -120,44 +100,48 @@ public class StopTooFarFromTripShapeValidatorTest {
         .build();
   }
 
+  private List<ValidationNotice> generateNotices(
+      List<GtfsStop> stops,
+      List<GtfsStopTime> stopTimes,
+      List<GtfsShape> shapes,
+      List<GtfsTrip> trips) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new StopTooFarFromTripShapeValidator(
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer),
+            GtfsTripTableContainer.forEntities(trips, noticeContainer),
+            GtfsShapeTableContainer.forEntities(shapes, noticeContainer),
+            GtfsStopTableContainer.forEntities(stops, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void stopOutsideTripShapeShouldGenerateNotice() {
     // See map of trip shape and stops (in GeoJSON) at
     // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
-                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 0),
-                // this location is outside buffer
-                createStop(5, "1003", 17.456467, -45.4569865, 0)));
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1),
-                createStopTime(8, "t1", "1002", 2),
-                createStopTime(9, "t1", "1003", 3)));
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape id", 28.05800068503469D, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer,
-            ImmutableList.of(createTrip(55, "route id", "service id", "t1", "shape id")));
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
+                    createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 0),
+                    // this location is outside buffer
+                    createStop(5, "1003", 17.456467, -45.4569865, 0)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1),
+                    createStopTime(8, "t1", "1002", 2),
+                    createStopTime(9, "t1", "1003", 3)),
+                ImmutableList.of(
+                    createShapePoint(
+                        5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(
+                        6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(
+                        7, "shape id", 28.05800068503469D, -82.4159394137605D, 3, 400f),
+                    createShapePoint(
+                        8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(createTrip(55, "route id", "service id", "t1", "shape id"))))
         .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape id", 100));
   }
 
@@ -165,37 +149,26 @@ public class StopTooFarFromTripShapeValidatorTest {
   public void stopWithinTripShapeShouldNotGenerateNotice() {
     // See map of trip shape and stops (in GeoJSON) at
     // https://gist.github.com/barbeau/d9c0b90a26a3e2ba105cae5f0e8aec4a
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 4),
-                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 4)));
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)));
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer,
-            ImmutableList.of(createTrip(55, "route id", "service id", "t1", "shape id")));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 4),
+                    createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 4)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)),
+                ImmutableList.of(
+                    createShapePoint(
+                        5, "shape id", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(
+                        6, "shape id", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(
+                        7, "shape id", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                    createShapePoint(
+                        8, "shape id", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape id", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(createTrip(55, "route id", "service id", "t1", "shape id"))))
+        .isEmpty();
   }
 
   /**
@@ -212,45 +185,27 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void twoTripsWithSameShapeStopOutsideBufferShouldGenerateOneNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer,
-            ImmutableList.of(
-                createTrip(4, "r1", "service1", "t1", "shape1"),
-                createTrip(9, "r1", "service1", "t2", "shape1")));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1),
-                createStopTime(8, "t1", "1002", 2),
-                createStopTime(9, "t1", "1003", 3)));
-
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
-                createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 0),
-                // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
+                    createStop(4, "1002", 28.05809979887893D, -82.41773971025437D, 0),
+                    // this location is outside buffer
+                    createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1),
+                    createStopTime(8, "t1", "1002", 2),
+                    createStopTime(9, "t1", "1003", 3)),
+                ImmutableList.of(
+                    createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                    createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(
+                    createTrip(4, "r1", "service1", "t1", "shape1"),
+                    createTrip(9, "r1", "service1", "t2", "shape1"))))
         .containsExactly(new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape1", 100));
   }
 
@@ -268,30 +223,17 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void tripWithoutShapeShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", null)));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)));
-
-    // No shapes.txt data
-    underTest.shapeTable = GtfsShapeTableContainer.forEntities(new ArrayList<>(), noticeContainer);
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 0),
+                    createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 0)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)),
+                // No shapes.txt data
+                ImmutableList.of(),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", null))))
+        .isEmpty();
   }
 
   /**
@@ -308,41 +250,26 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void stopWithoutLocationShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1")));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)));
-
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                // No location - optional for location_type=4
-                createStop(2, "1001", null, null, 4),
-                // No location - optional for location_type=4
-                createStop(4, "1002", null, null, 4),
-                // No location - optional for location_type=4
-                createStop(5, "1003", null, null, 4)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    // No location - optional for location_type=4
+                    createStop(2, "1001", null, null, 4),
+                    // No location - optional for location_type=4
+                    createStop(4, "1002", null, null, 4),
+                    // No location - optional for location_type=4
+                    createStop(5, "1003", null, null, 4)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1), createStopTime(8, "t1", "1002", 2)),
+                ImmutableList.of(
+                    createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                    createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1"))))
+        .isEmpty();
   }
 
   /**
@@ -359,40 +286,24 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void singleStopWithinBufferShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1")));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1),
-                createStopTime(8, "t1", "1002", 2),
-                createStopTime(9, "t1", "1003", 3)));
-
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                // this location is inside buffer
-                createStop(2, "1001", 28.05724310653972D, -82.41350776611507D, 0)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    // this location is inside buffer
+                    createStop(2, "1001", 28.05724310653972D, -82.41350776611507D, 0)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1),
+                    createStopTime(8, "t1", "1002", 2),
+                    createStopTime(9, "t1", "1003", 3)),
+                ImmutableList.of(
+                    createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                    createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1"))))
+        .isEmpty();
   }
 
   /**
@@ -409,37 +320,23 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void nullStopTimeShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1")));
-
-    underTest.stopTimeTable =
-        GtfsStopTimeTableContainer.forEntities(new ArrayList<>(), noticeContainer);
-
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
-                // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                    createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                    // this location is outside buffer
+                    createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+                ImmutableList.of(),
+                ImmutableList.of(
+                    createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                    createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1"))))
+        .isEmpty();
   }
 
   /**
@@ -456,37 +353,23 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void emptyStopTimesShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1")));
-
-    underTest.stopTimeTable =
-        GtfsStopTimeTableContainer.forEntities(new ArrayList<>(), noticeContainer);
-
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
-                createShapePoint(9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)));
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
-                // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                    createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                    // this location is outside buffer
+                    createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+                ImmutableList.of(),
+                ImmutableList.of(
+                    createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
+                    createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
+                    createShapePoint(7, "shape1", 28.05800068503469f, -82.4159394137605D, 3, 400f),
+                    createShapePoint(8, "shape1", 28.05808869825447D, -82.41648754043338D, 4, 400f),
+                    createShapePoint(
+                        9, "shape1", 28.05809979887893D, -82.41773971025437D, 5, 400f)),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1"))))
+        .isEmpty();
   }
 
   /**
@@ -503,34 +386,20 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void nullShapePointsShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1")));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1),
-                createStopTime(8, "t1", "1002", 2),
-                createStopTime(9, "t1", "1003", 3)));
-
-    underTest.shapeTable = GtfsShapeTableContainer.forEntities(new ArrayList<>(), noticeContainer);
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
-                // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                    createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                    // this location is outside buffer
+                    createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1),
+                    createStopTime(8, "t1", "1002", 2),
+                    createStopTime(9, "t1", "1003", 3)),
+                ImmutableList.of(),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1"))))
+        .isEmpty();
   }
 
   /**
@@ -547,145 +416,19 @@ public class StopTooFarFromTripShapeValidatorTest {
    */
   @Test
   public void emptyShapePointsShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest = new StopTooFarFromTripShapeValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer, ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1")));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1),
-                createStopTime(8, "t1", "1002", 2),
-                createStopTime(9, "t1", "1003", 3)));
-
-    underTest.shapeTable = GtfsShapeTableContainer.forEntities(new ArrayList<>(), noticeContainer);
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
-                createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
-                // this location is outside buffer
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
-  }
-
-  @Test
-  public void eachTripShouldOnlyBeProcessedOnce() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    StopTooFarFromTripShapeValidator underTest =
-        Mockito.spy(new StopTooFarFromTripShapeValidator());
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer,
-            ImmutableList.of(
-                createTrip(4, "r1", "service1", "t1", "shape1"),
-                createTrip(9, "r2", "service2", "t2", "shape2")));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(5, "t1", "1001", 1),
-                createStopTime(8, "t1", "1002", 2),
-                createStopTime(9, "t1", "1003", 3),
-                createStopTime(10, "t2", "1004", 4),
-                createStopTime(11, "t2", "1005", 5)));
-
-    underTest.shapeTable =
-        createShapeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createShapePoint(5, "shape1", 28.05724310653972D, -82.41350776611507D, 1, 400f),
-                createShapePoint(6, "shape1", 28.05746701492806D, -82.41493135129478D, 2, 400f),
-                createShapePoint(7, "shape1", 28.05800068503469D, -82.4159394137605D, 3, 400f),
-                createShapePoint(8, "shape2", 16.373032D, -61.459167D, 4, 400f),
-                createShapePoint(9, "shape2", 16.371539D, -61.459886D, 5, 400f)));
-
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "1001", 28.05808869825447D, -82.41648754043338D, 0),
-                createStop(4, "1002", 28.05808869825447D, -82.41648754043338D, 0),
-                // this location is outside buffer of shape1
-                createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4),
-                createStop(7, "1004", 16.373032D, -61.459167D, 4),
-                // this location is outside buffer of shape2
-                createStop(8, "1005", 28.05673053256373D, -82.4170801432763D, 4)));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
-        .containsExactlyElementsIn(
-            new StopTooFarFromTripShapeNotice[] {
-              new StopTooFarFromTripShapeNotice("1003", 3, "t1", "shape1", 100),
-              new StopTooFarFromTripShapeNotice("1005", 5, "t2", "shape2", 100),
-            });
-
-    ArgumentCaptor<String> tripIdCapture = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<List<GtfsStopTime>> stopTimeCapture = ArgumentCaptor.forClass(List.class);
-    ArgumentCaptor<String> shapeIdCapture = ArgumentCaptor.forClass(String.class);
-    ArgumentCaptor<List<GtfsShape>> shapesCapture = ArgumentCaptor.forClass(List.class);
-    ArgumentCaptor<GtfsStopTableContainer> stopTableCapture =
-        ArgumentCaptor.forClass(GtfsStopTableContainer.class);
-    ArgumentCaptor<Set<String>> cacheCapture = ArgumentCaptor.forClass(Set.class);
-
-    verify(underTest, times(1)).validate(noticeContainer);
-    verify(underTest, times(2))
-        .checkStopsWithinTripShape(
-            tripIdCapture.capture(),
-            stopTimeCapture.capture(),
-            shapeIdCapture.capture(),
-            shapesCapture.capture(),
-            stopTableCapture.capture(),
-            cacheCapture.capture());
-
-    // Make sure we only captured 2 sets of input parameters, one for each invocation
-    assertThat(tripIdCapture.getAllValues().size()).isEqualTo(2);
-    assertThat(stopTimeCapture.getAllValues().size()).isEqualTo(2);
-    assertThat(shapeIdCapture.getAllValues().size()).isEqualTo(2);
-    assertThat(shapesCapture.getAllValues().size()).isEqualTo(2);
-    assertThat(stopTableCapture.getAllValues().size()).isEqualTo(2);
-    assertThat(cacheCapture.getAllValues().size()).isEqualTo(2);
-
-    // Check first execution parameters of checkStopsWithinTripShape()
-    assertThat(tripIdCapture.getAllValues().get(0)).isEqualTo("t1");
-    assertThat(stopTimeCapture.getAllValues().get(0))
-        .isEqualTo(underTest.stopTimeTable.byTripId("t1"));
-    assertThat(shapeIdCapture.getAllValues().get(0)).isEqualTo("shape1");
-    assertThat(shapesCapture.getAllValues().get(0))
-        .isEqualTo(underTest.shapeTable.byShapeId("shape1"));
-    assertThat(stopTableCapture.getAllValues().get(0)).isEqualTo(underTest.stopTable);
-
-    // Check 2nd execution parameters of checkStopsWithinTripShape()
-    assertThat(tripIdCapture.getAllValues().get(1)).isEqualTo("t2");
-    assertThat(stopTimeCapture.getAllValues().get(1))
-        .isEqualTo(underTest.stopTimeTable.byTripId("t2"));
-    assertThat(shapeIdCapture.getAllValues().get(1)).isEqualTo("shape2");
-    assertThat(shapesCapture.getAllValues().get(1))
-        .isEqualTo(underTest.shapeTable.byShapeId("shape2"));
-    assertThat(stopTableCapture.getAllValues().get(1)).isEqualTo(underTest.stopTable);
-
-    // Note that the contents of the cache are the final state, not the state at specific invocation
-    // because it's passed by reference and not value
-    Set<String> expected = new java.util.HashSet<>();
-    expected.add("shape11001");
-    expected.add("shape11002");
-    expected.add("shape11003");
-    expected.add("shape21005");
-    expected.add("shape21004");
-    assertThat(cacheCapture.getAllValues().get(0)).isEqualTo(expected);
-    assertThat(cacheCapture.getAllValues().get(1)).isEqualTo(expected);
-
-    Mockito.verifyNoMoreInteractions(underTest);
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "1001", 28.05811731042478D, -82.41616877502503D, 4),
+                    createStop(4, "1002", 28.05812364854794D, -82.41617370439423D, 4),
+                    // this location is outside buffer
+                    createStop(5, "1003", 28.05673053256373D, -82.4170801432763D, 4)),
+                ImmutableList.of(
+                    createStopTime(5, "t1", "1001", 1),
+                    createStopTime(8, "t1", "1002", 2),
+                    createStopTime(9, "t1", "1003", 3)),
+                ImmutableList.of(),
+                ImmutableList.of(createTrip(4, "r1", "service1", "t1", "shape1"))))
+        .isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TooFastTravelValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TooFastTravelValidatorTest.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.TooFastTravelNotice;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
@@ -32,10 +33,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 
 public class TooFastTravelValidatorTest {
-  private static GtfsStopTableContainer createStopTable(
-      NoticeContainer noticeContainer, List<GtfsStop> entities) {
-    return GtfsStopTableContainer.forEntities(entities, noticeContainer);
-  }
 
   private static GtfsStop createStop(long csvRowNumber, String stopId, double stopLon) {
     return new GtfsStop.Builder()
@@ -63,16 +60,6 @@ public class TooFastTravelValidatorTest {
         .build();
   }
 
-  private static GtfsStopTimeTableContainer createStopTimeTable(
-      NoticeContainer noticeContainer, List<GtfsStopTime> entities) {
-    return GtfsStopTimeTableContainer.forEntities(entities, noticeContainer);
-  }
-
-  private static GtfsTripTableContainer createTripTable(
-      NoticeContainer noticeContainer, List<GtfsTrip> entities) {
-    return GtfsTripTableContainer.forEntities(entities, noticeContainer);
-  }
-
   private static GtfsTrip createTrip() {
     return new GtfsTrip.Builder()
         .setCsvRowNumber(34)
@@ -82,48 +69,47 @@ public class TooFastTravelValidatorTest {
         .build();
   }
 
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsStop> stops, List<GtfsTrip> trips, List<GtfsStopTime> stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new TooFastTravelValidator(
+            GtfsTripTableContainer.forEntities(trips, noticeContainer),
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer),
+            GtfsStopTableContainer.forEntities(stops, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
   @Test
   public void fastTravelContiguousStopsShouldGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/473f265f1bc0404c8e4738bbe4977649
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.001),
-                createStop(3, "s1", 0.002),
-                createStop(4, "s2", 0.003)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(
-                    5,
-                    "s1",
-                    1,
-                    GtfsTime.fromSecondsSinceMidnight(7),
-                    GtfsTime.fromSecondsSinceMidnight(9)),
-                createStopTime(
-                    6,
-                    "s2",
-                    4,
-                    GtfsTime.fromSecondsSinceMidnight(15),
-                    GtfsTime.fromSecondsSinceMidnight(20))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.001),
+                    createStop(3, "s1", 0.002),
+                    createStop(4, "s2", 0.003)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(
+                        5,
+                        "s1",
+                        1,
+                        GtfsTime.fromSecondsSinceMidnight(7),
+                        GtfsTime.fromSecondsSinceMidnight(9)),
+                    createStopTime(
+                        6,
+                        "s2",
+                        4,
+                        GtfsTime.fromSecondsSinceMidnight(15),
+                        GtfsTime.fromSecondsSinceMidnight(20)))))
         .containsExactly(new TooFastTravelNotice("t1", 200.15114352186376d, 0, 1));
   }
 
@@ -131,51 +117,39 @@ public class TooFastTravelValidatorTest {
   public void fastTravelFarStopsShouldGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/d21cc8b1519d4f44f9ebd53858cda78d
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002),
-                createStop(5, "s3", 0.003)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(
-                    5,
-                    "s1",
-                    1,
-                    GtfsTime.fromSecondsSinceMidnight(10),
-                    GtfsTime.fromSecondsSinceMidnight(10)),
-                createStopTime(
-                    6,
-                    "s2",
-                    2,
-                    GtfsTime.fromSecondsSinceMidnight(10),
-                    GtfsTime.fromSecondsSinceMidnight(10)),
-                createStopTime(
-                    6,
-                    "s3",
-                    3,
-                    GtfsTime.fromSecondsSinceMidnight(11),
-                    GtfsTime.fromSecondsSinceMidnight(13))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002),
+                    createStop(5, "s3", 0.003)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(
+                        5,
+                        "s1",
+                        1,
+                        GtfsTime.fromSecondsSinceMidnight(10),
+                        GtfsTime.fromSecondsSinceMidnight(10)),
+                    createStopTime(
+                        6,
+                        "s2",
+                        2,
+                        GtfsTime.fromSecondsSinceMidnight(10),
+                        GtfsTime.fromSecondsSinceMidnight(10)),
+                    createStopTime(
+                        6,
+                        "s3",
+                        3,
+                        GtfsTime.fromSecondsSinceMidnight(11),
+                        GtfsTime.fromSecondsSinceMidnight(13)))))
         .containsExactly(new TooFastTravelNotice("t1", 800.604574087455d, 1, 3));
   }
 
@@ -183,83 +157,60 @@ public class TooFastTravelValidatorTest {
   public void noFastTravelShouldNotGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/c556bfa6ae2622166c594eed51f4b468
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.001),
-                createStop(3, "s1", 0.002),
-                createStop(4, "s2", 0.003)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(
-                    5,
-                    "s1",
-                    1,
-                    GtfsTime.fromSecondsSinceMidnight(28),
-                    GtfsTime.fromSecondsSinceMidnight(44)),
-                createStopTime(
-                    6,
-                    "s2",
-                    4,
-                    GtfsTime.fromSecondsSinceMidnight(75),
-                    GtfsTime.fromSecondsSinceMidnight(122))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices());
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.001),
+                    createStop(3, "s1", 0.002),
+                    createStop(4, "s2", 0.003)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(
+                        5,
+                        "s1",
+                        1,
+                        GtfsTime.fromSecondsSinceMidnight(28),
+                        GtfsTime.fromSecondsSinceMidnight(44)),
+                    createStopTime(
+                        6,
+                        "s2",
+                        4,
+                        GtfsTime.fromSecondsSinceMidnight(75),
+                        GtfsTime.fromSecondsSinceMidnight(122)))))
+        .isEmpty();
   }
 
   @Test
   public void fastTravelMissingArrivalTimeShouldGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/2924c8c7b8ee4e52aec04fec166849b4
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(5, "s1", 1, null, GtfsTime.fromSecondsSinceMidnight(6)),
-                createStopTime(
-                    6,
-                    "s2",
-                    4,
-                    GtfsTime.fromSecondsSinceMidnight(7),
-                    GtfsTime.fromSecondsSinceMidnight(12))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(5, "s1", 1, null, GtfsTime.fromSecondsSinceMidnight(6)),
+                    createStopTime(
+                        6,
+                        "s2",
+                        4,
+                        GtfsTime.fromSecondsSinceMidnight(7),
+                        GtfsTime.fromSecondsSinceMidnight(12)))))
         .containsExactly(new TooFastTravelNotice("t1", 800.604574087455d, 0, 4));
   }
 
@@ -267,78 +218,55 @@ public class TooFastTravelValidatorTest {
   public void noFastTravelMissingArrivalTimeShouldNotGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/e1a1095287677758598cb4e897b4f439
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(5, "s1", 1, null, GtfsTime.fromSecondsSinceMidnight(10)),
-                createStopTime(
-                    6,
-                    "s2",
-                    4,
-                    GtfsTime.fromSecondsSinceMidnight(55),
-                    GtfsTime.fromSecondsSinceMidnight(100))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(5, "s1", 1, null, GtfsTime.fromSecondsSinceMidnight(10)),
+                    createStopTime(
+                        6,
+                        "s2",
+                        4,
+                        GtfsTime.fromSecondsSinceMidnight(55),
+                        GtfsTime.fromSecondsSinceMidnight(100)))))
+        .isEmpty();
   }
 
   @Test
   public void fastTravelMissingDepartureTimeShouldGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/dc1996244f2d2a86ababb8ae81b8eab0
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(5, "s1", 1, GtfsTime.fromSecondsSinceMidnight(6), null),
-                createStopTime(
-                    6,
-                    "s2",
-                    4,
-                    GtfsTime.fromSecondsSinceMidnight(7),
-                    GtfsTime.fromSecondsSinceMidnight(12))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(5, "s1", 1, GtfsTime.fromSecondsSinceMidnight(6), null),
+                    createStopTime(
+                        6,
+                        "s2",
+                        4,
+                        GtfsTime.fromSecondsSinceMidnight(7),
+                        GtfsTime.fromSecondsSinceMidnight(12)))))
         .containsExactly(new TooFastTravelNotice("t1", 400.3022870437275, 0, 4));
   }
 
@@ -346,140 +274,106 @@ public class TooFastTravelValidatorTest {
   public void noFastTravelMissingDepartureTimeShouldNotGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/633d17dade4955230f67f567f32365d9
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(5, "s1", 1, GtfsTime.fromSecondsSinceMidnight(10), null),
-                createStopTime(
-                    6,
-                    "s2",
-                    4,
-                    GtfsTime.fromSecondsSinceMidnight(15),
-                    GtfsTime.fromSecondsSinceMidnight(20))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(5, "s1", 1, GtfsTime.fromSecondsSinceMidnight(10), null),
+                    createStopTime(
+                        6,
+                        "s2",
+                        4,
+                        GtfsTime.fromSecondsSinceMidnight(15),
+                        GtfsTime.fromSecondsSinceMidnight(20)))))
+        .isEmpty();
   }
 
   @Test
   public void stopTimeWithArrivalBeforePreviousDepartureTimeShouldNotGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/d88be566850d47ea60cbcab0e869052c
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002),
-                createStop(5, "s3", 0.003)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(
-                    5,
-                    "s1",
-                    1,
-                    GtfsTime.fromSecondsSinceMidnight(4),
-                    GtfsTime.fromSecondsSinceMidnight(10)),
-                createStopTime(
-                    6,
-                    "s2",
-                    2,
-                    GtfsTime.fromSecondsSinceMidnight(10),
-                    GtfsTime.fromSecondsSinceMidnight(10)),
-                createStopTime(
-                    6,
-                    "s3",
-                    3,
-                    GtfsTime.fromSecondsSinceMidnight(11),
-                    GtfsTime.fromSecondsSinceMidnight(13))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002),
+                    createStop(5, "s3", 0.003)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(
+                        5,
+                        "s1",
+                        1,
+                        GtfsTime.fromSecondsSinceMidnight(4),
+                        GtfsTime.fromSecondsSinceMidnight(10)),
+                    createStopTime(
+                        6,
+                        "s2",
+                        2,
+                        GtfsTime.fromSecondsSinceMidnight(10),
+                        GtfsTime.fromSecondsSinceMidnight(10)),
+                    createStopTime(
+                        6,
+                        "s3",
+                        3,
+                        GtfsTime.fromSecondsSinceMidnight(11),
+                        GtfsTime.fromSecondsSinceMidnight(13)))))
+        .isEmpty();
   }
 
   @Test
   public void fastTravelBetweenIncludingNonTimepointsShouldGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/583b53f2e46f02f0276877831cc7a54e
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002),
-                createStop(5, "s3", 0.003),
-                createStop(6, "s4", 0.004),
-                createStop(7, "s5", 0.005)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(3, "s1", 1, null, null),
-                createStopTime(4, "s2", 2, null, null),
-                createStopTime(
-                    8,
-                    "s3",
-                    3,
-                    GtfsTime.fromSecondsSinceMidnight(7),
-                    GtfsTime.fromSecondsSinceMidnight(10)),
-                createStopTime(6, "s4", 4, null, null),
-                createStopTime(
-                    7,
-                    "s5",
-                    5,
-                    GtfsTime.fromSecondsSinceMidnight(20),
-                    GtfsTime.fromSecondsSinceMidnight(28))));
-
-    underTest.validate(noticeContainer);
-
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002),
+                    createStop(5, "s3", 0.003),
+                    createStop(6, "s4", 0.004),
+                    createStop(7, "s5", 0.005)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(3, "s1", 1, null, null),
+                    createStopTime(4, "s2", 2, null, null),
+                    createStopTime(
+                        8,
+                        "s3",
+                        3,
+                        GtfsTime.fromSecondsSinceMidnight(7),
+                        GtfsTime.fromSecondsSinceMidnight(10)),
+                    createStopTime(6, "s4", 4, null, null),
+                    createStopTime(
+                        7,
+                        "s5",
+                        5,
+                        GtfsTime.fromSecondsSinceMidnight(20),
+                        GtfsTime.fromSecondsSinceMidnight(28)))))
         .containsExactly(new TooFastTravelNotice("t1", 600.4534305655912, 0, 3));
   }
 
@@ -487,48 +381,38 @@ public class TooFastTravelValidatorTest {
   public void noFastTravelBetweenIncludingNonTimepointsShouldNotGenerateNotice() {
     // sample table descriptions available at:
     // https://gist.github.com/lionel-nj/b2fe94906679fe30ca2c444fa8c92ce0
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TooFastTravelValidator underTest = new TooFastTravelValidator();
-    underTest.stopTable =
-        createStopTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStop(2, "s0", 0.000),
-                createStop(3, "s1", 0.001),
-                createStop(4, "s2", 0.002),
-                createStop(5, "s3", 0.003),
-                createStop(6, "s4", 0.004),
-                createStop(7, "s5", 0.005)));
-
-    underTest.tripTable = createTripTable(noticeContainer, ImmutableList.of(createTrip()));
-
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            noticeContainer,
-            ImmutableList.of(
-                createStopTime(
-                    4,
-                    "s0",
-                    0,
-                    GtfsTime.fromSecondsSinceMidnight(0),
-                    GtfsTime.fromSecondsSinceMidnight(5)),
-                createStopTime(3, "s1", 1, null, null),
-                createStopTime(4, "s2", 2, null, null),
-                createStopTime(
-                    8,
-                    "s3",
-                    3,
-                    GtfsTime.fromSecondsSinceMidnight(20),
-                    GtfsTime.fromSecondsSinceMidnight(25)),
-                createStopTime(6, "s4", 4, null, null),
-                createStopTime(
-                    7,
-                    "s5",
-                    5,
-                    GtfsTime.fromSecondsSinceMidnight(39),
-                    GtfsTime.fromSecondsSinceMidnight(44))));
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStop(2, "s0", 0.000),
+                    createStop(3, "s1", 0.001),
+                    createStop(4, "s2", 0.002),
+                    createStop(5, "s3", 0.003),
+                    createStop(6, "s4", 0.004),
+                    createStop(7, "s5", 0.005)),
+                ImmutableList.of(createTrip()),
+                ImmutableList.of(
+                    createStopTime(
+                        4,
+                        "s0",
+                        0,
+                        GtfsTime.fromSecondsSinceMidnight(0),
+                        GtfsTime.fromSecondsSinceMidnight(5)),
+                    createStopTime(3, "s1", 1, null, null),
+                    createStopTime(4, "s2", 2, null, null),
+                    createStopTime(
+                        8,
+                        "s3",
+                        3,
+                        GtfsTime.fromSecondsSinceMidnight(20),
+                        GtfsTime.fromSecondsSinceMidnight(25)),
+                    createStopTime(6, "s4", 4, null, null),
+                    createStopTime(
+                        7,
+                        "s5",
+                        5,
+                        GtfsTime.fromSecondsSinceMidnight(39),
+                        GtfsTime.fromSecondsSinceMidnight(44)))))
+        .isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidatorTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.UnusedTripNotice;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
@@ -60,8 +61,8 @@ public class TripUsageValidatorTest {
         .build();
   }
 
-  private static GtfsStopTimeTableContainer createStopTimeTable(
-      String[] tripIds, String[] stopIds, String[][] times, NoticeContainer noticeContainer) {
+  private static List<GtfsStopTime> createStopTimes(
+      String[] tripIds, String[] stopIds, String[][] times) {
     Preconditions.checkArgument(
         tripIds.length == times.length, "tripIds.length must be equal to times.length");
 
@@ -75,55 +76,48 @@ public class TripUsageValidatorTest {
       }
     }
 
-    return GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer);
+    return stopTimes;
+  }
+
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsTrip> trips, List<GtfsStopTime> stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new TripUsageValidator(
+            GtfsTripTableContainer.forEntities(trips, noticeContainer),
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
   }
 
   @Test
   public void allTripsUsedShouldNotGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TripUsageValidator underTest = new TripUsageValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer,
-            ImmutableList.of(
-                createTrip(1, "route id value", "service id value", "t0"),
-                createTrip(3, "route id value", "service id value", "t1")));
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            new String[] {"t0", "t1"},
-            new String[] {"s0", "s1"},
-            new String[][] {
-              new String[] {"08:00:00", "09:00:00"}, new String[] {"10:00:00", "11:00:00"},
-            },
-            noticeContainer);
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createTrip(1, "route id value", "service id value", "t0"),
+                    createTrip(3, "route id value", "service id value", "t1")),
+                createStopTimes(
+                    new String[] {"t0", "t1"},
+                    new String[] {"s0", "s1"},
+                    new String[][] {
+                      new String[] {"08:00:00", "09:00:00"}, new String[] {"10:00:00", "11:00:00"},
+                    })))
+        .isEmpty();
   }
 
   @Test
   public void unusedTripShouldGenerateNotice() {
-    NoticeContainer noticeContainer = new NoticeContainer();
-    TripUsageValidator underTest = new TripUsageValidator();
-
-    underTest.tripTable =
-        createTripTable(
-            noticeContainer,
-            ImmutableList.of(
-                createTrip(1, "route id value", "service id value", "used trip id value"),
-                createTrip(3, "route id value", "service id value", "unused trip id value")));
-    underTest.stopTimeTable =
-        createStopTimeTable(
-            new String[] {"used trip id value"},
-            new String[] {"s0", "s1"},
-            new String[][] {
-              new String[] {"08:00:00", "09:00:00"},
-            },
-            noticeContainer);
-
-    underTest.validate(noticeContainer);
-    assertThat(noticeContainer.getValidationNotices())
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createTrip(1, "route id value", "service id value", "used trip id value"),
+                    createTrip(3, "route id value", "service id value", "unused trip id value")),
+                createStopTimes(
+                    new String[] {"used trip id value"},
+                    new String[] {"s0", "s1"},
+                    new String[][] {
+                      new String[] {"08:00:00", "09:00:00"},
+                    })))
         .containsExactly(new UnusedTripNotice("unused trip id value", 3));
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/ForeignKeyValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/ForeignKeyValidatorGenerator.java
@@ -16,7 +16,6 @@
 
 package org.mobilitydata.gtfsvalidator.processor;
 
-import com.squareup.javapoet.FieldSpec;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.TypeSpec;
@@ -39,6 +38,7 @@ import org.mobilitydata.gtfsvalidator.validator.FileValidator;
  * <p>A foreign key constraint is added with {@code @ForeignKey} annotation in GTFS schema.
  */
 public class ForeignKeyValidatorGenerator {
+
   private static final String VALIDATOR_PACKAGE_NAME = "org.mobilitydata.gtfsvalidator.validator";
 
   private final Map<String, GtfsFileDescriptor> fileDescriptors = new HashMap<>();
@@ -92,12 +92,21 @@ public class ForeignKeyValidatorGenerator {
             .superclass(FileValidator.class);
 
     typeSpec.addField(
-        FieldSpec.builder(parentClasses.tableContainerTypeName(), "parentContainer")
-            .addAnnotation(Inject.class)
-            .build());
+        parentClasses.tableContainerTypeName(),
+        "parentContainer",
+        Modifier.PRIVATE,
+        Modifier.FINAL);
     typeSpec.addField(
-        FieldSpec.builder(childClasses.tableContainerTypeName(), "childContainer")
+        childClasses.tableContainerTypeName(), "childContainer", Modifier.PRIVATE, Modifier.FINAL);
+
+    typeSpec.addMethod(
+        MethodSpec.constructorBuilder()
+            .addModifiers(Modifier.PUBLIC)
             .addAnnotation(Inject.class)
+            .addParameter(parentClasses.tableContainerTypeName(), "parentContainer")
+            .addParameter(childClasses.tableContainerTypeName(), "childContainer")
+            .addStatement("this.parentContainer = parentContainer")
+            .addStatement("this.childContainer = childContainer")
             .build());
 
     MethodSpec.Builder validateMethod =


### PR DESCRIPTION
Injectable constructors provide a cleaner interface for dependency injection than injectable fields.