### PR TITLE
feat: make report names user configurable via CLI args

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -34,7 +34,7 @@ java -jar gtfs-validator-v2.0.jar --input relative/path/to/dataset.zip --output 
  1. Validate the GTFS data and output the results to the directory located at `relative/output/path`. 
  1. Export both validation and system errors reports to JSON by default. This folder will contain the `.json` file with information related to the validation process. The validation report will (by default) be named as `report.json` and the system errors report can be found under the name of `system_errors.json`.
  
-  ⚠️ Note that reports naming can be overridden by providing values to `-v` and/or `-e` CLI arguments. These **must** include `.json` file extension.
+  ⚠️ Note that reports naming can be overridden by providing values to `-v` and/or `-e` CLI arguments. These **should** include `.json` extension.
 
 ### on a hosted GTFS zip file at a URL
 Sample usage:

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -7,14 +7,16 @@
 ## via cli-app
 **Full list of command line parameters available**
 
-| Short name 	| Long name             	| required? 	| Description                                                                                                               	|
-|------------	|-----------------------	|-----------	|---------------------------------------------------------------------------------------------------------------------------	|
-| `-i`       	| `--input`             	| Optional   	| Location of the input GTFS ZIP or unarchived directory.                                                                   	|
-| `-f`       	| `--feed_name`         	| Required    	| Name of the feed, e.g., `nl-openov`. It must start from two-letter country code (ISO 3166-1 alpha-2).                     	|
-| `-o`       	| `--output`            	| Optional   	| Base directory to store the outputs.                                                                                      	|
-| `-s`       	| `--storage_directory` 	| Optional   	| Target path where to store the GTFS archive. Downloaded from network (if not provided, the ZIP will be stored in memory). 	|
-| `-t`       	| `--threads`           	| Optional   	| Number of threads to use.                                                                                                 	|
-| `-u`       	| `--url`               	| Optional   	| Fully qualified URL to download GTFS archive.                                                                             	|
+| Short name 	| Long name                     	| required? 	| Description                                                                                                               	|
+|------------	|-------------------------------	|-----------	|---------------------------------------------------------------------------------------------------------------------------	|
+| `-i`       	| `--input`                     	| Optional  	| Location of the input GTFS ZIP or unarchived directory.                                                                   	|
+| `-f`       	| `--feed_name`                 	| Required  	| Name of the feed, e.g., `nl-openov`. It must start from two-letter country code (ISO 3166-1 alpha-2).                     	|
+| `-o`       	| `--output`                    	| Optional  	| Base directory to store the outputs.                                                                                      	|
+| `-s`       	| `--storage_directory`         	| Optional  	| Target path where to store the GTFS archive. Downloaded from network (if not provided, the ZIP will be stored in memory). 	|
+| `-t`       	| `--threads`                   	| Optional  	| Number of threads to use.                                                                                                 	|
+| `-u`       	| `--url`                       	| Optional  	| Fully qualified URL to download GTFS archive.                                                                             	|
+| `-v`       	| `--validation_report_name`    	| Optional  	| Name of the validation report (including `.json` extension).                                                              	|
+| `-e`       	| `--system_errors_report_name` 	| Optional  	| Name of the system errors report (including `.json` extension).                                                             	|
 
 ⚠️ Note that exactly one of the following options must be provided: `--url` or `--input`.
 
@@ -30,7 +32,9 @@ java -jar gtfs-validator-v2.0.jar --input relative/path/to/dataset.zip --output 
 ...which will:
  1. Search for a GTFS dataset located at `relative/path/to/dataset.zip`
  1. Validate the GTFS data and output the results to the directory located at `relative/output/path`. 
- 1. Export both validation and system errors reports to JSON by default. This folder will contain the `.json` file with information related to the validation process. The validation report will be named as `report.json` and the system errors report can be found under the name of `system_errors.json`. 
+ 1. Export both validation and system errors reports to JSON by default. This folder will contain the `.json` file with information related to the validation process. The validation report will (by default) be named as `report.json` and the system errors report can be found under the name of `system_errors.json`.
+ 
+  ⚠️ Note that reports naming can be overridden by providing values to `-v` and/or `-e` CLI arguments. These **must** include `.json` file extension.
 
 ### on a hosted GTFS zip file at a URL
 Sample usage:

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -56,6 +56,16 @@ public class Arguments {
               + "downloaded from network (if not provided, the ZIP will be stored in memory)")
   private String storageDirectory;
 
+  @Parameter(
+      names = {"-v", "--validation_report_name"},
+      description = "The name of the validation report including .json extension.")
+  private String validationReportName;
+
+  @Parameter(
+      names = {"-e", "--system_errors_report_name"},
+      description = "The name of the system errors report including .json extension.")
+  private String systemErrorsReportName;
+
   public String getInput() {
     return input;
   }
