### PR TITLE
feat: Pass severityLevel to constructor of some notices

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
@@ -26,13 +26,15 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p><a href="https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md">GTFS
  * reference</a> does not provide any special requirements or standards.
- *
- * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class InvalidEmailNotice extends ValidationNotice {
 
   public InvalidEmailNotice(
-      String filename, long csvRowNumber, String fieldName, String fieldValue) {
+      String filename,
+      long csvRowNumber,
+      String fieldName,
+      String fieldValue,
+      SeverityLevel severityLevel) {
     super(
         ImmutableMap.of(
             "filename",
@@ -43,6 +45,11 @@ public class InvalidEmailNotice extends ValidationNotice {
             fieldName,
             "fieldValue",
             fieldValue),
-        SeverityLevel.ERROR);
+        severityLevel);
+  }
+
+  public InvalidEmailNotice(
+      String filename, long csvRowNumber, String fieldName, String fieldValue) {
+    this(filename, csvRowNumber, fieldName, fieldValue, SeverityLevel.ERROR);
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
@@ -29,6 +29,10 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidEmailNotice extends ValidationNotice {
 
+  /**
+   * Constructs a notice with given severity. This constructor may be used by users that want to
+   * lower the priority to {@code WARNING}.
+   */
   public InvalidEmailNotice(
       String filename,
       long csvRowNumber,
@@ -48,6 +52,7 @@ public class InvalidEmailNotice extends ValidationNotice {
         severityLevel);
   }
 
+  /** Constructs a notice with the default severity {@code ERROR}. */
   public InvalidEmailNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     this(filename, csvRowNumber, fieldName, fieldValue, SeverityLevel.ERROR);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
@@ -26,13 +26,15 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p><a href="https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md">GTFS
  * reference</a> does not provide any special requirements or standards.
- *
- * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class InvalidPhoneNumberNotice extends ValidationNotice {
 
   public InvalidPhoneNumberNotice(
-      String filename, long csvRowNumber, String fieldName, String fieldValue) {
+      String filename,
+      long csvRowNumber,
+      String fieldName,
+      String fieldValue,
+      SeverityLevel severityLevel) {
     super(
         ImmutableMap.of(
             "filename",
@@ -43,6 +45,11 @@ public class InvalidPhoneNumberNotice extends ValidationNotice {
             fieldName,
             "fieldValue",
             fieldValue),
-        SeverityLevel.ERROR);
+        severityLevel);
+  }
+
+  public InvalidPhoneNumberNotice(
+      String filename, long csvRowNumber, String fieldName, String fieldValue) {
+    this(filename, csvRowNumber, fieldName, fieldValue, SeverityLevel.ERROR);
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
@@ -29,6 +29,10 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidPhoneNumberNotice extends ValidationNotice {
 
+  /**
+   * Constructs a notice with given severity. This constructor may be used by users that want to
+   * lower the priority to {@code WARNING}.
+   */
   public InvalidPhoneNumberNotice(
       String filename,
       long csvRowNumber,
@@ -48,6 +52,7 @@ public class InvalidPhoneNumberNotice extends ValidationNotice {
         severityLevel);
   }
 
+  /** Constructs a notice with the default severity {@code ERROR}. */
   public InvalidPhoneNumberNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     this(filename, csvRowNumber, fieldName, fieldValue, SeverityLevel.ERROR);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
@@ -34,12 +34,15 @@ import com.google.common.collect.ImmutableMap;
  *
  * <p>However, some production feeds may use certain characters without escaping and those URL may
  * be still openable in modern browsers.
- *
- * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class InvalidUrlNotice extends ValidationNotice {
 
-  public InvalidUrlNotice(String filename, long csvRowNumber, String fieldName, String fieldValue) {
+  public InvalidUrlNotice(
+      String filename,
+      long csvRowNumber,
+      String fieldName,
+      String fieldValue,
+      SeverityLevel severityLevel) {
     super(
         ImmutableMap.of(
             "filename",
@@ -50,6 +53,10 @@ public class InvalidUrlNotice extends ValidationNotice {
             fieldName,
             "fieldValue",
             fieldValue),
-        SeverityLevel.ERROR);
+        severityLevel);
+  }
+
+  public InvalidUrlNotice(String filename, long csvRowNumber, String fieldName, String fieldValue) {
+    this(filename, csvRowNumber, fieldName, fieldValue, SeverityLevel.ERROR);
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
@@ -37,6 +37,10 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidUrlNotice extends ValidationNotice {
 
+  /**
+   * Constructs a notice with given severity. This constructor may be used by users that want to
+   * lower the priority to {@code WARNING}.
+   */
   public InvalidUrlNotice(
       String filename,
       long csvRowNumber,
@@ -56,6 +60,7 @@ public class InvalidUrlNotice extends ValidationNotice {
         severityLevel);
   }
 
+  /** Constructs a notice with the default severity {@code ERROR}. */
   public InvalidUrlNotice(String filename, long csvRowNumber, String fieldName, String fieldValue) {
     this(filename, csvRowNumber, fieldName, fieldValue, SeverityLevel.ERROR);
   }


### PR DESCRIPTION
Pass severityLevel to constructor of notices for invalid email, phone and URL.

Some clients (e.g, Google) may want to reduce severity to WARNING.
