### PR TITLE
feat: Validate that combination of route names and type are unique wi…

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -557,7 +557,7 @@ At least one of the fields `is_producer`, `is_operator`, or `is_authority` shoul
 
 All routes of the same `route_type` with the same `agency_id` should have unique combinations of `route_short_name` and `route_long_name`.
 
-Note that there may be valid cases where routes have the same short and long name, e.g., if they serve difference areas. However, different directions must be modeled as the same route.
+Note that there may be valid cases where routes have the same short and long name, e.g., if they serve different areas. However, different directions must be modeled as the same route.
 
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)

--- a/RULES.md
+++ b/RULES.md
@@ -555,15 +555,9 @@ At least one of the fields `is_producer`, `is_operator`, or `is_authority` shoul
 
 #### DuplicateRouteNameNotice
 
-All routes should have different `routes.route_long_name` - if two `routes.route_long_name` are the same, and the two routes belong to the same agency, a notice is generated.
+All routes of the same `route_type` with the same `agency_id` should have unique combinations of `route_short_name` and `route_long_name`.
 
-Note that there may be valid cases where routes may have the same `routes.route_long_name` and this notice can be ignored. For example, routes may have the same `routes.route_long_name` if they serve difference areas. However, they must not be different trips of the same route or different directions of the same route - these cases should always have unique `routes.route_long_name`.
-
-All routes should have different `routes.route_short_name` - if two `routes.route_short_name` are the same, and the two routes belong to the same agency, a notice is generated.
-
-Note that there may be valid cases where routes may have the same `routes.route_short_name` and this notice can be ignored. For example, routes may have the same routes.route_short_name if they serve difference areas. However, they must not be different trips of the same route or different directions of the same route - these cases should always have unique `routes.route_short_name`.
-
-The same combination of `route_short_name` and `route_long_name` should not be used for more than one route.
+Note that there may be valid cases where routes have the same short and long name, e.g., if they serve difference areas. However, different directions must be modeled as the same route.
 
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -1,32 +1,36 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.table.GtfsRouteType.BUS;
+import static org.mobilitydata.gtfsvalidator.table.GtfsRouteType.LIGHT_RAIL;
 
 import com.google.common.collect.ImmutableList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
 import org.mobilitydata.gtfsvalidator.validator.DuplicateRouteNameValidator.DuplicateRouteNameNotice;
 
 public class DuplicateRouteNameValidatorTest {
 
-  private GtfsRoute createRoute(
+  private static GtfsRoute createRoute(
       int csvRowNumber,
       String routeId,
       String agencyId,
-      String shortName,
-      String longName,
-      int routeType) {
+      @Nullable String shortName,
+      @Nullable String longName,
+      GtfsRouteType routeType) {
     return new GtfsRoute.Builder()
         .setCsvRowNumber(csvRowNumber)
         .setRouteId(routeId)
         .setAgencyId(agencyId)
         .setRouteShortName(shortName)
         .setRouteLongName(longName)
-        .setRouteType(routeType)
+        .setRouteType(routeType.getNumber())
         .build();
   }
 
@@ -38,153 +42,77 @@ public class DuplicateRouteNameValidatorTest {
   }
 
   @Test
-  public void duplicateRouteLongNamesOfRoutesFromDifferentAgenciesShouldNotGenerateNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(
-                    createRoute(
-                        2, "1st route id value", "agency id", "short name", "duplicate value", 2),
-                    createRoute(
-                        4,
-                        "2nd route id value",
-                        "other agency id",
-                        "other short name",
-                        "duplicate value",
-                        3),
-                    createRoute(8, "3rd route id value", null, "another one", "duplicate value", 2),
-                    createRoute(
-                        8,
-                        "4th route id value",
-                        "agenCY ID",
-                        "other sname",
-                        "duplicate value",
-                        2))))
-        .isEmpty();
+  public void sameNamesTypeAgency_yieldsNotice() {
+    GtfsRoute route1 = createRoute(2, "route1", "agency1", "L1", "Dulwich Hill", LIGHT_RAIL);
+    GtfsRoute route2 = createRoute(3, "route2", "agency1", "L1", "Dulwich Hill", LIGHT_RAIL);
+    assertThat(generateNotices(ImmutableList.of(route1, route2)))
+        .containsExactly(new DuplicateRouteNameNotice(route1, route2));
   }
 
   @Test
-  public void duplicateRouteLongNamesOfRoutesFromSameAgencyShouldGenerateNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(
-                    createRoute(
-                        2, "1st route id value", "agency id", "short name", "duplicate value", 2),
-                    createRoute(
-                        4,
-                        "2nd route id value",
-                        "agency id",
-                        "other short name",
-                        "duplicate value",
-                        2),
-                    createRoute(
-                        8,
-                        "3rd route id value",
-                        "agency id",
-                        "another one",
-                        "duplicate value",
-                        2))))
+  public void manyRoutes_yieldsMultipleNotices() {
+    GtfsRoute route1 = createRoute(2, "route1", "agency1", "L1", "Dulwich Hill", LIGHT_RAIL);
+    GtfsRoute route2 = createRoute(3, "route2", "agency1", "L1", "Dulwich Hill", LIGHT_RAIL);
+    GtfsRoute route3 = createRoute(4, "route3", "agency1", "L1", "Dulwich Hill", LIGHT_RAIL);
+    assertThat(generateNotices(ImmutableList.of(route1, route2, route3)))
         .containsExactly(
-            new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"),
-            new DuplicateRouteNameNotice("route_long_name", 8, "3rd route id value"));
+            new DuplicateRouteNameNotice(route1, route2),
+            new DuplicateRouteNameNotice(route1, route3));
   }
 
   @Test
