### PR TITLE
fix: Protect against start_date and end_date in wrong order

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
@@ -42,6 +42,10 @@ public final class CalendarUtil {
     if (calendar != null) {
       serviceStart = calendar.startDate().getLocalDate();
       serviceEnd = calendar.endDate().getLocalDate();
+      if (serviceStart.isAfter(serviceEnd)) {
+        // Protection against invalid data. An error is reported by a dedicated validator.
+        serviceEnd = serviceStart;
+      }
       weeklyPattern =
           ServicePeriod.weeklyPatternFromMTWTFSS(
               calendar.mondayValue(),

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
@@ -72,7 +72,7 @@ public class CalendarUtilTest {
   }
 
   @Test
-  public void createServicePeriod() {
+  public void createServicePeriod_valid() {
     ServicePeriod servicePeriod =
         CalendarUtil.createServicePeriod(
             createGtfsCalendar(
@@ -92,13 +92,28 @@ public class CalendarUtilTest {
   }
 
   @Test
-  public void CreateServicePeriodEmpty() {
+  public void createServicePeriod_empty() {
     ServicePeriod servicePeriod = CalendarUtil.createServicePeriod(null, ImmutableList.of());
     assertThat(servicePeriod.getServiceStart()).isEqualTo(ServicePeriod.EPOCH);
     assertThat(servicePeriod.getServiceEnd()).isEqualTo(ServicePeriod.EPOCH);
     assertThat(servicePeriod.getWeeklyPattern()).isEqualTo(0);
     assertThat(servicePeriod.getAddedDays()).isEmpty();
     assertThat(servicePeriod.getRemovedDays()).isEmpty();
+  }
+
+  @Test
+  public void createServicePeriod_startAfterEnd() {
+    ServicePeriod servicePeriod =
+        CalendarUtil.createServicePeriod(
+            createGtfsCalendar(
+                "s1",
+                LocalDate.of(2021, 1, 5),
+                LocalDate.of(2021, 1, 4),
+                ImmutableSet.of(DayOfWeek.MONDAY, DayOfWeek.TUESDAY)),
+            ImmutableList.of());
+    assertThat(servicePeriod.getServiceStart()).isEqualTo(LocalDate.of(2021, 1, 5));
+    assertThat(servicePeriod.getServiceEnd()).isEqualTo(LocalDate.of(2021, 1, 5));
+    assertThat(servicePeriod.toDates()).containsExactly(LocalDate.of(2021, 1, 5));
   }
 
   @Test


### PR DESCRIPTION
ServicePeriod constructor throws an exception for start and end date in
wrong order. There is a dedicated GtfsCalendarEndRangeValidator, so an
error is reported to the end user. This change avoids throwing an
exception in other validators that rely on CalendarUtil.
