### PR TITLE
fix: Remove redundant SuppressWarnings

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -191,7 +191,6 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  @SuppressWarnings("unchecked")
   private static <T> T createValidator(Class<T> clazz, Function<Class<?>, Object> provider)
       throws ReflectiveOperationException {
     Constructor<T> chosenConstructor;
@@ -218,7 +217,6 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  @SuppressWarnings("unchecked")
   public static <T> T createValidatorWithContext(
       Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
     return createValidator(clazz, validationContext::get);


### PR DESCRIPTION
There are no unchecked type conversions in the annotated functions.