### PR TITLE
fix: bump debian version used in docker image

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker image
 
 on:
-  release:
-    types: [ prereleased, released ]
+  push:
+    branches: [ fix/debian-version-used-in-docker-image ]
 
 jobs:
   test:
@@ -122,7 +122,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ steps.prep.outputs.tags }}
+          tags: ${{ github.sha }}
           labels: |
             org.opencontainers.image.source=https://github.com/mobilitydata/gtfs-validator.git
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -122,7 +122,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          tags: ${{ github.sha }}
+          tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=https://github.com/mobilitydata/gtfs-validator.git
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,8 +1,8 @@
 name: Docker image
 
 on:
-  push:
-    branches: [ fix/debian-version-used-in-docker-image ]
+  release:
+    types: [ prereleased, released ]
 
 jobs:
   test:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM java:8
-COPY main/build/libs/*.jar /
+FROM java:11
 WORKDIR /
+COPY main/build/libs/*.jar /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM java:11
+FROM openjdk:11
 COPY main/build/libs/*.jar /
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
 FROM java:11
-WORKDIR /
 COPY main/build/libs/*.jar /
+WORKDIR /


### PR DESCRIPTION
closes #844 

**Summary:**

This PR provides support to bump debian version used in docker image.

**Expected behavior:** 

Pull the image generated for this bug fix:

1. `docker pull ghcr.io/mobilitydata/gtfs-validator:fix-debian-version-used-in-docker-image
`
2. Run `cat /etc/issue` to see Debian version.

<img width="353" alt="Capture d’écran, le 2021-05-05 à 14 37 03" src="https://user-images.githubusercontent.com/35747326/117192122-5c0a6800-adaf-11eb-8d45-d0cf013676de.png">

Debian version is 10 🎉

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
