### PR TITLE
feat: Inject individual objects and validate the constructors

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
@@ -17,8 +17,8 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.auto.value.AutoValue;
-import java.time.ZonedDateTime;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 
 /**
  * A read-only context passed to particular validator objects. It gives information relevant for
@@ -50,13 +50,25 @@ public abstract class ValidationContext {
    *
    * @return The time when validation started as @code{ZonedDateTime}
    */
-  public abstract ZonedDateTime now();
+  public abstract CurrentDateTime currentDateTime();
+
+  /** Returns a member of the context with requested class. */
+  public <T> T get(Class<T> clazz) {
+    if (CountryCode.class.isAssignableFrom(clazz)) {
+      return (T) countryCode();
+    }
+    if (CurrentDateTime.class.isAssignableFrom(clazz)) {
+      return (T) currentDateTime();
+    }
+    throw new IllegalArgumentException(
+        "Cannot find " + clazz.getCanonicalName() + " in validation context");
+  }
 
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setCountryCode(CountryCode countryCode);
 
-    public abstract Builder setNow(ZonedDateTime now);
+    public abstract Builder setCurrentDateTime(CurrentDateTime currentDateTime);
 
     public abstract ValidationContext build();
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -32,6 +32,8 @@ import java.util.Map.Entry;
 import java.util.function.Function;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
