### PR TITLE
feat: Make file headers available in CSV table containers

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,7 +43,6 @@ dependencies {
     implementation 'com.google.flogger:flogger:0.5.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"
-    testImplementation 'org.mockito:mockito-core:1.10.19'
 }
 
 test {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvHeader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvHeader.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.parsing;
+
+import com.google.common.base.Strings;
+import java.util.HashMap;
+import javax.annotation.Nullable;
+
+/** Read access to a header row in a CSV file. */
+public class CsvHeader {
+  private final HashMap<String, Integer> columnIndices = new HashMap<>();
+  private final String[] columnNames;
+
+  public static final CsvHeader EMPTY = new CsvHeader(null);
+
+  /**
+   * Creates a header for the given column names.
+   *
+   * <p>Empty or null columns names are treated as {@code ""}.
+   */
+  public CsvHeader(@Nullable String[] columnNames) {
+    this.columnNames = columnNames == null ? new String[] {} : columnNames;
+    for (int i = 0; i < this.columnNames.length; ++i) {
+      if (Strings.isNullOrEmpty(columnNames[i])) {
+        this.columnNames[i] = "";
+      } else {
+        columnIndices.putIfAbsent(columnNames[i], i);
+      }
+    }
+  }
+
+  /** Returns all columns in the table. */
+  public String[] getColumnNames() {
+    return columnNames;
+  }
+
+  /** Returns column name at given index, or null if the index is out of bounds. */
+  @Nullable
+  public String getColumnName(int columnIndex) {
+    if (columnIndex < 0 || columnIndex >= columnNames.length) {
+      return null;
+    }
+    return columnNames[columnIndex];
+  }
+
+  /** Returns the amount of columns. */
+  public int getColumnCount() {
+    return columnNames.length;
+  }
+
+  /**
+   * Returns index of a column with the given name, or -1 if there is no such column.
+   */
+  public int getColumnIndex(String columnName) {
+    return columnIndices.getOrDefault(columnName, -1);
+  }
+
+  /** Tells if a column with the given name exists. */
+  public boolean hasColumn(String columnName) {
+    return columnIndices.containsKey(columnName);
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvRow.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvRow.java
@@ -21,43 +21,21 @@ import javax.annotation.Nullable;
 
 /** Read access to a data row in a CSV file. */
 public class CsvRow {
-  private final CsvFile csvFile;
   private final long rowNumber;
   private final String[] columnValues;
 
-  public CsvRow(CsvFile csvFile, long rowNumber, String[] columnValues) {
-    this.csvFile = csvFile;
+  public CsvRow(long rowNumber, String[] columnValues) {
     this.rowNumber = rowNumber;
     this.columnValues = columnValues;
-  }
-
-  public CsvFile getCsvFile() {
-    return csvFile;
   }
 
   public long getRowNumber() {
     return rowNumber;
   }
 
-  public int getColumnIndex(String columnName) {
-    return csvFile.getColumnIndex(columnName);
-  }
-
+  /** Returns amount of columns in this row. */
   public int getColumnCount() {
     return columnValues.length;
-  }
-
-  public String getColumnName(int columnIndex) {
-    return csvFile.getColumnName(columnIndex);
-  }
-
-  /**
-   * Returns base name of the file that contains this row, e.g., "stops.txt".
-   *
-   * @return file name
-   */
-  public String getFileName() {
-    return csvFile.getFileName();
   }
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.table;
 
 import java.util.List;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 
 /**
  * Container for {@code GtfsEntity} instances for the whole GTFS table, e.g., stops.txt.
@@ -31,12 +32,19 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
 
   private final TableStatus tableStatus;
 
-  public GtfsTableContainer(TableStatus tableStatus) {
+  private final CsvHeader header;
+
+  public GtfsTableContainer(TableStatus tableStatus, CsvHeader header) {
     this.tableStatus = tableStatus;
+    this.header = header;
   }
 
   public TableStatus getTableStatus() {
     return tableStatus;
+  }
+
+  public CsvHeader getHeader() {
+    return header;
   }
 
   public abstract Class<T> getEntityClass();

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
@@ -26,25 +26,26 @@ import org.mobilitydata.gtfsvalidator.notice.EmptyColumnNameNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.UnknownColumnNotice;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 
 /** A validator that checks table headers for required columns etc. */
 public class TableHeaderValidator {
   public boolean validate(
       String filename,
-      String[] actualColumns,
+      CsvHeader actualHeader,
       Set<String> supportedColumns,
       Set<String> requiredColumns,
       NoticeContainer noticeContainer) {
     boolean isValid = true;
-    if (actualColumns.length == 0) {
+    if (actualHeader.getColumnCount() == 0) {
       // This is an empty file.
       return isValid;
     }
     Map<String, Integer> columnIndices = new HashMap<>();
     // Sorted tree set for stable order of notices.
     TreeSet<String> missingColumns = new TreeSet<>(requiredColumns);
-    for (int i = 0; i < actualColumns.length; ++i) {
-      String column = actualColumns[i];
+    for (int i = 0; i < actualHeader.getColumnCount(); ++i) {
+      String column = actualHeader.getColumnName(i);
       // Column indices are zero-based. We add 1 to make them 1-based.
       if (Strings.isNullOrEmpty(column)) {
         noticeContainer.addValidationNotice(new EmptyColumnNameNotice(filename, i + 1));

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvFileTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvFileTest.java
@@ -40,9 +40,10 @@ public class CsvFileTest {
   public void emptyFile() throws IOException {
     InputStream inputStream = toInputStream("");
     CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvHeader header = csvFile.getHeader();
 
     assertThat(csvFile.isEmpty()).isEqualTo(true);
-    assertThat(csvFile.getColumnCount()).isEqualTo(0);
+    assertThat(header.getColumnCount()).isEqualTo(0);
     assertThat(csvFile.getFileName()).isEqualTo("stops.txt");
     assertThat(csvFile.iterator().hasNext()).isEqualTo(false);
 
@@ -53,11 +54,12 @@ public class CsvFileTest {
   public void headersOnlyFile() throws IOException {
     InputStream inputStream = toInputStream("stop_id,stop_name");
     CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvHeader header = csvFile.getHeader();
 
     assertThat(csvFile.isEmpty()).isEqualTo(false);
-    assertThat(csvFile.getColumnCount()).isEqualTo(2);
-    assertThat(csvFile.getColumnName(0)).isEqualTo("stop_id");
-    assertThat(csvFile.getColumnIndex("stop_name")).isEqualTo(1);
+    assertThat(header.getColumnCount()).isEqualTo(2);
+    assertThat(header.getColumnName(0)).isEqualTo("stop_id");
+    assertThat(header.getColumnIndex("stop_name")).isEqualTo(1);
     assertThat(csvFile.getFileName()).isEqualTo("stops.txt");
     assertThat(csvFile.iterator().hasNext()).isEqualTo(false);
 
@@ -70,17 +72,17 @@ public class CsvFileTest {
         toInputStream(
             "stop_id,stop_name,stop_lat\n" + "s1,First stop,3.21\n" + "s2,Second stop,1.31\n");
     CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvHeader header = csvFile.getHeader();
 
     assertThat(csvFile.isEmpty()).isEqualTo(false);
-    assertThat(csvFile.getColumnCount()).isEqualTo(3);
-    assertThat(csvFile.getColumnName(0)).isEqualTo("stop_id");
-    assertThat(csvFile.getColumnIndex("stop_name")).isEqualTo(1);
+    assertThat(header.getColumnCount()).isEqualTo(3);
+    assertThat(header.getColumnName(0)).isEqualTo("stop_id");
+    assertThat(header.getColumnIndex("stop_name")).isEqualTo(1);
     assertThat(csvFile.getFileName()).isEqualTo("stops.txt");
 
     Iterator<CsvRow> iterator = csvFile.iterator();
     assertThat(iterator.hasNext()).isEqualTo(true);
     CsvRow row = iterator.next();
-    assertThat(row.getFileName()).isEqualTo("stops.txt");
     assertThat(row.asString(0)).isEqualTo("s1");
     assertThat(row.asString(2)).isEqualTo("3.21");
     assertThat(row.asString(200)).isNull();
@@ -104,17 +106,17 @@ public class CsvFileTest {
                 + "s1,First stop,3.21\r\n"
                 + "s2,Second stop,1.31\r\n");
     CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvHeader header = csvFile.getHeader();
 
     assertThat(csvFile.isEmpty()).isEqualTo(false);
-    assertThat(csvFile.getColumnCount()).isEqualTo(3);
-    assertThat(csvFile.getColumnName(0)).isEqualTo("stop_id");
-    assertThat(csvFile.getColumnIndex("stop_name")).isEqualTo(1);
+    assertThat(header.getColumnCount()).isEqualTo(3);
+    assertThat(header.getColumnName(0)).isEqualTo("stop_id");
+    assertThat(header.getColumnIndex("stop_name")).isEqualTo(1);
     assertThat(csvFile.getFileName()).isEqualTo("stops.txt");
 
     Iterator<CsvRow> iterator = csvFile.iterator();
     assertThat(iterator.hasNext()).isEqualTo(true);
     CsvRow row = iterator.next();
-    assertThat(row.getFileName()).isEqualTo("stops.txt");
     assertThat(row.asString(0)).isEqualTo("s1");
     assertThat(row.asString(2)).isEqualTo("3.21");
     assertThat(row.asString(200)).isNull();
@@ -164,8 +166,9 @@ public class CsvFileTest {
                 ByteOrderMark.UTF_8.getBytes(),
                 ("stop_id,stop_name\n" + "s1,First stop\n").getBytes(StandardCharsets.UTF_8)));
     CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
+    CsvHeader header = csvFile.getHeader();
 
-    assertThat(csvFile.getColumnNames()).asList().containsExactly("stop_id", "stop_name");
+    assertThat(header.getColumnNames()).asList().containsExactly("stop_id", "stop_name");
 
     Iterator<CsvRow> iterator = csvFile.iterator();
     assertThat(iterator.hasNext()).isEqualTo(true);

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvHeaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvHeaderTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.parsing;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public final class CsvHeaderTest {
+  @Test
+  public void nonEmpty() {
+    CsvHeader header = new CsvHeader(new String[] {"stop_id", "stop_name", "stop_code"});
+    assertThat(header.getColumnCount()).isEqualTo(3);
+    assertThat(header.getColumnIndex("stop_id")).isEqualTo(0);
+    assertThat(header.getColumnIndex("stop_name")).isEqualTo(1);
+    assertThat(header.getColumnIndex("stop_code")).isEqualTo(2);
+    assertThat(header.getColumnIndex("agency_id")).isEqualTo(-1);
+    assertThat(header.hasColumn("stop_id")).isTrue();
+    assertThat(header.hasColumn("agency_id")).isFalse();
+    assertThat(header.getColumnName(1)).isEqualTo("stop_name");
+    assertThat(header.getColumnNames())
+        .asList()
+        .containsExactly("stop_id", "stop_name", "stop_code");
+  }
+
+  @Test
+  public void empty() {
+    CsvHeader header = new CsvHeader(new String[] {});
+    assertThat(header.getColumnCount()).isEqualTo(0);
+    assertThat(header.getColumnIndex("stop_id")).isEqualTo(-1);
+    assertThat(header.hasColumn("agency_id")).isFalse();
+    assertThat(header.getColumnNames()).isEmpty();
+  }
+
+  @Test
+  public void nullColumn() {
+    CsvHeader header = new CsvHeader(new String[] {null, ""});
+    assertThat(header.getColumnCount()).isEqualTo(2);
+    assertThat(header.getColumnIndex("")).isEqualTo(-1);
+    assertThat(header.getColumnNames()).asList().containsExactly("", "");
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvRowTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/CsvRowTest.java
@@ -18,57 +18,19 @@ package org.mobilitydata.gtfsvalidator.parsing;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class CsvRowTest {
-
-  private static InputStream toInputStream(String s) {
-    return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
-  }
-
   @Test
-  public void testCsvRowAllMethods() throws IOException {
-    InputStream inputStream =
-        toInputStream(
-            "stop_id,stop_name,stop_lat\n" + "s1,First stop,3.21\n" + "s2,Second stop,1.31\n");
-    CsvFile csvFile = new CsvFile(inputStream, "stops.txt");
-    inputStream.close();
-
-    String[] columnValues = {
-      "stop_id",
-      "stop_code",
-      "stop_name",
-      "tts_stop_name",
-      "stop_desc",
-      "stop_lat",
-      "stop_lon",
-      "location_type",
-      "parent_station",
-      "stop_timezone",
-      "wheelchair_boarding",
-      "level_id",
-      "platform_code"
-    };
-
-    CsvRow underTest = new CsvRow(csvFile, 3, columnValues);
+  public void testCsvRowAllMethods() {
+    CsvRow underTest = new CsvRow(3, new String[] {"stop_id", "stop_code", ""});
 
     assertThat(underTest.getRowNumber()).isEqualTo(3);
-    assertThat(underTest.getColumnIndex("stop_name")).isEqualTo(1);
-    assertThat(underTest.getColumnIndex("location_type")).isEqualTo(-1);
-    assertThat(underTest.getColumnCount()).isEqualTo(13);
-    assertThat(underTest.getColumnName(0)).isEqualTo("stop_id");
-    assertThat(underTest.getColumnName(1)).isEqualTo("stop_name");
-    assertThat(underTest.getColumnName(2)).isEqualTo("stop_lat");
-    assertThat(underTest.getFileName()).isEqualTo("stops.txt");
     assertThat(underTest.asString(0)).isEqualTo("stop_id");
     assertThat(underTest.asString(1)).isEqualTo("stop_code");
-    assertThat(underTest.asString(2)).isEqualTo("stop_name");
+    assertThat(underTest.asString(2)).isNull();
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
@@ -27,6 +27,7 @@ import org.mobilitydata.gtfsvalidator.notice.EmptyColumnNameNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.UnknownColumnNotice;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 
 @RunWith(JUnit4.class)
 public class TableHeaderValidatorTest {
@@ -38,7 +39,7 @@ public class TableHeaderValidatorTest {
             new TableHeaderValidator()
                 .validate(
                     "stops.txt",
-                    new String[] {"stop_id", "stop_name"},
+                    new CsvHeader(new String[] {"stop_id", "stop_name"}),
                     ImmutableSet.of("stop_id", "stop_name", "stop_lat", "stop_lon"),
                     ImmutableSet.of("stop_id"),
                     container))
@@ -54,7 +55,7 @@ public class TableHeaderValidatorTest {
             new TableHeaderValidator()
                 .validate(
                     "stops.txt",
-                    new String[] {"stop_id", "stop_name", "stop_extra"},
+                    new CsvHeader(new String[] {"stop_id", "stop_name", "stop_extra"}),
                     ImmutableSet.of("stop_id", "stop_name"),
                     ImmutableSet.of("stop_id"),
                     container))
@@ -71,7 +72,7 @@ public class TableHeaderValidatorTest {
             new TableHeaderValidator()
                 .validate(
                     "stops.txt",
-                    new String[] {"stop_name"},
+                    new CsvHeader(new String[] {"stop_name"}),
                     ImmutableSet.of("stop_id", "stop_name"),
                     ImmutableSet.of("stop_id"),
                     container))
@@ -88,7 +89,7 @@ public class TableHeaderValidatorTest {
             new TableHeaderValidator()
                 .validate(
                     "stops.txt",
-                    new String[] {"stop_id", "stop_name", "stop_id"},
+                    new CsvHeader(new String[] {"stop_id", "stop_name", "stop_id"}),
                     ImmutableSet.of("stop_id", "stop_name"),
                     ImmutableSet.of("stop_id"),
                     container))
@@ -105,7 +106,7 @@ public class TableHeaderValidatorTest {
             new TableHeaderValidator()
                 .validate(
                     "stops.txt",
-                    new String[] {},
+                    CsvHeader.EMPTY,
                     ImmutableSet.of("stop_id", "stop_name"),
                     ImmutableSet.of("stop_id"),
                     container))
@@ -121,7 +122,7 @@ public class TableHeaderValidatorTest {
             new TableHeaderValidator()
                 .validate(
                     "stops.txt",
-                    new String[] {"stop_id", null, "stop_name", ""},
+                    new CsvHeader(new String[] {"stop_id", null, "stop_name", ""}),
                     ImmutableSet.of("stop_id", "stop_name"),
                     ImmutableSet.of("stop_id"),
                     container))

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -45,6 +45,7 @@ import org.mobilitydata.gtfsvalidator.notice.EmptyFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvFile;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.parsing.CsvRow;
 import org.mobilitydata.gtfsvalidator.parsing.FieldCache;
 import org.mobilitydata.gtfsvalidator.parsing.RowParser;
@@ -226,8 +227,9 @@ public class TableLoaderGenerator {
                     + " noticeContainer)")
             .addStatement("return table")
             .endControlFlow()
+            .addStatement("$T header = csvFile.getHeader()", CsvHeader.class)
             .beginControlFlow(
-                "if (!new $T().validate(FILENAME, csvFile.getColumnNames(), "
+                "if (!new $T().validate(FILENAME, header, "
                     + "getColumnNames(), getRequiredColumnNames(), noticeContainer))",
                 TableHeaderValidator.class)
             .addStatement(
@@ -236,7 +238,7 @@ public class TableLoaderGenerator {
 
     for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
       method.addStatement(
-          "final int $L = csvFile.getColumnIndex($L)",
+          "final int $L = header.getColumnIndex($L)",
           fieldColumnIndex(field.name()),
           fieldNameField(field.name()));
     }
@@ -260,7 +262,8 @@ public class TableLoaderGenerator {
     method
         .addStatement("final $T.Builder builder = new $T.Builder()", gtfsEntityType, gtfsEntityType)
         .addStatement(
-            "final $T rowParser = new $T(validationContext.feedName(), noticeContainer)",
+            "final $T rowParser = new $T(FILENAME, header, validationContext.feedName(),"
+                + " noticeContainer)",
             RowParser.class,
             RowParser.class)
         .addStatement(
@@ -349,7 +352,7 @@ public class TableLoaderGenerator {
             "return new $T($T.UNPARSABLE_ROWS)", tableContainerTypeName, TableStatus.class)
         .nextControlFlow("else")
         .addStatement(
-            "$T table = $T.forEntities(entities, noticeContainer)",
+            "$T table = $T.forHeaderAndEntities(header, entities, noticeContainer)",
             tableContainerTypeName,
             tableContainerTypeName)
         .addStatement(


### PR DESCRIPTION
Some validation rules may need to check whether a certain column is
present. E.g., this can allow them to skip further validation.

Unit tests are simplified and mocks are removed.