### PR TITLE
ci: change url for PTV dataset in end_to_end 100

### DIFF
--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Validate dataset from -- MKV (Miskolc, Hungary)
         run: java -jar main/build/libs/*.jar --url http://transitfeeds.com/p/mvk-zrt/839/latest/download --output_base output --feed_name hu-mkv --storage_directory mkv.zip
       - name: Validate dataset from -- PTV (Melbourne, Australia)
-        run: java -jar main/build/libs/*.jar --url http://transitfeeds.com/p/ptv/497/latest/download --output_base output --feed_name au-ptv --storage_directory ptv.zip
+        run: java -jar main/build/libs/*.jar --url https://openmobilitydata.org/p/ptv/497/20210315/download --output_base output --feed_name au-ptv --storage_directory ptv.zip
       - name: Validate dataset from -- Pays de la Loire (France)
         run: java -jar main/build/libs/*.jar --url http://transitfeeds.com/p/region-des-pays-de-la-loire/1071/latest/download --output_base output --feed_name fr-loire --storage_directory loire.zip
       - name: Validate dataset from -- RATP (Paris, France)

--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Validate dataset from -- MKV (Miskolc, Hungary)
         run: java -jar main/build/libs/*.jar --url http://transitfeeds.com/p/mvk-zrt/839/latest/download --output_base output --feed_name hu-mkv --storage_directory mkv.zip
       - name: Validate dataset from -- PTV (Melbourne, Australia)
-        run: java -jar main/build/libs/*.jar --url https://openmobilitydata.org/p/ptv/497/20210315/download --output_base output --feed_name au-ptv --storage_directory ptv.zip
+        run: java -jar main/build/libs/*.jar --url https://transitfeeds.com/p/ptv/497/20210315/download --output_base output --feed_name au-ptv --storage_directory ptv.zip
       - name: Validate dataset from -- Pays de la Loire (France)
         run: java -jar main/build/libs/*.jar --url http://transitfeeds.com/p/region-des-pays-de-la-loire/1071/latest/download --output_base output --feed_name fr-loire --storage_directory loire.zip
       - name: Validate dataset from -- RATP (Paris, France)

--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -2,7 +2,7 @@ name: End to end 100
 
 on:
   push:
-    branches: [ master, extend-end-to-end ] #<-- replace extend-end-to-end by the name of the agency/publisher
+    branches: [ master, extend-end-to-end, fix-end-to-end-100 ] #<-- replace extend-end-to-end by the name of the agency/publisher
 
 jobs:
   run-on-data:

--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -2,7 +2,7 @@ name: End to end 100
 
 on:
   push:
-    branches: [ master, extend-end-to-end, fix-end-to-end-100 ] #<-- replace extend-end-to-end by the name of the agency/publisher
+    branches: [ master, extend-end-to-end ] #<-- replace extend-end-to-end by the name of the agency/publisher
 
 jobs:
   run-on-data:


### PR DESCRIPTION
Relates to #835 

**Summary:**

This PR changes the URL used to validate PTV's dataset (Melbourne) as a temporary bug fix.

**Expected behavior:** 

No OOM error. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- ~[ ] Linked all relevant issues~
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
