### PR TITLE
feat: Prevent OOM in NoticeContainer and speed up hasValidationErrors

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -24,6 +24,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -33,38 +34,87 @@ import java.util.List;
  * own NoticeContainer, and after execution is complete the results are merged.
  */
 public class NoticeContainer {
-  private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
   private static final Gson DEFAULT_GSON =
       new GsonBuilder().serializeNulls().serializeSpecialFloatingPointValues().create();
 
+  /** Limit on the amount of exported notices of the same type and severity. */
+  private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
+
+  /**
+   * Limit on the total amount of stored validation notices.
+   *
+   * <p>This is a measure to prevent OOM in the rare case when each row in a large file (such as
+   * stop_times.txt or shapes.txt) produces a notice. Since this case is rare, we just introduce a
+   * total limit on the amount of notices instead of counting amount of notices of each type.
+   *
+   * Note that system errors are not limited since we don't expect to have a lot of them.
+   */
+  private static final int MAX_VALIDATION_NOTICES = 10000000;
+
   private final List<ValidationNotice> validationNotices = new ArrayList<>();
   private final List<SystemError> systemErrors = new ArrayList<>();
+  private boolean hasValidationErrors = false;
 
+  /** Adds a new validation notice to the container (if there is capacity). */
   public void addValidationNotice(ValidationNotice notice) {
-    validationNotices.add(notice);
+    if (notice.isError()) {
+      hasValidationErrors = true;
+    }
+    if (validationNotices.size() <= MAX_VALIDATION_NOTICES) {
+      validationNotices.add(notice);
+    }
   }
 
+  /** Adds a new system error to the container (if there is capacity). */
   public void addSystemError(SystemError error) {
     systemErrors.add(error);
   }
 
+  /**
+   * Adds all validation notices and system errors from another container.
+   *
+   * <p>This is useful for multithreaded validation: each thread has its own notice container which
+   * is merged into the global container when the thread finishes.
+   *
+   * @param otherContainer a container to take the notices from
+   */
+  public void addAll(NoticeContainer otherContainer) {
+    validationNotices.addAll(otherContainer.validationNotices);
+    systemErrors.addAll(otherContainer.systemErrors);
+    hasValidationErrors |= otherContainer.hasValidationErrors;
+  }
+
+  /** Tells if this container has any {@code ValidationNotice} that is an error. */
+  public boolean hasValidationErrors() {
+    return hasValidationErrors;
+  }
+
+  /** Returns a list of all validation notices in the container. */
   public List<ValidationNotice> getValidationNotices() {
-    return validationNotices;
+    return Collections.unmodifiableList(validationNotices);
   }
 
+  /** Returns a list of all system errors in the container. */
   public List<SystemError> getSystemErrors() {
-    return systemErrors;
+    return Collections.unmodifiableList(systemErrors);
   }
 
+  /** Exports all validation notices as JSON. */
   public String exportValidationNotices() {
     return exportJson(validationNotices);
   }
 
+  /** Exports all system errors as JSON. */
   public String exportSystemErrors() {
     return exportJson(systemErrors);
   }
 
-  private static <T extends Notice> String exportJson(List<T> notices) {
+  /**
+   * Exports notices as JSON.
+   *
+   * Up to {@link #MAX_EXPORTS_PER_NOTICE_TYPE} is exported per each type+severity.
+   */
+  public static <T extends Notice> String exportJson(List<T> notices) {
     JsonObject root = new JsonObject();
     JsonArray jsonNotices = new JsonArray();
     root.add("notices", jsonNotices);
@@ -99,32 +149,5 @@ public class NoticeContainer {
       noticesByType.put(notice.getCode() + notice.getSeverityLevel().ordinal(), notice);
     }
     return noticesByType;
-  }
-
-  /**
-   * Adds all validation notices and system errors from another container.
-   *
-   * <p>This is useful for multithreaded validation: each thread has its own notice container which
-   * is merged into the global container when the thread finishes.
-   *
-   * @param otherContainer a container to take the notices from
-   */
-  public void addAll(NoticeContainer otherContainer) {
-    validationNotices.addAll(otherContainer.validationNotices);
-    systemErrors.addAll(otherContainer.systemErrors);
-  }
-
-  /**
-   * Tells if this container has any {@code ValidationNotice} that is an error.
-   *
-   * <p>Note that this method is O(n) since it iterates over all validation notices.
-   */
-  public boolean hasValidationErrors() {
-    for (ValidationNotice notice : validationNotices) {
-      if (notice.isError()) {
-        return true;
-      }
-    }
-    return false;
   }
 }


### PR DESCRIPTION
Store up to 10 M validation notices. This is a measure to prevent OOM
in the rare case when each row in a large file (such as stop_times.txt
or shapes.txt) produces a notice. Since this case is rare, we just
introduce a total limit on the amount of notices instead of counting
amount of notices of each type.

Note that system errors are not limited since we don't expect to have
a lot of them.

Now we have a boolean field to flag if there are validation errors. This
way hasValidationErrors() now takes O(1) instead of O(n).

We also documented the methods and return unmodifiableList from getters.
We cannot use ImmutableList since the notice lists are always growing.