### PR TITLE
feat: print help menu

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -11,6 +11,7 @@
 |------------	|-------------------------------	|-----------	|---------------------------------------------------------------------------------------------------------------------------	|
 | `-i`       	| `--input`                     	| Optional  	| Location of the input GTFS ZIP or unarchived directory.                                                                   	|
 | `-c`       	| `--country_code`                 	| Optional  	| Country code of the feed, e.g., `nl`. It must be a two-letter country code (ISO 3166-1 alpha-2).                           	|
+| `-h`       	| `--help`                 	        | Optional  	| Print help menu.                                                                                                              |
 | `-o`       	| `--output`                    	| Optional  	| Base directory to store the outputs.                                                                                      	|
 | `-s`       	| `--storage_directory`         	| Optional  	| Target path where to store the GTFS archive. Downloaded from network (if not provided, the ZIP will be stored in memory). 	|
 | `-t`       	| `--threads`                   	| Optional  	| Number of threads to use.                                                                                                 	|
@@ -21,6 +22,8 @@
 ⚠️ Note that exactly one of the following options must be provided: `--url` or `--input`.
 
 ⚠️ Note that `--storage_directory` must not be provided if `--url` is not provided.
+
+⚠️ Note that parameters marked with an asterisk (*) in the help menu are mandatory.
 
 ### on a local GTFS zip file
 Sample usage:

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -71,6 +71,12 @@ public class Arguments {
       description = "The name of the system errors report including .json extension.")
   private String systemErrorsReportName;
 
+  @Parameter(
+      names = {"-h", "--help"},
+      description = "Print help",
+      help = true)
+  private Boolean help = false;
+
   public String getFeedName() {
     return feedName;
   }
@@ -111,5 +117,9 @@ public class Arguments {
       return "system_errors.json";
     }
     return systemErrorsReportName;
+  }
+
+  public boolean getHelp() {
+    return help;
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -75,7 +75,7 @@ public class Arguments {
       names = {"-h", "--help"},
       description = "Print help",
       help = true)
-  private Boolean help = false;
+  private boolean help = false;
 
   public String getFeedName() {
     return feedName;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -48,15 +48,15 @@ public class Main {
 
   public static void main(String[] argv) {
     Arguments args = new Arguments();
-    CliParametersAnalyzer cliParametersAnalyzer = new CliParametersAnalyzer();
     JCommander jCommander = new JCommander(args);
     jCommander.parse(argv);
     if (args.getHelp()) {
-      printHelp(jCommander);
+      jCommander.usage();
       System.out.println(
           "⚠️ Note that parameters marked with an asterisk (*) in the help menu are mandatory.");
       return;
     }
+    CliParametersAnalyzer cliParametersAnalyzer = new CliParametersAnalyzer();
     if (!cliParametersAnalyzer.isValid(args)) {
       System.exit(1);
     }
@@ -160,14 +160,5 @@ public class Main {
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");
     }
-  }
-
-  /**
-   * Prints help menu
-   *
-   * @param jCommander the {@code JCommander} used to parse CLI arguments
-   */
-  private static void printHelp(JCommander jCommander) {
-    jCommander.usage();
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -53,6 +53,8 @@ public class Main {
     jCommander.parse(argv);
     if (args.getHelp()) {
       printHelp(jCommander);
+      System.out.println(
+          "⚠️ Note that parameters marked with an asterisk (*) in the help menu are mandatory.");
       return;
     }
     if (!cliParametersAnalyzer.isValid(args)) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -49,7 +49,12 @@ public class Main {
   public static void main(String[] argv) {
     Arguments args = new Arguments();
     CliParametersAnalyzer cliParametersAnalyzer = new CliParametersAnalyzer();
-    new JCommander(args).parse(argv);
+    JCommander jCommander = new JCommander(args);
+    jCommander.parse(argv);
+    if (args.getHelp()) {
+      printHelp(jCommander);
+      return;
+    }
     if (!cliParametersAnalyzer.isValid(args)) {
       System.exit(1);
     }
@@ -153,5 +158,14 @@ public class Main {
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");
     }
+  }
+
+  /**
+   * Prints help menu
+   *
+   * @param jCommander the {@code JCommander} used to parse CLI arguments
+   */
+  private static void printHelp(JCommander jCommander) {
+    jCommander.usage();
   }
 }


### PR DESCRIPTION
closes #857 

**Summary:**

This PR provides support to print help menu 

**Expected behavior:** 

Print help if `-h` is provided as a CLI parameter. Such help should describe the usage of each CLI parameter. When provided, presence of required parameters should not be checked.

Running the validator with the following CLI parameters:
* `-h`;
* `--help`;
* `-u http://webapps.thebus.org/transitdata/Production/google_transit.zip -o output -t 4 -h`;
*  or `-u http://webapps.thebus.org/transitdata/Production/google_transit.zip -o output -t 4 --help` produce the following output:

<img width="681" alt="Capture d’écran, le 2021-05-05 à 15 21 43" src="https://user-images.githubusercontent.com/35747326/117197287-a1ca2f00-adb5-11eb-93bd-5dceeaa3f36c.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
