### PR TITLE
feat: Treat empty files as parsed unsuccessfully

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -93,7 +93,6 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
    */
   public boolean isParsedSuccessfully() {
     switch (tableStatus) {
-      case EMPTY_FILE:
       case PARSABLE_HEADERS_AND_ROWS:
         return true;
       case MISSING_FILE:

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -226,16 +226,7 @@ public class TableLoaderGenerator {
             .beginControlFlow("if (csvFile.isEmpty())")
             .addStatement(
                 "noticeContainer.addValidationNotice(new $T(FILENAME))", EmptyFileNotice.class)
-            .addStatement(
-                "$T table = new $T($T.EMPTY_FILE)",
-                tableContainerTypeName,
-                tableContainerTypeName,
-                TableStatus.class)
-            .addStatement(
-                "$T.invokeSingleFileValidators(validatorProvider.createSingleFileValidators(table),"
-                    + " noticeContainer)",
-                ValidatorUtil.class)
-            .addStatement("return table")
+            .addStatement("return new $T($T.EMPTY_FILE)", tableContainerTypeName, TableStatus.class)
             .endControlFlow()
             .addStatement("$T header = csvFile.getHeader()", CsvHeader.class)
             .beginControlFlow(


### PR DESCRIPTION
EmptyFileNotice is already an ERROR.

We have verified on 3K feeds at Google that none provides empty CSV file
(i.e. a file that contains no rows and no headers). We do not see a use
case for empty files in GTFS.

Since an empty file is an error, we do not invoke single-file validators
for it. Cross-file validations will not be invoked if any file is
completely empty.

In future we may merge EMPTY_FILE, INVALID_HEADERS and UNPARSABLE_ROWS
into a single constant.
