### PR TITLE
feat: Simplify validator functions

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
@@ -104,7 +104,7 @@ public class DefaultFieldValidator implements GtfsFieldValidator {
     }
   }
 
-  public static boolean hasOnlyPrintableAscii(String s) {
+  static boolean hasOnlyPrintableAscii(String s) {
     for (int i = 0, n = s.length(); i < n; ++i) {
       if (!(s.charAt(i) >= 32 && s.charAt(i) < 127)) {
         return false;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
@@ -62,43 +62,36 @@ public class DefaultFieldValidator implements GtfsFieldValidator {
   }
 
   @Override
-  public boolean validateId(
-      String id, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
+  public void validateId(String id, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
     if (!hasOnlyPrintableAscii(id)) {
       noticeContainer.addValidationNotice(
           new NonAsciiOrNonPrintableCharNotice(
               cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), id));
-      return false;
     }
-    return true;
   }
 
   @Override
-  public boolean validateUrl(
+  public void validateUrl(
       String url, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
     if (!UrlValidator.getInstance().isValid(url)) {
       noticeContainer.addValidationNotice(
           new InvalidUrlNotice(
               cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), url));
-      return false;
     }
-    return true;
   }
 
   @Override
-  public boolean validateEmail(
+  public void validateEmail(
       String email, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
     if (!EmailValidator.getInstance().isValid(email)) {
       noticeContainer.addValidationNotice(
           new InvalidEmailNotice(
               cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), email));
-      return false;
     }
-    return true;
   }
 
   @Override
-  public boolean validatePhoneNumber(
+  public void validatePhoneNumber(
       String phoneNumber, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
     if (!PhoneNumberUtil.getInstance()
         .isPossibleNumber(phoneNumber, countryCode.getCountryCode())) {
@@ -108,12 +101,10 @@ public class DefaultFieldValidator implements GtfsFieldValidator {
               cellContext.csvRowNumber(),
               cellContext.fieldName(),
               phoneNumber));
-      return false;
     }
-    return true;
   }
 
-  static boolean hasOnlyPrintableAscii(String s) {
+  public static boolean hasOnlyPrintableAscii(String s) {
     for (int i = 0, n = s.length(); i < n; ++i) {
       if (!(s.charAt(i) >= 32 && s.charAt(i) < 127)) {
         return false;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsFieldValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsFieldValidator.java
@@ -21,7 +21,8 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 /**
  * Validator for a single field in a GTFS file.
  *
- * <p>All methods of this validator store notices in the provided container.
+ * <p>All methods of this validator store notices in the provided container. If an error is stored,
+ * then the value is considered invalid.
  */
 public interface GtfsFieldValidator {
 
@@ -36,32 +37,16 @@ public interface GtfsFieldValidator {
   String validateField(
       String fieldValue, GtfsCellContext cellContext, NoticeContainer noticeContainer);
 
-  /**
-   * Validates an ID field.
-   *
-   * @return true if the value is valid, false otherwise
-   */
-  boolean validateId(String id, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+  /** Validates an ID field and adds notices to the container. */
+  void validateId(String id, GtfsCellContext cellContext, NoticeContainer noticeContainer);
 
-  /**
-   * Validates a URL field.
-   *
-   * @return true if the value is valid, false otherwise
-   */
-  boolean validateUrl(String url, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+  /** Validates a URL field and adds notices to the container. */
+  void validateUrl(String url, GtfsCellContext cellContext, NoticeContainer noticeContainer);
 
-  /**
-   * Validates an e-mail field.
-   *
-   * @return true if the value is valid, false otherwise
-   */
-  boolean validateEmail(String email, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+  /** Validates an e-mail field and adds notices to the container. */
+  void validateEmail(String email, GtfsCellContext cellContext, NoticeContainer noticeContainer);
 
-  /**
-   * Validates a phone number field.
-   *
-   * @return true if the value is valid, false otherwise
-   */
-  boolean validatePhoneNumber(
+  /** Validates a phone number field and adds notices to the container. */
+  void validatePhoneNumber(
       String phoneNumber, GtfsCellContext cellContext, NoticeContainer noticeContainer);
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidatorTest.java
@@ -18,7 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.util.function.Predicate;
+import java.util.function.Consumer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -50,16 +50,16 @@ public class DefaultFieldValidatorTest {
     assertThat(DefaultFieldValidator.hasOnlyPrintableAscii("\01\23")).isFalse();
   }
 
-  private static void assertValid(Predicate<NoticeContainer> validate) {
+  private static void assertValid(Consumer<NoticeContainer> validate) {
     NoticeContainer noticeContainer = new NoticeContainer();
-    assertThat(validate.test(noticeContainer)).isTrue();
+    validate.accept(noticeContainer);
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
   }
 
   private static void assertInvalid(
-      Predicate<NoticeContainer> validate, ValidationNotice... validationNotices) {
+      Consumer<NoticeContainer> validate, ValidationNotice... validationNotices) {
     NoticeContainer noticeContainer = new NoticeContainer();
-    assertThat(validate.test(noticeContainer)).isFalse();
+    validate.accept(noticeContainer);
     assertThat(noticeContainer.getValidationNotices()).containsExactlyElementsIn(validationNotices);
   }
 


### PR DESCRIPTION
If an error is stored to the NoticeContainer, then it is already clear
that the field is invalid. Returning an additional boolean is redundant
and may lead to bugs when the function returns false but no error
notices are emitted.