-  public void duplicateRouteShortNamesOfRoutesFromDifferentAgenciesShouldNotGenerateNotice() {
+  public void noShortNames_yieldsNotice() {
+    GtfsRoute route1 = createRoute(2, "route1", "agency1", null, "Dulwich Hill", LIGHT_RAIL);
+    GtfsRoute route2 = createRoute(3, "route2", "agency1", null, "Dulwich Hill", LIGHT_RAIL);
+    assertThat(generateNotices(ImmutableList.of(route1, route2)))
+        .containsExactly(new DuplicateRouteNameNotice(route1, route2));
+  }
+
+  @Test
+  public void noLongNames_yieldsNotice() {
+    GtfsRoute route1 = createRoute(2, "route1", "agency1", "L1", null, LIGHT_RAIL);
+    GtfsRoute route2 = createRoute(3, "route2", "agency1", "L1", null, LIGHT_RAIL);
+    assertThat(generateNotices(ImmutableList.of(route1, route2)))
+        .containsExactly(new DuplicateRouteNameNotice(route1, route2));
+  }
+
+  @Test
+  public void differentShortNames_yieldsNoNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(
-                    createRoute(
-                        2, "1st route id value", null, "duplicate value", "1st long name", 2),
-                    createRoute(
-                        4,
-                        "2nd route id value",
-                        "agency id",
-                        "duplicate value",
-                        "2nd long name",
-                        3),
-                    createRoute(
-                        8,
-                        "3rd route id value",
-                        "other agency id",
-                        "duplicate value",
-                        "3rd long name",
-                        3))))
+                    createRoute(2, "route1", "agency1", "L1", "North Line", LIGHT_RAIL),
+                    createRoute(2, "route2", "agency1", "L2", "North Line", LIGHT_RAIL))))
         .isEmpty();
   }
 
   @Test
-  public void duplicateRouteShortNamesOfRoutesFromSameAgencyShouldGenerateNotice() {
+  public void differentLongNames_yieldsNoNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(
-                    createRoute(
-                        2,
-                        "1st route id value",
-                        "agency id",
-                        "duplicate value",
-                        "1st long name",
-                        2),
-                    createRoute(
-                        4,
-                        "2nd route id value",
-                        "agency id",
-                        "duplicate value",
-                        "2nd long name",
-                        2),
-                    createRoute(
-                        8,
-                        "3rd route id value",
-                        "agency id",
-                        "duplicate value",
-                        "3rd long name",
-                        2))))
-        .containsExactly(
-            new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
-            new DuplicateRouteNameNotice("route_short_name", 8, "3rd route id value"));
-  }
-
-  @Test
-  public void uniqueRouteLongNameShouldNotGenerateNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(
-                    createRoute(2, "1st route id value", "agency id", null, "1st value", 2),
-                    createRoute(5, "4th route id value", "agency id", null, "1st value", 3),
-                    createRoute(4, "2nd route id value", "another agency id", null, "2nd value", 3),
-                    createRoute(8, "3rd route id value", "another one", null, "3rd value", 3))))
+                    createRoute(2, "route1", "agency1", "L1", "North Line", LIGHT_RAIL),
+                    createRoute(2, "route2", "agency1", "L1", "South Line", LIGHT_RAIL))))
         .isEmpty();
   }
 
   @Test
-  public void uniqueRouteShortNameShouldNotGenerateNotice() {
+  public void differentAgencies_yieldsNoNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(
-                    createRoute(2, "1st route id value", "agency id", "1st value", null, 2),
-                    createRoute(5, "4th route id value", "agency id", "1st value", null, 3),
-                    createRoute(4, "2nd route id value", "another agency id", "2nd value", null, 3),
-                    createRoute(8, "3rd route id value", "another one", "3rd value", null, 3))))
+                    createRoute(2, "route1", "agency1", "L1", "North Line", LIGHT_RAIL),
+                    createRoute(2, "route2", "agency2", "L1", "North Line", LIGHT_RAIL))))
         .isEmpty();
   }
 
   @Test
-  public void duplicateRouteNamesCombinationShouldGenerateNotice() {
+  public void differentTypes_yieldsNoNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(
-                    createRoute(2, "1st route id value", "agency id", "short name", "long name", 2),
-                    createRoute(
-                        5, "4th route id value", "agency id", "short name", "long value", 3),
-                    createRoute(4, "2nd route id value", "agency id", "short name", "long name", 2),
-                    createRoute(
-                        8,
-                        "3rd route id value",
-                        "agency id",
-                        "other short value",
-                        "other long name",
-                        3))))
-        .containsExactly(
-            new DuplicateRouteNameNotice("route_short_name", 4, "2nd route id value"),
-            new DuplicateRouteNameNotice("route_long_name", 4, "2nd route id value"));
+                    createRoute(2, "route1", "agency1", "L1", "North Line", LIGHT_RAIL),
+                    createRoute(2, "route2", "agency1", "L2", "North Line", BUS))))
+        .isEmpty();
   }
 }


### PR DESCRIPTION
…thin an agency

This logic corresponds to real-world use cases validated at Google for
all its production feeds.

Previous validation produced too many false positives because it ignored
route type and validated uniqueness of short and long names separately.
