### PR TITLE
feat: Catch CSV parse errors and add validation notices

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -68,6 +68,7 @@ Notices are split into three categories: `INFO`, `WARNING`, `ERROR`.
 | Name                                                                                                            	| Description                                                                                                                                                 	|
 |-----------------------------------------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------------------------------	|
 | [`BlockTripsWithOverlappingStopTimesNotice`](#BlockTripsWithOverlappingStopTimesNotice)                         	| Block trips with overlapping stop times.                                                                                                                    	|
+| [`CsvParsingFailedNotice`](#CsvParsingFailedNotice)                                                             	| Parsing of a CSV file failed.                                                                                                                             	|
 | [`DecreasingOrEqualShapeDistanceNotice`](#DecreasingOrEqualShapeDistanceNotice)                                 	| Decreasing or equal `shape_dist_traveled` in `shapes.txt`.                                                                                                  	|
 | [`DecreasingOrEqualStopTimeDistanceNotice`](#DecreasingOrEqualStopTimeDistanceNotice)                           	| Decreasing or equal `shape_dist_traveled` in `stop_times.txt`.                                                                                              	|
 | [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)                                                             	| Duplicated column in CSV.                                                                                                                                   	|
@@ -168,6 +169,12 @@ Trips with the same block id have overlapping stop times.
 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)
+
+<a name="CsvParsingFailedNotice"/>
+
+#### CsvParsingFailedNotice
+
+Parsing of a CSV file failed. One common case of the problem is when a cell value contains more than 4096 characters.
 
 <a name="DecreasingOrEqualShapeDistanceNotice"/>
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.univocity.parsers.common.TextParsingException;
+
+/**
+ * Parsing of a CSV file failed.
+ *
+ * <p>One common case of the problem is when a cell value contains more than 4096 characters.
+ *
+ * <p>Severity: {@code SeverityLevel.ERROR}
+ */
+public class CsvParsingFailedNotice extends ValidationNotice {
+  public CsvParsingFailedNotice(String filename, TextParsingException exception) {
+    super(
+        new ImmutableMap.Builder<String, Object>()
+            .put("filename", filename)
+            .put("charIndex", exception.getCharIndex())
+            .put("columnIndex", exception.getColumnIndex())
+            .put("lineIndex", exception.getLineIndex())
+            .put("message", Strings.nullToEmpty(exception.getMessage()))
+            .put("content", Strings.nullToEmpty(exception.getParsedContent()))
+            .build(),
+        SeverityLevel.ERROR);
+  }
+}

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -70,6 +70,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.google.flogger:flogger:0.5.1'
     implementation 'com.google.flogger:flogger-system-backend:0.5.1'
+    implementation 'com.univocity:univocity-parsers:2.9.0'
     implementation 'io.sgr:s2-geometry-library-java:1.0.1'
     implementation 'org.locationtech.spatial4j:spatial4j:0.7'
     testImplementation group: 'junit', name: 'junit', version: '4.13'

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'org.apache.commons:commons-lang3:3.6'
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.google.flogger:flogger:0.5.1'
+    implementation 'com.univocity:univocity-parsers:2.9.0'
     implementation 'io.sgr:s2-geometry-library-java:1.0.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -32,6 +32,7 @@ import com.squareup.javapoet.MethodSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
+import com.univocity.parsers.common.TextParsingException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -41,6 +42,7 @@ import javax.lang.model.element.Modifier;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
 import org.mobilitydata.gtfsvalidator.annotation.Generated;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsLoader;
+import org.mobilitydata.gtfsvalidator.notice.CsvParsingFailedNotice;
 import org.mobilitydata.gtfsvalidator.notice.EmptyFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -211,8 +213,16 @@ public class TableLoaderGenerator {
             .addParameter(NoticeContainer.class, "noticeContainer")
             .returns(
                 ParameterizedTypeName.get(ClassName.get(GtfsTableContainer.class), gtfsEntityType))
+            .addStatement("$T csvFile", CsvFile.class)
+            .beginControlFlow("try")
+            .addStatement("csvFile = new $T(inputStream, FILENAME)", CsvFile.class)
+            .nextControlFlow("catch ($T e)", TextParsingException.class)
             .addStatement(
-                "$T csvFile = new $T(inputStream, FILENAME)", CsvFile.class, CsvFile.class)
+                "noticeContainer.addValidationNotice(new $T(FILENAME, e))",
+                CsvParsingFailedNotice.class)
+            .addStatement(
+                "return new $T($T.INVALID_HEADERS)", tableContainerTypeName, TableStatus.class)
+            .endControlFlow()
             .beginControlFlow("if (csvFile.isEmpty())")
             .addStatement(
                 "noticeContainer.addValidationNotice(new $T(FILENAME))", EmptyFileNotice.class)
@@ -279,6 +289,7 @@ public class TableLoaderGenerator {
             gtfsEntityType);
 
     method
+        .beginControlFlow("try")
         .beginControlFlow("for ($T row : csvFile)", CsvRow.class)
         .beginControlFlow("if (row.getRowNumber() % $L == 0)", LOG_EVERY_N_ROWS)
         .addStatement("logger.atInfo().log($S, FILENAME, row.getRowNumber())", "Reading %s, row %d")
@@ -324,7 +335,15 @@ public class TableLoaderGenerator {
         .endControlFlow()
         .addStatement("noticeContainer.addAll(rowNotices)");
 
-    method.endControlFlow(); // end for (row)
+    method
+        .endControlFlow() // end for (row)
+        .nextControlFlow("catch ($T e)", TextParsingException.class)
+        .addStatement(
+            "noticeContainer.addValidationNotice(new $T(FILENAME, e))",
+            CsvParsingFailedNotice.class)
+        .addStatement(
+            "return new $T($T.UNPARSABLE_ROWS)", tableContainerTypeName, TableStatus.class)
+        .nextControlFlow("finally");
 
     // Print statistics for cache efficiency.
     for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
@@ -342,6 +361,8 @@ public class TableLoaderGenerator {
             cacheName);
       }
     }
+
+    method.endControlFlow(); // end try-catch-finally
 
     method
         .beginControlFlow("if (hasUnparsableRows)")


### PR DESCRIPTION
If a CSV file failed to parse, there will be a clear user-visible
notice, e.g.:

```
        {
            "code": "csv_parsing_failed",
            "severity": "ERROR",
            "totalNotices": 1,
            "notices": [
                {
                    "filename": "stops.txt",
                    "charIndex": 278201,
                    "columnIndex": 2,
                    "lineIndex": 2148,
                    "message": "Length of parsed input (4097) exceeds the maximum number of characters defined in your parser settings (4096).",
                    "content": "..."
                }
            ]
         }
```
