### PR TITLE
feat: Return non-null for invalid strings and doubles

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -199,7 +199,7 @@ public class RowParser {
               header.getColumnName(columnIndex),
               "latitude within [-90, 90]",
               value));
-      return null;
+      return value;
     }
     return value;
   }
@@ -215,7 +215,7 @@ public class RowParser {
               header.getColumnName(columnIndex),
               "longitude within [-180, 180]",
               value));
-      return null;
+      return value;
     }
     return value;
   }
@@ -379,7 +379,7 @@ public class RowParser {
    * @param columnIndex index of the column to parse
    * @param required whether the value is required according to GTFS
    * @param validatingFunction the predicate to validate a given string
-   * @return the cell value at the given column or null if the value is missing or invalid
+   * @return the cell value at the given column or null if the value is missing
    */
   @Nullable
   private String asValidatedString(
@@ -388,15 +388,10 @@ public class RowParser {
     if (s == null) {
       return null;
     }
-    NoticeContainer fieldNotices = new NoticeContainer();
     validatingFunction.apply(
         s,
         GtfsCellContext.create(fileName, row.getRowNumber(), header.getColumnName(columnIndex)),
-        fieldNotices);
-    noticeContainer.addAll(fieldNotices);
-    if (fieldNotices.hasValidationErrors()) {
-      return null;
-    }
+        noticeContainer);
     return s;
   }
 


### PR DESCRIPTION
This is a performance improvement: this way we do not create a
temporary NoticeContainer object for each string value.

This affects the following functions:
* asLatitude
* asLongitude
* asUrl
* asEmail
* asPhoneNumber

These functions were returning null for invalid values just for
consistency with such functions as asLanguageCode or asTimezone that
are not able to return a valid Locale or ZoneId object for invalid field
values.

There is no practical need to return null for invalid values. A
TableLoader creates a separate NoticeContainer instance per each row and
if there are any errors for any cell, the whole row is considered
invalid.
