### PR TITLE
feat: Provide enum setters and clearFIELD methods

### DIFF
--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
@@ -59,7 +59,7 @@ public class CalendarUtilTest {
     return new GtfsCalendarDate.Builder()
         .setServiceId(serviceId)
         .setDate(GtfsDate.fromLocalDate(date))
-        .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_ADDED.getNumber())
+        .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_ADDED)
         .build();
   }
 
@@ -67,7 +67,7 @@ public class CalendarUtilTest {
     return new GtfsCalendarDate.Builder()
         .setServiceId(serviceId)
         .setDate(GtfsDate.fromLocalDate(date))
-        .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_REMOVED.getNumber())
+        .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_REMOVED)
         .build();
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidatorTest.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.table.GtfsAttributionRole.ASSIGNED;
 
 import java.util.List;
 import org.junit.Test;
@@ -25,13 +26,10 @@ import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsAttribution;
-import org.mobilitydata.gtfsvalidator.table.GtfsAttributionRole;
 import org.mobilitydata.gtfsvalidator.validator.AttributionWithoutRoleValidator.AttributionWithoutRoleNotice;
 
 @RunWith(JUnit4.class)
 public class AttributionWithoutRoleValidatorTest {
-
-  private static final Integer ASSIGNED = GtfsAttributionRole.ASSIGNED.getNumber();
 
   private static List<ValidationNotice> generateNotices(GtfsAttribution attribution) {
     NoticeContainer noticeContainer = new NoticeContainer();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidatorTest.java
@@ -30,7 +30,7 @@ public class DuplicateRouteNameValidatorTest {
         .setAgencyId(agencyId)
         .setRouteShortName(shortName)
         .setRouteLongName(longName)
-        .setRouteType(routeType.getNumber())
+        .setRouteType(routeType)
         .build();
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidatorTest.java
@@ -46,7 +46,7 @@ public class LocationTypeSingleEntityValidatorTest {
             .setStopId("s0")
             .setCsvRowNumber(1)
             .setStopName("Stop 0")
-            .setLocationType(GtfsLocationType.STATION.getNumber());
+            .setLocationType(GtfsLocationType.STATION);
 
     assertThat(validateStop(builder.build())).isEmpty();
 
@@ -63,7 +63,7 @@ public class LocationTypeSingleEntityValidatorTest {
             .setStopId("s0")
             .setCsvRowNumber(1)
             .setStopName("Stop 0")
-            .setLocationType(GtfsLocationType.STOP.getNumber())
+            .setLocationType(GtfsLocationType.STOP)
             .setPlatformCode("1")
             .setParentStation("parent");
 
@@ -89,7 +89,7 @@ public class LocationTypeSingleEntityValidatorTest {
               .setStopId("s0")
               .setCsvRowNumber(1)
               .setStopName("Stop 0")
-              .setLocationType(locationType.getNumber())
+              .setLocationType(locationType)
               .setParentStation("parent");
 
       assertThat(validateStop(builder.build())).isEmpty();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
@@ -43,14 +43,14 @@ public class ParentLocationTypeValidatorTest {
                         .setCsvRowNumber(1)
                         .setStopId("child")
                         .setStopName("Child location")
-                        .setLocationType(childType.getNumber())
+                        .setLocationType(childType)
                         .setParentStation("parent")
                         .build(),
                     new GtfsStop.Builder()
                         .setCsvRowNumber(2)
                         .setStopId("parent")
                         .setStopName("Parent location")
-                        .setLocationType(parentType.getNumber())
+                        .setLocationType(parentType)
                         .build()),
                 noticeContainer))
         .validate(noticeContainer);
@@ -65,7 +65,7 @@ public class ParentLocationTypeValidatorTest {
                     new GtfsStop.Builder()
                         .setCsvRowNumber(1)
                         .setStopId("child")
-                        .setLocationType(locationType.getNumber())
+                        .setLocationType(locationType)
                         .build()),
                 noticeContainer))
         .validate(noticeContainer);

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/FieldNameConverter.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/FieldNameConverter.java
@@ -36,6 +36,10 @@ public final class FieldNameConverter {
     return "set" + StringUtils.capitalize(field);
   }
 
+  public static String clearMethodName(String field) {
+    return "clear" + StringUtils.capitalize(field);
+  }
+
   public static String hasMethodName(String field) {
     return "has" + StringUtils.capitalize(field);
   }


### PR DESCRIPTION
Entity Builder classes are used in two contexts:
* in autogenerated Loader classes;
* in unit tests.

Loader classes call setFieldName() methods that accept Integer. But for unit tests, it is more convenient to pass the enum.

```
    @Nonnull
    public GtfsPathway.Builder setPathwayMode(@Nullable Integer value) {
      if (value == null) {
        return clearPathwayMode();
      }
      pathwayMode = value;
      bitField0_ |= 0x8;
      return this;
    }

    @Nonnull
    public GtfsPathway.Builder setPathwayMode(@Nullable GtfsPathwayMode value) {
      return value == null ? clearPathwayMode() : setPathwayMode(value.getNumber());
    }

    @Nonnull
    public GtfsPathway.Builder clearPathwayMode() {
      pathwayMode = DEFAULT_PATHWAY_MODE;
      bitField0_ &= ~0x8;
      return this;
    }
```