### PR TITLE
feat: Export infinity and NaN values in JSON

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -34,7 +34,8 @@ import java.util.List;
  */
 public class NoticeContainer {
   private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
-  private static final Gson DEFAULT_GSON = new GsonBuilder().serializeNulls().create();
+  private static final Gson DEFAULT_GSON =
+      new GsonBuilder().serializeNulls().serializeSpecialFloatingPointValues().create();
 
   private final List<ValidationNotice> validationNotices = new ArrayList<>();
   private final List<SystemError> systemErrors = new ArrayList<>();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -65,6 +65,20 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void exportInfinityInContext() {
+    NoticeContainer container = new NoticeContainer();
+    container.addValidationNotice(
+        new TestValidationNotice(
+            "test_notice",
+            ImmutableMap.of("infinityField", Double.POSITIVE_INFINITY),
+            SeverityLevel.ERROR));
+    assertThat(container.exportValidationNotices())
+        .isEqualTo(
+            "{\"notices\":[{\"code\":\"test_notice\",\"severity\":\"ERROR\","
+                + "\"totalNotices\":1,\"notices\":[{\"infinityField\":Infinity}]}]}");
+  }
+
+  @Test
   public void exportSeverities() {
     NoticeContainer container = new NoticeContainer();
     container.addValidationNotice(


### PR DESCRIPTION
Some notices may have special double values (NaN, Infinity, -Infinity)
in the context. If we do not allow their serialization, then an attempt
to store validation results ends up with a runtime exception.

Documentation for GSON library says the following.

Section 2.4 of <a href="http://www.ietf.org/rfc/rfc4627.txt">JSON specification</a> disallows
special double values (NaN, Infinity, -Infinity). However,
<a href="http://www.ecma-international.org/publications/files/ECMA-ST/Ecma-262.pdf">Javascript
specification</a> (see section 4.3.20, 4.3.22, 4.3.23) allows these values as valid Javascript
values. Moreover, most JavaScript engines will accept these special values in JSON without
problem. So, at a practical level, it makes sense to accept these values as valid JSON even
though JSON specification disallows them.
