### PR TITLE
fix: Prevent NullPointerException when Throwable.getMessage returns null

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
@@ -16,7 +16,9 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 
 /**
  * This is related to Input and Output operations in the code.
@@ -25,7 +27,10 @@ import com.google.common.collect.ImmutableMap;
  */
 public class IOError extends SystemError {
 
-  public IOError(String message) {
-    super(ImmutableMap.of("message", message));
+  public IOError(IOException exception) {
+    super(
+        ImmutableMap.of(
+            "exception", exception.getClass().getCanonicalName(),
+            "message", Strings.nullToEmpty(exception.getMessage())));
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
@@ -1,7 +1,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
-import javax.annotation.Nullable;
 
 /**
  * Describes a runtime exception during loading a table. This normally indicates a bug in validator
@@ -10,16 +10,14 @@ import javax.annotation.Nullable;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class RuntimeExceptionInLoaderError extends SystemError {
-  public RuntimeExceptionInLoaderError(
-      String filename, String exceptionClassName, @Nullable String message) {
-    // Throwable.getMessage() may return null, so we need to support it gracefully.
+  public RuntimeExceptionInLoaderError(String filename, RuntimeException exception) {
     super(
         ImmutableMap.of(
             "filename",
             filename,
             "exception",
-            exceptionClassName,
+            exception.getClass().getCanonicalName(),
             "message",
-            message == null ? "" : message));
+            Strings.nullToEmpty(exception.getMessage())));
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInValidatorError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInValidatorError.java
@@ -1,5 +1,6 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
 /**
@@ -9,10 +10,15 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class RuntimeExceptionInValidatorError extends SystemError {
-  public RuntimeExceptionInValidatorError(
-      String validatorClassName, String exceptionClassName, String message) {
+  public RuntimeExceptionInValidatorError(String validatorClassName, RuntimeException exception) {
+    // Throwable.getMessage() may return null, so we need to support it gracefully.
     super(
         ImmutableMap.of(
-            "validator", validatorClassName, "exception", exceptionClassName, "message", message));
+            "validator",
+            validatorClassName,
+            "exception",
+            exception.getClass().getCanonicalName(),
+            "message",
+            Strings.nullToEmpty(exception.getMessage())));
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadExecutionError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadExecutionError.java
@@ -1,6 +1,8 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Describes an ExecutionException during multithreaded validation.
@@ -11,7 +13,10 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class ThreadExecutionError extends SystemError {
-  public ThreadExecutionError(String exceptionClassName, String message) {
-    super(ImmutableMap.of("exception", exceptionClassName, "message", message));
+  public ThreadExecutionError(ExecutionException exception) {
+    super(
+        ImmutableMap.of(
+            "exception", exception.getCause().getClass().getCanonicalName(),
+            "message", Strings.nullToEmpty(exception.getCause().getMessage())));
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadInterruptedError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadInterruptedError.java
@@ -1,6 +1,8 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import javax.annotation.Nullable;
 
 /**
  * Describes an InterruptedException during multithreaded validation.
@@ -11,7 +13,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class ThreadInterruptedError extends SystemError {
-  public ThreadInterruptedError(String message) {
-    super(ImmutableMap.of("message", message));
+  public ThreadInterruptedError(@Nullable String message) {
+    super(ImmutableMap.of("message", Strings.nullToEmpty(message)));
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
@@ -16,7 +16,9 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
+import java.net.URISyntaxException;
 
 /**
  * Indicates that a string could not be parsed as a URI reference.
@@ -25,7 +27,10 @@ import com.google.common.collect.ImmutableMap;
  */
 public class URISyntaxError extends SystemError {
 
-  public URISyntaxError(String message) {
-    super(ImmutableMap.of("message", message));
+  public URISyntaxError(URISyntaxException exception) {
+    super(
+        ImmutableMap.of(
+            "exception", exception.getClass().getCanonicalName(),
+            "message", Strings.nullToEmpty(exception.getMessage())));
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -113,9 +113,7 @@ public class GtfsFeedLoader {
                   // this thread. We catch an exception here for storing
                   // the context since we know the filename here.
                   logger.atSevere().withCause(e).log("Runtime exception when loading %s", filename);
-                  loaderNotices.addSystemError(
-                      new RuntimeExceptionInLoaderError(
-                          filename, e.getClass().getCanonicalName(), e.getMessage()));
+                  loaderNotices.addSystemError(new RuntimeExceptionInLoaderError(filename, e));
                   // Since the file was not loaded successfully, we treat
                   // it as missing for continuing validation.
                   tableContainer = loader.loadMissingFile(validatorProvider, loaderNotices);
@@ -181,9 +179,7 @@ public class GtfsFeedLoader {
   private static void addThreadExecutionError(
       ExecutionException e, NoticeContainer noticeContainer) {
     logger.atSevere().withCause(e).log("Execution exception");
-    Throwable cause = e.getCause();
-    noticeContainer.addSystemError(
-        new ThreadExecutionError(cause.getClass().getCanonicalName(), cause.getMessage()));
+    noticeContainer.addSystemError(new ThreadExecutionError(e));
   }
 
   static class TableAndNoticeContainers {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtil.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtil.java
@@ -76,8 +76,7 @@ public final class ValidatorUtil {
       logger.atSevere().withCause(e).log(
           "Runtime exception in validator %s", validatorClass.getCanonicalName());
       noticeContainer.addSystemError(
-          new RuntimeExceptionInValidatorError(
-              validatorClass.getCanonicalName(), e.getClass().getCanonicalName(), e.getMessage()));
+          new RuntimeExceptionInValidatorError(validatorClass.getCanonicalName(), e));
     }
   }
 

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -35,7 +35,7 @@ public class NoticeContainerTest {
     container.addValidationNotice(new MissingRequiredFileNotice("agency.txt"));
     container.addSystemError(
         new RuntimeExceptionInValidatorError(
-            "FaultyValidator", "java.lang.IndexOutOfBoundsException", "Index 0 out of bounds"));
+            "FaultyValidator", new IndexOutOfBoundsException("Index 0 out of bounds")));
     assertThat(container.exportValidationNotices())
         .isEqualTo(
             "{\"notices\":["
@@ -90,10 +90,10 @@ public class NoticeContainerTest {
     ValidationNotice n2 = new UnknownFileNotice("unknown.txt");
     SystemError e1 =
         new RuntimeExceptionInValidatorError(
-            "Validator1", "java.lang.IndexOutOfBoundsException", "Index 0 out of bounds");
+            "Validator1", new IndexOutOfBoundsException("Index 0 out of bounds"));
     SystemError e2 =
         new RuntimeExceptionInValidatorError(
-            "Validator2", "java.lang.NegativeArraySizeException", "Index -1 out of bounds");
+            "Validator2", new NegativeArraySizeException("Index -1 out of bounds"));
     NoticeContainer c1 = new NoticeContainer();
     c1.addValidationNotice(n1);
     c1.addSystemError(e1);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -90,10 +90,10 @@ public class Main {
       }
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
-      noticeContainer.addSystemError(new IOError(e.getMessage()));
+      noticeContainer.addSystemError(new IOError(e));
     } catch (URISyntaxException e) {
       logger.atSevere().withCause(e).log("Syntax error in URI");
-      noticeContainer.addSystemError(new URISyntaxError(e.getMessage()));
+      noticeContainer.addSystemError(new URISyntaxError(e));
     } catch (InterruptedException e) {
       logger.atSevere().withCause(e).log("Interrupted thread");
       noticeContainer.addSystemError(new ThreadInterruptedError(e.getMessage()));
@@ -124,7 +124,7 @@ public class Main {
       gtfsInput.close();
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot close GTFS input");
-      noticeContainer.addSystemError(new IOError(e.getMessage()));
+      noticeContainer.addSystemError(new IOError(e));
     }
 
     // Output


### PR DESCRIPTION
Throwable.getMessage() can return null but ImmutableMap may not keep
nulls, so we store "" instead.

We pass an exception instance to the constructors for convenience.

Note that ThreadInterruptedError was not updated since we plan to remove
it.
