### PR TITLE
docs: Add issue template for new validation rules

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-validation-rule.md
+++ b/.github/ISSUE_TEMPLATE/new-validation-rule.md
@@ -1,0 +1,17 @@
+---
+name: New validation rule
+about: Suggest a new GTFS validation rule for this project
+title: ''
+labels: new rule
+assignees: ''
+
+---
+
+**What problem in GTFS datasets does this new rule address? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the new validation rule**
+A clear description of the new rule logic you'd like to see. Ex. For all stops in stops.txt, [...]
+
+**Error vs warning**
+Should this be an error (violates a requirement of the GTFS spec) or a warning (a best practice or suggestion)?


### PR DESCRIPTION
Adds a new issue template option to the "New issue" workflow.  The options after this is merged are:
1. Bug report
2. Feature request
3. New validation rule

Closes https://github.com/MobilityData/gtfs-validator/issues/816