@@ -78,5 +88,19 @@ public class Arguments {
 
   public String getStorageDirectory() {
     return storageDirectory;
+  }
+
+  public String getValidationReportName() {
+    if (validationReportName == null) {
+      return "report.json";
+    }
+    return validationReportName;
+  }
+
+  public String getSystemErrorsReportName() {
+    if (systemErrorsReportName == null) {
+      return "system_errors.json";
+    }
+    return systemErrorsReportName;
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -91,7 +91,7 @@ public class Main {
       noticeContainer.addSystemError(new ThreadInterruptedError(e.getMessage()));
     }
     if (gtfsInput == null) {
-      exportReport(args.getOutputBase(), noticeContainer);
+      exportReport(noticeContainer, args);
       return;
     }
     ValidationContext validationContext =
@@ -103,7 +103,7 @@ public class Main {
         feedLoader.loadAndValidate(gtfsInput, validationContext, validatorLoader, noticeContainer);
 
     // Output
-    exportReport(args.getOutputBase(), noticeContainer);
+    exportReport(noticeContainer, args);
     final long endNanos = System.nanoTime();
     if (!feedContainer.isParsedSuccessfully()) {
       System.out.println(" ----------------------------------------- ");
@@ -117,14 +117,14 @@ public class Main {
   }
 
   /** Generates and exports reports for both validation notices and system errors reports. */
-  private static void exportReport(final String outputBase, final NoticeContainer noticeContainer) {
-    new File(outputBase).mkdirs();
+  private static void exportReport(final NoticeContainer noticeContainer, final Arguments args) {
+    new File(args.getOutputBase()).mkdirs();
     try {
       Files.write(
-          Paths.get(outputBase, "report.json"),
+          Paths.get(args.getOutputBase(), args.getValidationReportName()),
           noticeContainer.exportValidationNotices().getBytes(StandardCharsets.UTF_8));
       Files.write(
-          Paths.get(outputBase, "system_errors.json"),
+          Paths.get(args.getOutputBase(), args.getSystemErrorsReportName()),
           noticeContainer.exportSystemErrors().getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -37,8 +37,10 @@ public class ArgumentsTest {
     assertThat(underTest.getOutputBase()).matches("output value");
     assertThat(underTest.getFeedName()).matches("feed name value");
     assertThat(underTest.getNumThreads()).isEqualTo(4);
+    assertThat(underTest.getValidationReportName()).matches("report.json");
+    assertThat(underTest.getSystemErrorsReportName()).matches("system_errors.json");
 
-    // same test using -u and -s command line options
+    // same test using -u, -s, -v and -e command line options
     commandLineArgumentAsStringArray =
         new String[] {
           "-o", "output value",
@@ -46,6 +48,8 @@ public class ArgumentsTest {
           "-t", "4",
           "-u", "url value",
           "-s", "storage value",
+          "-v", "validation_report.json",
+          "-e", "errors.json",
         };
 
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
@@ -54,6 +58,8 @@ public class ArgumentsTest {
     assertThat(underTest.getNumThreads()).isEqualTo(4);
     assertThat(underTest.getUrl()).matches("url value");
     assertThat(underTest.getStorageDirectory()).matches("storage value");
+    assertThat(underTest.getValidationReportName()).matches("validation_report.json");
+    assertThat(underTest.getSystemErrorsReportName()).matches("errors.json");
   }
 
   @Test
@@ -70,8 +76,10 @@ public class ArgumentsTest {
     assertThat(underTest.getOutputBase()).matches("output value");
     assertThat(underTest.getFeedName()).matches("feed name value");
     assertThat(underTest.getNumThreads()).isEqualTo(4);
+    assertThat(underTest.getValidationReportName()).matches("report.json");
+    assertThat(underTest.getSystemErrorsReportName()).matches("system_errors.json");
 
-    // same test using -u and -s command line options
+    // same test using -u, -s, -v and -e command line options
     commandLineArgumentAsStringArray =
         new String[] {
           "--output_base", "output value",
@@ -79,6 +87,8 @@ public class ArgumentsTest {
           "--threads", "4",
           "--url", "url value",
           "--storage_directory", "storage value",
+          "--validation_report_name", "validation_report.json",
+          "--system_errors_report_name", "errors.json",
         };
 
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
@@ -87,6 +97,8 @@ public class ArgumentsTest {
     assertThat(underTest.getNumThreads()).isEqualTo(4);
     assertThat(underTest.getUrl()).matches("url value");
     assertThat(underTest.getStorageDirectory()).matches("storage value");
+    assertThat(underTest.getValidationReportName()).matches("validation_report.json");
+    assertThat(underTest.getSystemErrorsReportName()).matches("errors.json");
   }
 
   @Test


### PR DESCRIPTION
**Summary:**

This PR provides support to override naming of report outputs.

**Expected behavior:** 

Additional CLI args : 
* `-v` or `--validation_report_name` - the value given to this CLI args should include `.json` extension;
* `-e` or `system_errors_report_name` - the value given to this CLI args should include `.json` extension.

If provided: the reports will be named as defined by the user, else a default value are used: 
* `report.json` for the validation report
* `system_errors.json` for the error report

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- ~[ ] Linked all relevant issues~
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
