### PR TITLE
fix: Swap arguments of isAssignableFrom

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
@@ -53,11 +53,12 @@ public abstract class ValidationContext {
   public abstract CurrentDateTime currentDateTime();
 
   /** Returns a member of the context with requested class. */
+  @SuppressWarnings("unchecked")
   public <T> T get(Class<T> clazz) {
-    if (CountryCode.class.isAssignableFrom(clazz)) {
+    if (clazz.isAssignableFrom(CountryCode.class)) {
       return (T) countryCode();
     }
-    if (CurrentDateTime.class.isAssignableFrom(clazz)) {
+    if (clazz.isAssignableFrom(CurrentDateTime.class)) {
       return (T) currentDateTime();
     }
     throw new IllegalArgumentException(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -191,6 +191,7 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
+  @SuppressWarnings("unchecked")
   private static <T> T createValidator(Class<T> clazz, Function<Class<?>, Object> provider)
       throws ReflectiveOperationException {
     Constructor<T> chosenConstructor;
@@ -217,6 +218,7 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
+  @SuppressWarnings("unchecked")
   public static <T> T createValidatorWithContext(
       Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
     return createValidator(clazz, validationContext::get);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -191,7 +191,6 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  @SuppressWarnings("unchecked")
   private static <T> T createValidator(Class<T> clazz, Function<Class<?>, Object> provider)
       throws ReflectiveOperationException {
     Constructor<T> chosenConstructor;
@@ -218,7 +217,6 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  @SuppressWarnings("unchecked")
   public static <T> T createValidatorWithContext(
       Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
     return createValidator(clazz, validationContext::get);

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
@@ -1,0 +1,47 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+
+@RunWith(JUnit4.class)
+public final class ValidationContextTest {
+  private static final CountryCode COUNTRY_CODE = CountryCode.forStringOrUnknown("AU");
+  private static final CurrentDateTime CURRENT_DATE_TIME =
+      new CurrentDateTime(ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC));
+  private static final ValidationContext VALIDATION_CONTEXT =
+      ValidationContext.builder()
+          .setCountryCode(COUNTRY_CODE)
+          .setCurrentDateTime(CURRENT_DATE_TIME)
+          .build();
+
+  @Test
+  public void get_countryCode_successful() {
+    assertThat(VALIDATION_CONTEXT.get(CountryCode.class)).isEqualTo(COUNTRY_CODE);
+  }
+
+  @Test
+  public void get_currentDateTime_successful() {
+    assertThat(VALIDATION_CONTEXT.get(CurrentDateTime.class)).isEqualTo(CURRENT_DATE_TIME);
+  }
+
+  @Test
+  public void get_unsupported_throws() {
+    assertThrows(
+        IllegalArgumentException.class, () -> VALIDATION_CONTEXT.get(ChildCurrentDateTime.class));
+  }
+
+  private static class ChildCurrentDateTime extends CurrentDateTime {
+
+    public ChildCurrentDateTime(ZonedDateTime now) {
+      super(now);
+    }
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
Consider we want to inject a ChildCurrentDateTime class. This assignment
is invalid:

  ChildCurrentDateTime param = new CurrentDateTime();

It may be only the other way:

  CurrentDateTime param = new ChildCurrentDateTime();

See also the valid implementation:

```
  private static boolean isInjectableFromContext(Class<?> parameterType) {
    return parameterType.isAssignableFrom(CurrentDateTime.class)
        || parameterType.isAssignableFrom(CountryCode.class);
  }
```