### PR TITLE
feat: Return void from TableHeaderValidator.validate

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
@@ -31,16 +31,15 @@ import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 /** Default implementation of {@code TableHeaderValidator}. */
 public class DefaultTableHeaderValidator implements TableHeaderValidator {
   @Override
-  public boolean validate(
+  public void validate(
       String filename,
       CsvHeader actualHeader,
       Set<String> supportedColumns,
       Set<String> requiredColumns,
       NoticeContainer noticeContainer) {
-    boolean isValid = true;
     if (actualHeader.getColumnCount() == 0) {
       // This is an empty file.
-      return isValid;
+      return;
     }
     Map<String, Integer> columnIndices = new HashMap<>();
     // Sorted tree set for stable order of notices.
@@ -56,7 +55,6 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
       if (prev != null) {
         noticeContainer.addValidationNotice(
             new DuplicatedColumnNotice(filename, column, prev + 1, i + 1));
-        isValid = false;
       }
       if (!supportedColumns.contains(column)) {
         noticeContainer.addValidationNotice(new UnknownColumnNotice(filename, column, i + 1));
@@ -64,11 +62,9 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
       missingColumns.remove(column);
     }
     if (!missingColumns.isEmpty()) {
-      isValid = false;
       for (String column : missingColumns) {
         noticeContainer.addValidationNotice(new MissingRequiredColumnNotice(filename, column));
       }
     }
-    return isValid;
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
@@ -22,12 +22,8 @@ import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 
 /** A validator that checks table headers for required columns etc. */
 public interface TableHeaderValidator {
-  /**
-   * Validates header of a single GTFS CSV table.
-   *
-   * @return true is the header is valid, false otherwise
-   */
-  boolean validate(
+  /** Validates header of a single GTFS CSV table and adds errors and warnings to the container. */
+  void validate(
       String filename,
       CsvHeader actualHeader,
       Set<String> supportedColumns,

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
@@ -34,101 +34,95 @@ public class TableHeaderValidatorTest {
   @Test
   public void expectedColumns() {
     NoticeContainer container = new NoticeContainer();
+    new DefaultTableHeaderValidator()
+        .validate(
+            "stops.txt",
+            new CsvHeader(new String[] {"stop_id", "stop_name"}),
+            ImmutableSet.of("stop_id", "stop_name", "stop_lat", "stop_lon"),
+            ImmutableSet.of("stop_id"),
+            container);
 
-    assertThat(
-            new DefaultTableHeaderValidator()
-                .validate(
-                    "stops.txt",
-                    new CsvHeader(new String[] {"stop_id", "stop_name"}),
-                    ImmutableSet.of("stop_id", "stop_name", "stop_lat", "stop_lon"),
-                    ImmutableSet.of("stop_id"),
-                    container))
-        .isTrue();
-    assertThat(container.getValidationNotices().isEmpty()).isTrue();
+    assertThat(container.getValidationNotices()).isEmpty();
+    assertThat(container.hasValidationErrors()).isFalse();
   }
 
   @Test
   public void unknownColumnShouldGenerateNotice() {
     NoticeContainer container = new NoticeContainer();
+    new DefaultTableHeaderValidator()
+        .validate(
+            "stops.txt",
+            new CsvHeader(new String[] {"stop_id", "stop_name", "stop_extra"}),
+            ImmutableSet.of("stop_id", "stop_name"),
+            ImmutableSet.of("stop_id"),
+            container);
 
-    assertThat(
-            new DefaultTableHeaderValidator()
-                .validate(
-                    "stops.txt",
-                    new CsvHeader(new String[] {"stop_id", "stop_name", "stop_extra"}),
-                    ImmutableSet.of("stop_id", "stop_name"),
-                    ImmutableSet.of("stop_id"),
-                    container))
-        .isTrue();
     assertThat(container.getValidationNotices())
         .containsExactly(new UnknownColumnNotice("stops.txt", "stop_extra", 3));
+    assertThat(container.hasValidationErrors()).isFalse();
   }
 
   @Test
   public void missingRequiredColumnShouldGenerateNotice() {
     NoticeContainer container = new NoticeContainer();
+    new DefaultTableHeaderValidator()
+        .validate(
+            "stops.txt",
+            new CsvHeader(new String[] {"stop_name"}),
+            ImmutableSet.of("stop_id", "stop_name"),
+            ImmutableSet.of("stop_id"),
+            container);
 
-    assertThat(
-            new DefaultTableHeaderValidator()
-                .validate(
-                    "stops.txt",
-                    new CsvHeader(new String[] {"stop_name"}),
-                    ImmutableSet.of("stop_id", "stop_name"),
-                    ImmutableSet.of("stop_id"),
-                    container))
-        .isFalse();
     assertThat(container.getValidationNotices())
         .containsExactly(new MissingRequiredColumnNotice("stops.txt", "stop_id"));
+    assertThat(container.hasValidationErrors()).isTrue();
   }
 
   @Test
   public void duplicatedColumnShouldGenerateNotice() {
     NoticeContainer container = new NoticeContainer();
+    new DefaultTableHeaderValidator()
+        .validate(
+            "stops.txt",
+            new CsvHeader(new String[] {"stop_id", "stop_name", "stop_id"}),
+            ImmutableSet.of("stop_id", "stop_name"),
+            ImmutableSet.of("stop_id"),
+            container);
 
-    assertThat(
-            new DefaultTableHeaderValidator()
-                .validate(
-                    "stops.txt",
-                    new CsvHeader(new String[] {"stop_id", "stop_name", "stop_id"}),
-                    ImmutableSet.of("stop_id", "stop_name"),
-                    ImmutableSet.of("stop_id"),
-                    container))
-        .isFalse();
     assertThat(container.getValidationNotices())
         .containsExactly(new DuplicatedColumnNotice("stops.txt", "stop_id", 1, 3));
+    assertThat(container.hasValidationErrors()).isTrue();
   }
 
   @Test
   public void emptyFileShouldNotGenerateNotice() {
     NoticeContainer container = new NoticeContainer();
+    new DefaultTableHeaderValidator()
+        .validate(
+            "stops.txt",
+            CsvHeader.EMPTY,
+            ImmutableSet.of("stop_id", "stop_name"),
+            ImmutableSet.of("stop_id"),
+            container);
 
-    assertThat(
-            new DefaultTableHeaderValidator()
-                .validate(
-                    "stops.txt",
-                    CsvHeader.EMPTY,
-                    ImmutableSet.of("stop_id", "stop_name"),
-                    ImmutableSet.of("stop_id"),
-                    container))
-        .isTrue();
-    assertThat(container.getValidationNotices().isEmpty()).isTrue();
+    assertThat(container.getValidationNotices()).isEmpty();
+    assertThat(container.hasValidationErrors()).isFalse();
   }
 
   @Test
   public void emptyColumnNameShouldGenerateNotice() {
     NoticeContainer container = new NoticeContainer();
+    new DefaultTableHeaderValidator()
+        .validate(
+            "stops.txt",
+            new CsvHeader(new String[] {"stop_id", null, "stop_name", ""}),
+            ImmutableSet.of("stop_id", "stop_name"),
+            ImmutableSet.of("stop_id"),
+            container);
 
-    assertThat(
-            new DefaultTableHeaderValidator()
-                .validate(
-                    "stops.txt",
-                    new CsvHeader(new String[] {"stop_id", null, "stop_name", ""}),
-                    ImmutableSet.of("stop_id", "stop_name"),
-                    ImmutableSet.of("stop_id"),
-                    container))
-        .isTrue();
     assertThat(container.getValidationNotices())
         .containsExactly(
             new EmptyColumnNameNotice("stops.txt", 2), new EmptyColumnNameNotice("stops.txt", 4));
+    assertThat(container.hasValidationErrors()).isFalse();
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -238,9 +238,13 @@ public class TableLoaderGenerator {
             .addStatement("return table")
             .endControlFlow()
             .addStatement("$T header = csvFile.getHeader()", CsvHeader.class)
-            .beginControlFlow(
-                "if (!validatorProvider.getTableHeaderValidator().validate(FILENAME, header, "
-                    + "getColumnNames(), getRequiredColumnNames(), noticeContainer))")
+            .addStatement(
+                "$T headerNotices = new $T()", NoticeContainer.class, NoticeContainer.class)
+            .addStatement(
+                "validatorProvider.getTableHeaderValidator().validate(FILENAME, header, "
+                    + "getColumnNames(), getRequiredColumnNames(), headerNotices)")
+            .addStatement("noticeContainer.addAll(headerNotices)")
+            .beginControlFlow("if (headerNotices.hasValidationErrors())")
             .addStatement(
                 "return new $T($T.INVALID_HEADERS)", tableContainerTypeName, TableStatus.class)
             .endControlFlow();


### PR DESCRIPTION
This simplifies the implementation logic and prevents potential bugs
when the function returns true ("valid") but adds some errors to the
container or vice versa.

Note that GtfsFieldValidator follows the same pattern: its validation
methods return void and the caller must use
NoticeContainer.hasValidationErrors.

Sample generated code.

```
    NoticeContainer headerNotices = new NoticeContainer();
    validatorProvider
        .getTableHeaderValidator()
        .validate(FILENAME, header, getColumnNames(), getRequiredColumnNames(), headerNotices);
    noticeContainer.addAll(headerNotices);
    if (headerNotices.hasValidationErrors()) {
      return new GtfsCalendarTableContainer(GtfsTableContainer.TableStatus.INVALID_HEADERS);
    }
```