### PR TITLE
feat: Dependency injection with ValidatorProvider

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -81,4 +81,16 @@ public abstract class Notice {
   public int hashCode() {
     return Objects.hash(getClass(), getContext(), getSeverityLevel());
   }
+
+  /**
+   * Tells if this notice is an {@code ERROR}.
+   *
+   * <p>This method is preferred to checking {@code severityLevel} directly since more levels may be
+   * added in the future.
+   *
+   * @return true if this notice is an error, false otherwise
+   */
+  public boolean isError() {
+    return getSeverityLevel().ordinal() >= SeverityLevel.ERROR.ordinal();
+  }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -112,4 +112,18 @@ public class NoticeContainer {
     validationNotices.addAll(otherContainer.validationNotices);
     systemErrors.addAll(otherContainer.systemErrors);
   }
+
+  /**
+   * Tells if this container has any {@code ValidationNotice} that is an error.
+   *
+   * <p>Note that this method is O(n) since it iterates over all validation notices.
+   */
+  public boolean hasValidationErrors() {
+    for (ValidationNotice notice : validationNotices) {
+      if (notice.isError()) {
+        return true;
+      }
+    }
+    return false;
+  }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableLoader.java
@@ -19,8 +19,7 @@ package org.mobilitydata.gtfsvalidator.table;
 import java.io.InputStream;
 import java.util.Set;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
-import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorProvider;
 
 /**
  * Loader for a single GTFS table, e.g., stops.txt.
@@ -41,12 +40,9 @@ public abstract class GtfsTableLoader<T extends GtfsEntity> {
 
   public abstract GtfsTableContainer<T> load(
       InputStream inputStream,
-      ValidationContext validationContext,
-      ValidatorLoader validatorLoader,
+      ValidatorProvider validatorProvider,
       NoticeContainer noticeContainer);
 
   public abstract GtfsTableContainer<T> loadMissingFile(
-      ValidationContext validationContext,
-      ValidatorLoader validatorLoader,
-      NoticeContainer noticeContainer);
+      ValidatorProvider validatorProvider, NoticeContainer noticeContainer);
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.i18n.phonenumbers.PhoneNumberUtil;
+import org.apache.commons.validator.routines.EmailValidator;
+import org.apache.commons.validator.routines.UrlValidator;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.InvalidEmailNotice;
+import org.mobilitydata.gtfsvalidator.notice.InvalidPhoneNumberNotice;
+import org.mobilitydata.gtfsvalidator.notice.InvalidUrlNotice;
+import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NewLineInValueNotice;
+import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+
+/** Default implementation of {@link GtfsFieldValidator}. */
+public class DefaultFieldValidator implements GtfsFieldValidator {
+
+  private final CountryCode countryCode;
+
+  public DefaultFieldValidator(CountryCode countryCode) {
+    this.countryCode = countryCode;
+  }
+
+  @Override
+  public String validateField(
+      String fieldValue, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
+    if (fieldValue.indexOf('\n') != -1 || fieldValue.indexOf('\r') != -1) {
+      noticeContainer.addValidationNotice(
+          new NewLineInValueNotice(
+              cellContext.filename(),
+              cellContext.csvRowNumber(),
+              cellContext.fieldName(),
+              fieldValue));
+    }
+    final String trimmed = fieldValue.trim();
+    if (trimmed.length() < fieldValue.length()) {
+      noticeContainer.addValidationNotice(
+          new LeadingOrTrailingWhitespacesNotice(
+              cellContext.filename(),
+              cellContext.csvRowNumber(),
+              cellContext.fieldName(),
+              fieldValue));
+      return trimmed;
+    }
+    return fieldValue;
+  }
+
+  @Override
+  public boolean validateId(
+      String id, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
+    if (!hasOnlyPrintableAscii(id)) {
+      noticeContainer.addValidationNotice(
+          new NonAsciiOrNonPrintableCharNotice(
+              cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), id));
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean validateUrl(
+      String url, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
+    if (!UrlValidator.getInstance().isValid(url)) {
+      noticeContainer.addValidationNotice(
+          new InvalidUrlNotice(
+              cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), url));
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean validateEmail(
+      String email, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
+    if (!EmailValidator.getInstance().isValid(email)) {
+      noticeContainer.addValidationNotice(
+          new InvalidEmailNotice(
+              cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), email));
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean validatePhoneNumber(
+      String phoneNumber, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
+    if (!PhoneNumberUtil.getInstance()
+        .isPossibleNumber(phoneNumber, countryCode.getCountryCode())) {
+      noticeContainer.addValidationNotice(
+          new InvalidPhoneNumberNotice(
+              cellContext.filename(),
+              cellContext.csvRowNumber(),
+              cellContext.fieldName(),
+              phoneNumber));
+      return false;
+    }
+    return true;
+  }
+
+  static boolean hasOnlyPrintableAscii(String s) {
+    for (int i = 0, n = s.length(); i < n; ++i) {
+      if (!(s.charAt(i) >= 32 && s.charAt(i) < 127)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.base.Strings;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.mobilitydata.gtfsvalidator.notice.DuplicatedColumnNotice;
+import org.mobilitydata.gtfsvalidator.notice.EmptyColumnNameNotice;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.UnknownColumnNotice;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+
+/** Default implementation of {@code TableHeaderValidator}. */
+public class DefaultTableHeaderValidator implements TableHeaderValidator {
+  @Override
+  public boolean validate(
+      String filename,
+      CsvHeader actualHeader,
+      Set<String> supportedColumns,
+      Set<String> requiredColumns,
+      NoticeContainer noticeContainer) {
+    boolean isValid = true;
+    if (actualHeader.getColumnCount() == 0) {
+      // This is an empty file.
+      return isValid;
+    }
+    Map<String, Integer> columnIndices = new HashMap<>();
+    // Sorted tree set for stable order of notices.
+    TreeSet<String> missingColumns = new TreeSet<>(requiredColumns);
+    for (int i = 0; i < actualHeader.getColumnCount(); ++i) {
+      String column = actualHeader.getColumnName(i);
+      // Column indices are zero-based. We add 1 to make them 1-based.
+      if (Strings.isNullOrEmpty(column)) {
+        noticeContainer.addValidationNotice(new EmptyColumnNameNotice(filename, i + 1));
+        continue;
+      }
+      Integer prev = columnIndices.putIfAbsent(column, i);
+      if (prev != null) {
+        noticeContainer.addValidationNotice(
+            new DuplicatedColumnNotice(filename, column, prev + 1, i + 1));
+        isValid = false;
+      }
+      if (!supportedColumns.contains(column)) {
+        noticeContainer.addValidationNotice(new UnknownColumnNotice(filename, column, i + 1));
+      }
+      missingColumns.remove(column);
+    }
+    if (!missingColumns.isEmpty()) {
+      isValid = false;
+      for (String column : missingColumns) {
+        noticeContainer.addValidationNotice(new MissingRequiredColumnNotice(filename, column));
+      }
+    }
+    return isValid;
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.ListMultimap;
+import com.google.common.flogger.FluentLogger;
+import java.util.ArrayList;
+import java.util.List;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+
+/** Default implementation of {@link ValidatorProvider}. */
+public class DefaultValidatorProvider implements ValidatorProvider {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  private final ValidationContext validationContext;
+  private final GtfsFieldValidator fieldValidator;
+  private final TableHeaderValidator tableHeaderValidator;
+  private final ListMultimap<Class<? extends GtfsEntity>, Class<? extends SingleEntityValidator<?>>>
+      singleEntityValidators;
+  private final ListMultimap<Class<? extends GtfsTableContainer>, Class<? extends FileValidator>>
+      singleFileValidators;
+  private final List<Class<? extends FileValidator>> multiFileValidators;
+
+  /** Creates a validator provider that uses given validators. */
+  public DefaultValidatorProvider(
+      ValidationContext validationContext,
+      ValidatorLoader validatorLoader,
+      GtfsFieldValidator fieldValidator,
+      TableHeaderValidator tableHeaderValidator) {
+    this.validationContext = validationContext;
+    this.fieldValidator = fieldValidator;
+    this.tableHeaderValidator = tableHeaderValidator;
+    this.singleEntityValidators = validatorLoader.getSingleEntityValidators();
+    this.singleFileValidators = validatorLoader.getSingleFileValidators();
+    this.multiFileValidators = validatorLoader.getMultiFileValidators();
+  }
+
+  /** Creates a validator provider that uses default validators for fields and headers. */
+  public DefaultValidatorProvider(
+      ValidationContext validationContext, ValidatorLoader validatorLoader) {
+    this(
+        validationContext,
+        validatorLoader,
+        new DefaultFieldValidator(validationContext.countryCode()),
+        new DefaultTableHeaderValidator());
+  }
+
+  @Override
+  public GtfsFieldValidator getFieldValidator() {
+    return fieldValidator;
+  }
+
+  @Override
+  public TableHeaderValidator getTableHeaderValidator() {
+    return tableHeaderValidator;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public <T extends GtfsEntity> List<SingleEntityValidator<T>> createSingleEntityValidators(
+      Class<T> clazz) {
+    List<SingleEntityValidator<T>> validators = new ArrayList<>();
+    for (Class<? extends SingleEntityValidator<?>> validatorClass :
+        singleEntityValidators.get(clazz)) {
+      try {
+        validators.add(
+            ValidatorLoader.createValidatorWithContext(
+                ((Class<? extends SingleEntityValidator<T>>) validatorClass), validationContext));
+      } catch (ReflectiveOperationException e) {
+        logger.atSevere().withCause(e).log(
+            "Cannot instantiate validator %s", validatorClass.getCanonicalName());
+      }
+    }
+    return validators;
+  }
+
+  @Override
+  public <T extends GtfsEntity> List<FileValidator> createSingleFileValidators(
+      GtfsTableContainer<T> table) {
+    List<FileValidator> validators = new ArrayList<>();
+    for (Class<? extends FileValidator> validatorClass :
+        singleFileValidators.get(table.getClass())) {
+      try {
+        validators.add(
+            ValidatorLoader.createSingleFileValidator(validatorClass, table, validationContext));
+      } catch (ReflectiveOperationException e) {
+        logger.atSevere().withCause(e).log(
+            "Cannot instantiate validator %s", validatorClass.getCanonicalName());
+        continue;
+      }
+    }
+    return validators;
+  }
+
+  @Override
+  public List<FileValidator> createMultiFileValidators(GtfsFeedContainer feed) {
+    ArrayList<FileValidator> validators = new ArrayList<>();
+    validators.ensureCapacity(multiFileValidators.size());
+    for (Class<? extends FileValidator> validatorClass : multiFileValidators) {
+      try {
+        validators.add(
+            ValidatorLoader.createMultiFileValidator(validatorClass, feed, validationContext));
+      } catch (ReflectiveOperationException e) {
+        logger.atSevere().withCause(e).log(
+            "Cannot instantiate validator %s", validatorClass.getCanonicalName());
+      }
+    }
+    return validators;
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsCellContext.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsCellContext.java
@@ -16,21 +16,22 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
-import java.util.Set;
-import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
-import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import com.google.auto.value.AutoValue;
 
-/** A validator that checks table headers for required columns etc. */
-public interface TableHeaderValidator {
-  /**
-   * Validates header of a single GTFS CSV table.
-   *
-   * @return true is the header is valid, false otherwise
-   */
-  boolean validate(
-      String filename,
-      CsvHeader actualHeader,
-      Set<String> supportedColumns,
-      Set<String> requiredColumns,
-      NoticeContainer noticeContainer);
+/** Context describing a cell in a GTFS file. */
+@AutoValue
+public abstract class GtfsCellContext {
+  /** Name of a GTFS file. */
+  public abstract String filename();
+
+  /** Number of a row in the GTFS file. */
+  public abstract long csvRowNumber();
+
+  /** Name of a field in the GTFS file. */
+  public abstract String fieldName();
+
+  /** Creates a context that describes a cell in a GTFS file. */
+  public static GtfsCellContext create(String filename, long csvRowNumber, String fieldName) {
+    return new AutoValue_GtfsCellContext(filename, csvRowNumber, fieldName);
+  }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsFieldValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsFieldValidator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+
+/**
+ * Validator for a single field in a GTFS file.
+ *
+ * <p>All methods of this validator store notices in the provided container.
+ */
+public interface GtfsFieldValidator {
+
+  /**
+   * Validates a single field of any type.
+   *
+   * <p>This validation performs common checks that do not depend on field type.
+   *
+   * <p>This function returns a possibly updated and fixed content for that field, e.g., with
+   * stripped trailing and leading whitespaces.
+   */
+  String validateField(
+      String fieldValue, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+
+  /**
+   * Validates an ID field.
+   *
+   * @return true if the value is valid, false otherwise
+   */
+  boolean validateId(String id, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+
+  /**
+   * Validates a URL field.
+   *
+   * @return true if the value is valid, false otherwise
+   */
+  boolean validateUrl(String url, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+
+  /**
+   * Validates an e-mail field.
+   *
+   * @return true if the value is valid, false otherwise
+   */
+  boolean validateEmail(String email, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+
+  /**
+   * Validates a phone number field.
+   *
+   * @return true if the value is valid, false otherwise
+   */
+  boolean validatePhoneNumber(
+      String phoneNumber, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import java.util.List;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+
+/**
+ * Provider of all kinds of validators for fields, entities and files.
+ *
+ * <p>A {@code ValidatorProvider} is a handy pack of validators passed to different parts of the
+ * system. Unit tests and users may provide their own implementations of {@code ValidatorProvider}.
+ */
+public interface ValidatorProvider {
+  /** Returns a validator for individual fields. */
+  GtfsFieldValidator getFieldValidator();
+
+  /** Returns a validator for table headers. */
+  TableHeaderValidator getTableHeaderValidator();
+
+  /**
+   * Creates a list of validators for a given GTFS entity type.
+   *
+   * <p>Use {@link ValidatorUtil#invokeSingleEntityValidators} to invoke the created validators on a
+   * given entity.
+   *
+   * @param clazz class of the GTFS entity
+   * @param <T> type of the GTFS entity
+   * @return a list of validators
+   */
+  <T extends GtfsEntity> List<SingleEntityValidator<T>> createSingleEntityValidators(
+      Class<T> clazz);
+
+  /**
+   * Creates a list of validators for the given table.
+   *
+   * <p>Use {@link ValidatorUtil#invokeSingleFileValidators} to invoke the created validators.
+   *
+   * @param table GTFS table to validate
+   * @param <T> type of the GTFS entity
+   */
+  <T extends GtfsEntity> List<FileValidator> createSingleFileValidators(
+      GtfsTableContainer<T> table);
+
+  /**
+   * Creates a list of cross-table validators.
+   *
+   * <p>Use {@link ValidatorUtil#safeValidate} to invoke each validator.
+   *
+   * @param feed GTFS feed to validate
+   */
+  List<FileValidator> createMultiFileValidators(GtfsFeedContainer feed);
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtil.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtil.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.flogger.FluentLogger;
+import java.util.List;
+import java.util.function.Consumer;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.RuntimeExceptionInValidatorError;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
+
+/** Methods for calling one or multiple validators and handle runtime exceptions gracefully. */
+public final class ValidatorUtil {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  /**
+   * Invokes all single-entity validators in the list.
+   *
+   * @param entity GTFS entity to validate
+   * @param validators list of single-entity validators
+   * @param noticeContainer container for accumulating notices
+   * @param <T> type of the GTFS entity
+   */
+  public static <T extends GtfsEntity> void invokeSingleEntityValidators(
+      T entity, List<SingleEntityValidator<T>> validators, NoticeContainer noticeContainer) {
+    for (SingleEntityValidator<T> validator : validators) {
+      safeValidate(c -> validator.validate(entity, c), validator.getClass(), noticeContainer);
+    }
+  }
+
+  /**
+   * Invokes single-file validators.
+   *
+   * @param validators list of single-file validators
+   * @param noticeContainer container for accumulating notices
+   * @param <T> type of the GTFS entity
+   */
+  public static <T extends GtfsEntity> void invokeSingleFileValidators(
+      List<FileValidator> validators, NoticeContainer noticeContainer) {
+    for (FileValidator validator : validators) {
+      safeValidate(validator::validate, validator.getClass(), noticeContainer);
+    }
+  }
+
+  /**
+   * Invokes the given validation function.
+   *
+   * <p>If the function raises an exception, then a system error is stored in the {@code
+   * noticeContainer}.
+   *
+   * @param validate a function to invoke
+   * @param validatorClass the class of the validator for debugging purposes
+   * @param noticeContainer the container for storing notices
+   */
+  public static void safeValidate(
+      Consumer<NoticeContainer> validate, Class validatorClass, NoticeContainer noticeContainer) {
+    try {
+      validate.accept(noticeContainer);
+    } catch (RuntimeException e) {
+      logger.atSevere().withCause(e).log(
+          "Runtime exception in validator %s", validatorClass.getCanonicalName());
+      noticeContainer.addSystemError(
+          new RuntimeExceptionInValidatorError(
+              validatorClass.getCanonicalName(), e.getClass().getCanonicalName(), e.getMessage()));
+    }
+  }
+
+  private ValidatorUtil() {}
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidatorTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.function.Predicate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.InvalidEmailNotice;
+import org.mobilitydata.gtfsvalidator.notice.InvalidPhoneNumberNotice;
+import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
+import org.mobilitydata.gtfsvalidator.notice.NewLineInValueNotice;
+import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+
+@RunWith(JUnit4.class)
+public class DefaultFieldValidatorTest {
+
+  private DefaultFieldValidator DEFAULT_FIELD_VALIDATOR =
+      new DefaultFieldValidator(CountryCode.forStringOrUnknown("AU"));
+  private GtfsCellContext CELL_CONTEXT = GtfsCellContext.create("stops.txt", 2, "stop_id");
+
+  @Test
+  public void hasOnlyPrintableAscii() {
+    assertThat(DefaultFieldValidator.hasOnlyPrintableAscii("abc")).isTrue();
+    assertThat(DefaultFieldValidator.hasOnlyPrintableAscii("a bc")).isTrue();
+    assertThat(DefaultFieldValidator.hasOnlyPrintableAscii("@<>&*()!")).isTrue();
+    // Cyrillic - not ASCII.
+    assertThat(DefaultFieldValidator.hasOnlyPrintableAscii("Привет!")).isFalse();
+    // Non-printable.
+    assertThat(DefaultFieldValidator.hasOnlyPrintableAscii("\01\23")).isFalse();
+  }
+
+  private static void assertValid(Predicate<NoticeContainer> validate) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    assertThat(validate.test(noticeContainer)).isTrue();
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  private static void assertInvalid(
+      Predicate<NoticeContainer> validate, ValidationNotice... validationNotices) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    assertThat(validate.test(noticeContainer)).isFalse();
+    assertThat(noticeContainer.getValidationNotices()).containsExactlyElementsIn(validationNotices);
+  }
+
+  @Test
+  public void validateId_valid() {
+    assertValid(nc -> DEFAULT_FIELD_VALIDATOR.validateId("32tgklu34y3k", CELL_CONTEXT, nc));
+  }
+
+  @Test
+  public void validateId_invalid() {
+    assertInvalid(
+        nc -> DEFAULT_FIELD_VALIDATOR.validateId("קום", CELL_CONTEXT, nc),
+        new NonAsciiOrNonPrintableCharNotice(
+            CELL_CONTEXT.filename(), CELL_CONTEXT.csvRowNumber(), CELL_CONTEXT.fieldName(), "קום"));
+  }
+
+  @Test
+  public void validateEmail_valid() {
+    assertValid(
+        nc -> DEFAULT_FIELD_VALIDATOR.validateEmail("no-reply@google.com", CELL_CONTEXT, nc));
+  }
+
+  @Test
+  public void validateEmail_invalid() {
+    assertInvalid(
+        nc -> DEFAULT_FIELD_VALIDATOR.validateEmail("invalid", CELL_CONTEXT, nc),
+        new InvalidEmailNotice(
+            CELL_CONTEXT.filename(),
+            CELL_CONTEXT.csvRowNumber(),
+            CELL_CONTEXT.fieldName(),
+            "invalid"));
+  }
+
+  @Test
+  public void validatePhoneNumber_valid() {
+    assertValid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("US"))
+                .validatePhoneNumber("(650) 253-0000", CELL_CONTEXT, nc));
+
+    assertValid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("ZZ"))
+                .validatePhoneNumber("+1 (650) 253-0000", CELL_CONTEXT, nc));
+
+    assertValid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("CH"))
+                .validatePhoneNumber("044 668 18 00", CELL_CONTEXT, nc));
+
+    assertValid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("NL"))
+                .validatePhoneNumber("+49 341 913 540 42", CELL_CONTEXT, nc));
+
+    assertValid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("NL"))
+                .validatePhoneNumber("004980038762246", CELL_CONTEXT, nc));
+  }
+
+  @Test
+  public void validatePhoneNumber_invalid() {
+    assertInvalid(
+        nc -> DEFAULT_FIELD_VALIDATOR.validatePhoneNumber("invalid", CELL_CONTEXT, nc),
+        new InvalidPhoneNumberNotice(
+            CELL_CONTEXT.filename(),
+            CELL_CONTEXT.csvRowNumber(),
+            CELL_CONTEXT.fieldName(),
+            "invalid"));
+
+    assertInvalid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("NL"))
+                .validatePhoneNumber("003280038762246", CELL_CONTEXT, nc),
+        new InvalidPhoneNumberNotice(
+            CELL_CONTEXT.filename(),
+            CELL_CONTEXT.csvRowNumber(),
+            CELL_CONTEXT.fieldName(),
+            "003280038762246"));
+
+    assertInvalid(
+        nc ->
+            new DefaultFieldValidator(CountryCode.forStringOrUnknown("ZZ"))
+                .validatePhoneNumber("003280038762246", CELL_CONTEXT, nc),
+        new InvalidPhoneNumberNotice(
+            CELL_CONTEXT.filename(),
+            CELL_CONTEXT.csvRowNumber(),
+            CELL_CONTEXT.fieldName(),
+            "003280038762246"));
+  }
+
+  @Test
+  public void whitespaceInValue_stripped() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    assertThat(DEFAULT_FIELD_VALIDATOR.validateField(" 1\t", CELL_CONTEXT, noticeContainer))
+        .isEqualTo("1");
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new LeadingOrTrailingWhitespacesNotice(
+                CELL_CONTEXT.filename(),
+                CELL_CONTEXT.csvRowNumber(),
+                CELL_CONTEXT.fieldName(),
+                " 1\t"));
+  }
+
+  @Test
+  public void newLineInValue() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    assertThat(DEFAULT_FIELD_VALIDATOR.validateField("a\nb", CELL_CONTEXT, noticeContainer))
+        .isEqualTo("a\nb");
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new NewLineInValueNotice(
+                CELL_CONTEXT.filename(),
+                CELL_CONTEXT.csvRowNumber(),
+                CELL_CONTEXT.fieldName(),
+                "a\nb"));
+  }
+
+  @Test
+  public void carriageReturnInValue() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    assertThat(DEFAULT_FIELD_VALIDATOR.validateField("a\rb", CELL_CONTEXT, noticeContainer))
+        .isEqualTo("a\rb");
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new NewLineInValueNotice(
+                CELL_CONTEXT.filename(),
+                CELL_CONTEXT.csvRowNumber(),
+                CELL_CONTEXT.fieldName(),
+                "a\rb"));
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
@@ -36,7 +36,7 @@ public class TableHeaderValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     assertThat(
-            new TableHeaderValidator()
+            new DefaultTableHeaderValidator()
                 .validate(
                     "stops.txt",
                     new CsvHeader(new String[] {"stop_id", "stop_name"}),
@@ -52,7 +52,7 @@ public class TableHeaderValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     assertThat(
-            new TableHeaderValidator()
+            new DefaultTableHeaderValidator()
                 .validate(
                     "stops.txt",
                     new CsvHeader(new String[] {"stop_id", "stop_name", "stop_extra"}),
@@ -69,7 +69,7 @@ public class TableHeaderValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     assertThat(
-            new TableHeaderValidator()
+            new DefaultTableHeaderValidator()
                 .validate(
                     "stops.txt",
                     new CsvHeader(new String[] {"stop_name"}),
@@ -86,7 +86,7 @@ public class TableHeaderValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     assertThat(
-            new TableHeaderValidator()
+            new DefaultTableHeaderValidator()
                 .validate(
                     "stops.txt",
                     new CsvHeader(new String[] {"stop_id", "stop_name", "stop_id"}),
@@ -103,7 +103,7 @@ public class TableHeaderValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     assertThat(
-            new TableHeaderValidator()
+            new DefaultTableHeaderValidator()
                 .validate(
                     "stops.txt",
                     CsvHeader.EMPTY,
@@ -119,7 +119,7 @@ public class TableHeaderValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     assertThat(
-            new TableHeaderValidator()
+            new DefaultTableHeaderValidator()
                 .validate(
                     "stops.txt",
                     new CsvHeader(new String[] {"stop_id", null, "stop_name", ""}),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -36,6 +36,7 @@ import org.mobilitydata.gtfsvalidator.notice.ThreadInterruptedError;
 import org.mobilitydata.gtfsvalidator.notice.URISyntaxError;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
+import org.mobilitydata.gtfsvalidator.validator.DefaultValidatorProvider;
 import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
@@ -101,7 +102,10 @@ public class Main {
             .setNow(ZonedDateTime.now(ZoneId.systemDefault()))
             .build();
     feedContainer =
-        feedLoader.loadAndValidate(gtfsInput, validationContext, validatorLoader, noticeContainer);
+    feedLoader.loadAndValidate(
+        gtfsInput,
+        new DefaultValidatorProvider(validationContext, validatorLoader),
+        noticeContainer);
     try {
       gtfsInput.close();
     } catch (IOException e) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.validator.DefaultValidatorProvider;
 import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
 
@@ -46,16 +47,23 @@ public class GtfsLevelTableLoaderTest {
     return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
   }
 
+  private static GtfsLevelTableContainer load(
+      InputStream inputStream, NoticeContainer noticeContainer) {
+    ValidatorLoader validatorLoader = new ValidatorLoader();
+    GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
+    return (GtfsLevelTableContainer)
+        loader.load(
+            inputStream,
+            new DefaultValidatorProvider(VALIDATION_CONTEXT, validatorLoader),
+            noticeContainer);
+  }
+
   @Test
   public void validFile() throws IOException {
-    ValidatorLoader validatorLoader = new ValidatorLoader();
     InputStream inputStream =
         toInputStream("level_id,level_name,level_index\n" + "level1,Ground,1\n");
-    GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsLevelTableContainer tableContainer =
-        (GtfsLevelTableContainer)
-            loader.load(inputStream, VALIDATION_CONTEXT, validatorLoader, noticeContainer);
+    GtfsLevelTableContainer tableContainer = load(inputStream, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(1);
@@ -70,13 +78,9 @@ public class GtfsLevelTableLoaderTest {
 
   @Test
   public void missingRequiredField() throws IOException {
-    ValidatorLoader validatorLoader = new ValidatorLoader();
     InputStream inputStream = toInputStream("level_id,level_name,level_index\n" + ",Ground,1\n");
-    GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsLevelTableContainer tableContainer =
-        (GtfsLevelTableContainer)
-            loader.load(inputStream, VALIDATION_CONTEXT, validatorLoader, noticeContainer);
+    GtfsLevelTableContainer tableContainer = load(inputStream, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isNotEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(0);
@@ -85,13 +89,9 @@ public class GtfsLevelTableLoaderTest {
 
   @Test
   public void emptyFile() throws IOException {
-    ValidatorLoader validatorLoader = new ValidatorLoader();
     InputStream inputStream = toInputStream("");
-    GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     NoticeContainer noticeContainer = new NoticeContainer();
-    GtfsLevelTableContainer tableContainer =
-        (GtfsLevelTableContainer)
-            loader.load(inputStream, VALIDATION_CONTEXT, validatorLoader, noticeContainer);
+    load(inputStream, noticeContainer);
 
     assertThat(noticeContainer.getValidationNotices()).isNotEmpty();
     assertThat(noticeContainer.getValidationNotices().get(0).getClass().getSimpleName())


### PR DESCRIPTION
We pass a single ValidatorProvider object instead of ValidatorContext
and ValidatorLoader. This allows us to achieve a list of goals.

1. Better modularity and testability. It is possible to inject a custom
   ValidatorProvider in the tests.
2. Clients may provide their own validation for phones, emails etc.
3. We open a way to define custom table header validators.
4. We will introduce a concept of critical validators (e.g., foreign key
   integrity) that will run before all other validators.
5. ValidationContext is now used in a small amount of files, so it will
   be easier to split it into smaller classes.
