### PR TITLE
feat: Add indices on stop.parent_station and stop_times.stop_id

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
@@ -30,8 +30,8 @@ import org.mobilitydata.gtfsvalidator.annotation.Required;
 @Required
 public interface GtfsStopSchema extends GtfsEntity {
   @FieldType(FieldTypeEnum.ID)
-  @Required
   @PrimaryKey
+  @Required
   String stopId();
 
   String stopCode();
@@ -62,8 +62,9 @@ public interface GtfsStopSchema extends GtfsEntity {
   GtfsLocationType locationType();
 
   @FieldType(FieldTypeEnum.ID)
-  @ForeignKey(table = "stops.txt", field = "stop_id")
+  @Index
   @ConditionallyRequired
+  @ForeignKey(table = "stops.txt", field = "stop_id")
   String parentStation();
 
   @FieldType(FieldTypeEnum.TIMEZONE)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeSchema.java
@@ -25,6 +25,7 @@ import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
 import org.mobilitydata.gtfsvalidator.annotation.FirstKey;
 import org.mobilitydata.gtfsvalidator.annotation.ForeignKey;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.Index;
 import org.mobilitydata.gtfsvalidator.annotation.NonNegative;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 import org.mobilitydata.gtfsvalidator.annotation.SequenceKey;
@@ -34,9 +35,9 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 @Required
 public interface GtfsStopTimeSchema extends GtfsEntity {
   @FieldType(FieldTypeEnum.ID)
+  @FirstKey
   @Required
   @ForeignKey(table = "trips.txt", field = "trip_id")
-  @FirstKey
   String tripId();
 
   @ConditionallyRequired
@@ -47,13 +48,14 @@ public interface GtfsStopTimeSchema extends GtfsEntity {
   GtfsTime departureTime();
 
   @FieldType(FieldTypeEnum.ID)
+  @Index
   @Required
   @ForeignKey(table = "stops.txt", field = "stop_id")
   String stopId();
 
+  @SequenceKey
   @Required
   @NonNegative
-  @SequenceKey
   int stopSequence();
 
   @CachedField


### PR DESCRIPTION
That will allow us to find all child stops of a station and all stop
times that belong to the same stop.

```
  stopTable.byParentStation("station1")
  stopTimeTable.byStopId("stop1")
```

Also reorder some annotations. We would like to have the following
common order:

* FieldType
* PrimaryKey, FirstKey or SequenceKey
* Index
* Required or ConditionallyRequired
* ForeignKey