@@ -57,7 +59,7 @@ public class ValidatorLoader {
   private final List<Class<? extends FileValidator>> multiFileValidators = new ArrayList<>();
 
   /** Loads validator classes from the default package path. */
-  public ValidatorLoader() {
+  public ValidatorLoader() throws ValidatorLoaderException {
     this(ImmutableList.of(DEFAULT_VALIDATOR_PACKAGE));
   }
 
@@ -67,12 +69,12 @@ public class ValidatorLoader {
    * @param validatorPackages list of package names for locating validator classes
    */
   @SuppressWarnings("unchecked")
-  public ValidatorLoader(ImmutableList<String> validatorPackages) {
+  public ValidatorLoader(ImmutableList<String> validatorPackages) throws ValidatorLoaderException {
     ClassPath classPath;
     try {
       classPath = ClassPath.from(ClassLoader.getSystemClassLoader());
     } catch (IOException exception) {
-      throw new RuntimeException(exception);
+      throw new ValidatorLoaderException("Cannot load classes", exception);
     }
     for (String packageName : validatorPackages) {
       for (ClassPath.ClassInfo classInfo : classPath.getTopLevelClassesRecursive(packageName)) {
@@ -106,7 +108,17 @@ public class ValidatorLoader {
   }
 
   @SuppressWarnings("unchecked")
-  private void addSingleEntityValidator(Class<? extends SingleEntityValidator<?>> validatorClass) {
+  private <T extends SingleEntityValidator<?>> void addSingleEntityValidator(
+      Class<T> validatorClass) throws ValidatorLoaderException {
+    Constructor<T> constructor = chooseConstructor(validatorClass);
+    for (Class<?> parameterType : constructor.getParameterTypes()) {
+      if (!isInjectableFromContext(parameterType)) {
+        throw new ValidatorLoaderException(
+            String.format(
+                "Cannot inject parameter of type %s to %s constructor",
+                parameterType.getCanonicalName(), validatorClass.getCanonicalName()));
+      }
+    }
     for (Method method : validatorClass.getMethods()) {
       // A child class of SingleEntityValidator has two `validate' methods:
       // 1) the inherited void validate(GtfsEntity entity, NoticeContainer noticeContainer);
@@ -125,33 +137,21 @@ public class ValidatorLoader {
   }
 
   @SuppressWarnings("unchecked")
-  private void addFileValidator(Class<? extends FileValidator> validatorClass) {
-    Constructor<FileValidator> chosenConstructor = null;
-    // Choose the default or injectable constructor.
-    for (Constructor<?> constructor : validatorClass.getDeclaredConstructors()) {
-      if (constructor.getParameterCount() == 0 || constructor.isAnnotationPresent(Inject.class)) {
-        chosenConstructor = (Constructor<FileValidator>) constructor;
-        break;
-      }
-    }
-    if (chosenConstructor == null) {
-      logger.atSevere().log(
-          "Validator %s has no injectable or default constructors",
-          validatorClass.getCanonicalName());
-      return;
-    }
+  private <T extends FileValidator> void addFileValidator(Class<T> validatorClass)
+      throws ValidatorLoaderException {
+    Constructor<T> constructor = chooseConstructor(validatorClass);
 
     // Find out which GTFS tables need to be injected.
     List<Class<? extends GtfsTableContainer<?>>> injectedTables = new ArrayList<>();
-    for (Class<?> parameterType : chosenConstructor.getParameterTypes()) {
-      if (parameterType.isAssignableFrom(ValidationContext.class)) {
+    for (Class<?> parameterType : constructor.getParameterTypes()) {
+      if (isInjectableFromContext(parameterType)) {
         continue;
       }
       if (!GtfsTableContainer.class.isAssignableFrom(parameterType)) {
-        logger.atSevere().log(
-            "Cannot inject parameter of type %s to %s constructor",
-            parameterType.getCanonicalName(), validatorClass.getCanonicalName());
-        return;
+        throw new ValidatorLoaderException(
+            String.format(
+                "Cannot inject parameter of type %s to %s constructor",
+                parameterType.getCanonicalName(), validatorClass.getCanonicalName()));
       }
       injectedTables.add((Class<? extends GtfsTableContainer<?>>) parameterType);
     }
@@ -161,6 +161,26 @@ public class ValidatorLoader {
     } else {
       multiFileValidators.add(validatorClass);
     }
+  }
+
+  private static boolean isInjectableFromContext(Class<?> parameterType) {
+    return parameterType.isAssignableFrom(CurrentDateTime.class)
+        || parameterType.isAssignableFrom(CountryCode.class);
+  }
+
+  /** Chooses the default or injectable constructor. */
+  @SuppressWarnings("unchecked")
+  private static <T> Constructor<T> chooseConstructor(Class<T> validatorClass)
+      throws ValidatorLoaderException {
+    for (Constructor<?> constructor : validatorClass.getDeclaredConstructors()) {
+      if (constructor.getParameterCount() == 0 || constructor.isAnnotationPresent(Inject.class)) {
+        return (Constructor<T>) constructor;
+      }
+    }
+    throw new ValidatorLoaderException(
+        String.format(
+            "Validator %s has no injectable or default constructors",
+            validatorClass.getCanonicalName()));
   }
 
   /**
@@ -174,15 +194,13 @@ public class ValidatorLoader {
   @SuppressWarnings("unchecked")
   private static <T> T createValidator(Class<T> clazz, Function<Class<?>, Object> provider)
       throws ReflectiveOperationException {
-    // Choose the default or injectable constructor.
-    Constructor<T> chosenConstructor = null;
-    for (Constructor<?> constructor : clazz.getDeclaredConstructors()) {
-      if (constructor.isAnnotationPresent(Inject.class) || constructor.getParameterCount() == 0) {
-        chosenConstructor = (Constructor<T>) constructor;
-        break;
-      }
+    Constructor<T> chosenConstructor;
+    try {
+      chosenConstructor = chooseConstructor(clazz);
+    } catch (ValidatorLoaderException e) {
+      // This should never happen since that problem when loading the validator class.
+      throw new NoSuchMethodException("Injectable or default constructor is not found");
     }
-
     // Inject constructor parameters.
     Object[] parameters = new Object[chosenConstructor.getParameterCount()];
     for (int i = 0; i < parameters.length; ++i) {
@@ -203,7 +221,7 @@ public class ValidatorLoader {
   @SuppressWarnings("unchecked")
   public static <T> T createValidatorWithContext(
       Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
-    return createValidator(clazz, parameter -> validationContext);
+    return createValidator(clazz, validationContext::get);
   }
 
   /** Instantiates a {@code FileValidator} for a single table. */
@@ -215,7 +233,9 @@ public class ValidatorLoader {
     return createValidator(
         clazz,
         parameterClass ->
-            parameterClass.isAssignableFrom(ValidationContext.class) ? validationContext : table);
+            parameterClass.isAssignableFrom(table.getClass())
+                ? table
+                : validationContext.get(parameterClass));
   }
 
   /** Instantiates a {@code FileValidator} for multiple tables in a given feed. */
@@ -228,9 +248,9 @@ public class ValidatorLoader {
     return createValidator(
         clazz,
         parameterClass ->
-            parameterClass.isAssignableFrom(ValidationContext.class)
-                ? validationContext
-                : feed.getTable((Class<? extends GtfsTableContainer<?>>) parameterClass));
+            GtfsTableContainer.class.isAssignableFrom(parameterClass)
+                ? feed.getTable((Class<? extends GtfsTableContainer<?>>) parameterClass)
+                : validationContext.get(parameterClass));
   }
 
   /** Describes all loaded validators. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderException.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderException.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+/** Exception related to dynamic loading of validator classes. */
+public class ValidatorLoaderException extends Exception {
+  public ValidatorLoaderException(String message) {
+    super(message);
+  }
+
+  public ValidatorLoaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -29,6 +29,7 @@ import java.nio.file.Paths;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.IOError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -39,6 +40,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
 import org.mobilitydata.gtfsvalidator.validator.DefaultValidatorProvider;
 import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
 
 /** The main entry point for GTFS Validator CLI. */
 public class Main {
@@ -52,7 +54,13 @@ public class Main {
       System.exit(1);
     }
 
-    ValidatorLoader validatorLoader = new ValidatorLoader();
+    ValidatorLoader validatorLoader = null;
+    try {
+      validatorLoader = new ValidatorLoader();
+    } catch (ValidatorLoaderException e) {
+      logger.atSevere().withCause(e).log("Cannot load validator classes");
+      System.exit(1);
+    }
     GtfsFeedLoader feedLoader = new GtfsFeedLoader();
 
     System.out.println("Country code: " + args.getCountryCode());
@@ -99,7 +107,7 @@ public class Main {
             .setCountryCode(
                 CountryCode.forStringOrUnknown(
                     args.getCountryCode() == null ? CountryCode.ZZ : args.getCountryCode()))
-            .setNow(ZonedDateTime.now(ZoneId.systemDefault()))
+            .setCurrentDateTime(new CurrentDateTime(ZonedDateTime.now(ZoneId.systemDefault())))
             .build();
     feedContainer =
         feedLoader.loadAndValidate(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -39,17 +40,17 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
  */
 @GtfsValidator
 public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedInfo> {
-  private final ValidationContext context;
+  private final CurrentDateTime currentDateTime;
 
   @Inject
-  FeedExpirationDateValidator(ValidationContext context) {
-    this.context = context;
+  FeedExpirationDateValidator(CurrentDateTime currentDateTime) {
+    this.currentDateTime = currentDateTime;
   }
 
   @Override
   public void validate(GtfsFeedInfo entity, NoticeContainer noticeContainer) {
     if (entity.hasFeedEndDate()) {
-      LocalDate now = context.now().toLocalDate();
+      LocalDate now = currentDateTime.getNow().toLocalDate();
       GtfsDate currentDate = GtfsDate.fromLocalDate(now);
       GtfsDate currentDatePlusSevenDays = GtfsDate.fromLocalDate(now.plusDays(7));
       GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(now.plusDays(30));

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
@@ -28,10 +28,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.validator.DefaultValidatorProvider;
 import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
 
 /** Runs GtfsLevelTableContainer on test CSV data. */
 @RunWith(JUnit4.class)
@@ -41,14 +43,17 @@ public class GtfsLevelTableLoaderTest {
       ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
 
   private static final ValidationContext VALIDATION_CONTEXT =
-      ValidationContext.builder().setCountryCode(TEST_COUNTRY_CODE).setNow(TEST_NOW).build();
+      ValidationContext.builder()
+          .setCountryCode(TEST_COUNTRY_CODE)
+          .setCurrentDateTime(new CurrentDateTime(TEST_NOW))
+          .build();
 
   private static InputStream toInputStream(String s) {
     return new ByteArrayInputStream(s.getBytes(StandardCharsets.UTF_8));
   }
 
   private static GtfsLevelTableContainer load(
-      InputStream inputStream, NoticeContainer noticeContainer) {
+      InputStream inputStream, NoticeContainer noticeContainer) throws ValidatorLoaderException {
     ValidatorLoader validatorLoader = new ValidatorLoader();
     GtfsLevelTableLoader loader = new GtfsLevelTableLoader();
     return (GtfsLevelTableContainer)
@@ -59,7 +64,7 @@ public class GtfsLevelTableLoaderTest {
   }
 
   @Test
-  public void validFile() throws IOException {
+  public void validFile() throws IOException, ValidatorLoaderException {
     InputStream inputStream =
         toInputStream("level_id,level_name,level_index\n" + "level1,Ground,1\n");
     NoticeContainer noticeContainer = new NoticeContainer();
@@ -77,7 +82,7 @@ public class GtfsLevelTableLoaderTest {
   }
 
   @Test
-  public void missingRequiredField() throws IOException {
+  public void missingRequiredField() throws IOException, ValidatorLoaderException {
     InputStream inputStream = toInputStream("level_id,level_name,level_index\n" + ",Ground,1\n");
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsLevelTableContainer tableContainer = load(inputStream, noticeContainer);
@@ -88,7 +93,7 @@ public class GtfsLevelTableLoaderTest {
   }
 
   @Test
-  public void emptyFile() throws IOException {
+  public void emptyFile() throws IOException, ValidatorLoaderException {
     InputStream inputStream = toInputStream("");
     NoticeContainer noticeContainer = new NoticeContainer();
     load(inputStream, noticeContainer);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -23,7 +23,7 @@ import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -31,16 +31,12 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.validator.FeedExpirationDateValidator.FeedExpirationDateNotice;
 
 public class FeedExpirationDateValidatorTest {
-  private static final CountryCode TEST_COUNTRY_CODE = CountryCode.forStringOrUnknown("au");
   private static final ZonedDateTime TEST_NOW =
       ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
 
-  private static final ValidationContext VALIDATION_CONTEXT =
-      ValidationContext.builder().setCountryCode(TEST_COUNTRY_CODE).setNow(TEST_NOW).build();
-
   private List<ValidationNotice> validateFeedInfo(GtfsFeedInfo feedInfo) {
     NoticeContainer container = new NoticeContainer();
-    new FeedExpirationDateValidator(VALIDATION_CONTEXT).validate(feedInfo, container);
+    new FeedExpirationDateValidator(new CurrentDateTime(TEST_NOW)).validate(feedInfo, container);
     return container.getValidationNotices();
   }
 


### PR DESCRIPTION
1. Inject individual objects like CurrentDateTime instead
   of the whole ValidationContext. This makes dependencies
   more explicit since a validator requires just a
   certain part of the potentially large ValidationContext.
2. Validate that all validator constructors accept parameters
   of supported types and throw an exception for any invalid
   validator. This prevents hidden bugs when a validator cannot
   be instantiated but nobody notices that because a file for
   the corresponding validator is not present.
