### PR TITLE
feat: introduce -p CLI parameter to output beautified reports

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -36,6 +36,8 @@ import java.util.List;
 public class NoticeContainer {
   private static final Gson DEFAULT_GSON =
       new GsonBuilder().serializeNulls().serializeSpecialFloatingPointValues().create();
+  private static final Gson PRETTY_GSON =
+      new GsonBuilder().setPrettyPrinting().serializeNulls().serializeSpecialFloatingPointValues().create();
 
   /** Limit on the amount of exported notices of the same type and severity. */
   private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
@@ -100,13 +102,13 @@ public class NoticeContainer {
   }
 
   /** Exports all validation notices as JSON. */
-  public String exportValidationNotices() {
-    return exportJson(validationNotices);
+  public String exportValidationNotices(boolean isPretty) {
+    return exportJson(validationNotices, isPretty);
   }
 
   /** Exports all system errors as JSON. */
-  public String exportSystemErrors() {
-    return exportJson(systemErrors);
+  public String exportSystemErrors(boolean isPretty) {
+    return exportJson(systemErrors, isPretty);
   }
 
   /**
@@ -114,10 +116,11 @@ public class NoticeContainer {
    *
    * <p>Up to {@link #MAX_EXPORTS_PER_NOTICE_TYPE} is exported per each type+severity.
    */
-  public static <T extends Notice> String exportJson(List<T> notices) {
+  public static <T extends Notice> String exportJson(List<T> notices, boolean isPretty) {
     JsonObject root = new JsonObject();
     JsonArray jsonNotices = new JsonArray();
     root.add("notices", jsonNotices);
+    Gson GSON = isPretty ? PRETTY_GSON : DEFAULT_GSON;
 
     for (Collection<T> noticesOfType : groupNoticesByTypeAndSeverity(notices).asMap().values()) {
       JsonObject noticesOfTypeJson = new JsonObject();
@@ -135,11 +138,11 @@ public class NoticeContainer {
           // Do not export too many notices for this type.
           break;
         }
-        noticesArrayJson.add(DEFAULT_GSON.toJsonTree(notice.getContext()));
+        noticesArrayJson.add(GSON.toJsonTree(notice.getContext()));
       }
     }
 
-    return DEFAULT_GSON.toJson(root);
+    return GSON.toJson(root);
   }
 
   private static <T extends Notice> ListMultimap<String, T> groupNoticesByTypeAndSeverity(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -56,49 +56,6 @@ public class NoticeContainer {
   private final List<SystemError> systemErrors = new ArrayList<>();
   private boolean hasValidationErrors = false;
 
-  /**
-   * Exports notices as JSON.
-   *
-   * <p>Up to {@link #MAX_EXPORTS_PER_NOTICE_TYPE} is exported per each type+severity.
-   */
-  public static <T extends Notice> String exportJson(List<T> notices, boolean isPretty) {
-    JsonObject root = new JsonObject();
-    JsonArray jsonNotices = new JsonArray();
-    root.add("notices", jsonNotices);
-    Gson gson = isPretty ? PRETTY_GSON : DEFAULT_GSON;
-
-    for (Collection<T> noticesOfType : groupNoticesByTypeAndSeverity(notices).asMap().values()) {
-      JsonObject noticesOfTypeJson = new JsonObject();
-      jsonNotices.add(noticesOfTypeJson);
-      T firstNotice = noticesOfType.iterator().next();
-      noticesOfTypeJson.addProperty("code", firstNotice.getCode());
-      noticesOfTypeJson.addProperty("severity", firstNotice.getSeverityLevel().toString());
-      noticesOfTypeJson.addProperty("totalNotices", noticesOfType.size());
-      JsonArray noticesArrayJson = new JsonArray();
-      noticesOfTypeJson.add("notices", noticesArrayJson);
-      int i = 0;
-      for (T notice : noticesOfType) {
-        ++i;
-        if (i > MAX_EXPORTS_PER_NOTICE_TYPE) {
-          // Do not export too many notices for this type.
-          break;
-        }
-        noticesArrayJson.add(gson.toJsonTree(notice.getContext()));
-      }
-    }
-
-    return gson.toJson(root);
-  }
-
-  private static <T extends Notice> ListMultimap<String, T> groupNoticesByTypeAndSeverity(
-      List<T> notices) {
-    ListMultimap<String, T> noticesByType = MultimapBuilder.treeKeys().arrayListValues().build();
-    for (T notice : notices) {
-      noticesByType.put(notice.getCode() + notice.getSeverityLevel().ordinal(), notice);
-    }
-    return noticesByType;
-  }
-
   /** Adds a new validation notice to the container (if there is capacity). */
   public void addValidationNotice(ValidationNotice notice) {
     if (notice.isError()) {
@@ -151,5 +108,48 @@ public class NoticeContainer {
   /** Exports all system errors as JSON. */
   public String exportSystemErrors(boolean isPretty) {
     return exportJson(systemErrors, isPretty);
+  }
+
+  /**
+   * Exports notices as JSON.
+   *
+   * <p>Up to {@link #MAX_EXPORTS_PER_NOTICE_TYPE} is exported per each type+severity.
+   */
+  public static <T extends Notice> String exportJson(List<T> notices, boolean isPretty) {
+    JsonObject root = new JsonObject();
+    JsonArray jsonNotices = new JsonArray();
+    root.add("notices", jsonNotices);
+    Gson gson = isPretty ? PRETTY_GSON : DEFAULT_GSON;
+
+    for (Collection<T> noticesOfType : groupNoticesByTypeAndSeverity(notices).asMap().values()) {
+      JsonObject noticesOfTypeJson = new JsonObject();
+      jsonNotices.add(noticesOfTypeJson);
+      T firstNotice = noticesOfType.iterator().next();
+      noticesOfTypeJson.addProperty("code", firstNotice.getCode());
+      noticesOfTypeJson.addProperty("severity", firstNotice.getSeverityLevel().toString());
+      noticesOfTypeJson.addProperty("totalNotices", noticesOfType.size());
+      JsonArray noticesArrayJson = new JsonArray();
+      noticesOfTypeJson.add("notices", noticesArrayJson);
+      int i = 0;
+      for (T notice : noticesOfType) {
+        ++i;
+        if (i > MAX_EXPORTS_PER_NOTICE_TYPE) {
+          // Do not export too many notices for this type.
+          break;
+        }
+        noticesArrayJson.add(gson.toJsonTree(notice.getContext()));
+      }
+    }
+
+    return gson.toJson(root);
+  }
+
+  private static <T extends Notice> ListMultimap<String, T> groupNoticesByTypeAndSeverity(
+      List<T> notices) {
+    ListMultimap<String, T> noticesByType = MultimapBuilder.treeKeys().arrayListValues().build();
+    for (T notice : notices) {
+      noticesByType.put(notice.getCode() + notice.getSeverityLevel().ordinal(), notice);
+    }
+    return noticesByType;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -29,24 +29,71 @@ import org.junit.runners.JUnit4;
 public class NoticeContainerTest {
 
   @Test
-  public void exportJson() {
+  public void exportJson_defaultPrint() {
     NoticeContainer container = new NoticeContainer();
     container.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
     container.addValidationNotice(new MissingRequiredFileNotice("agency.txt"));
     container.addSystemError(
         new RuntimeExceptionInValidatorError(
             "FaultyValidator", new IndexOutOfBoundsException("Index 0 out of bounds")));
-    assertThat(container.exportValidationNotices())
+    assertThat(container.exportValidationNotices(false))
         .isEqualTo(
             "{\"notices\":["
                 + "{\"code\":\"missing_required_file\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":2,\"notices\":"
                 + "[{\"filename\":\"stops.txt\"},{\"filename\":\"agency.txt\"}]}]}");
-    assertThat(container.exportSystemErrors())
+    assertThat(container.exportSystemErrors(false))
         .isEqualTo(
             "{\"notices\":[{\"code\":\"runtime_exception_in_validator_error\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":1,\"notices\":[{\"validator\":\"FaultyValidator\",\"exception\":\"java.lang.IndexOutOfBoundsException\",\"message\":\"Index"
                 + " 0 out of bounds\"}]}]}");
+  }
+
+  @Test
+  public void exportJson_prettyPrint() {
+    NoticeContainer container = new NoticeContainer();
+    container.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+    container.addValidationNotice(new MissingRequiredFileNotice("agency.txt"));
+    container.addSystemError(
+        new RuntimeExceptionInValidatorError(
+            "FaultyValidator", new IndexOutOfBoundsException("Index 0 out of bounds")));
+    assertThat(container.exportValidationNotices(true))
+        .isEqualTo(
+            "{\n"
+                + "  \"notices\": [\n"
+                + "    {\n"
+                + "      \"code\": \"missing_required_file\",\n"
+                + "      \"severity\": \"ERROR\",\n"
+                + "      \"totalNotices\": 2,\n"
+                + "      \"notices\": [\n"
+                + "        {\n"
+                + "          \"filename\": \"stops.txt\"\n"
+                + "        },\n"
+                + "        {\n"
+                + "          \"filename\": \"agency.txt\"\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}");
+    assertThat(container.exportSystemErrors(true))
+        .isEqualTo(
+            "{\n"
+                + "  \"notices\": [\n"
+                + "    {\n"
+                + "      \"code\": \"runtime_exception_in_validator_error\",\n"
+                + "      \"severity\": \"ERROR\",\n"
+                + "      \"totalNotices\": 1,\n"
+                + "      \"notices\": [\n"
+                + "        {\n"
+                + "          \"validator\": \"FaultyValidator\",\n"
+                + "          \"exception\": \"java.lang.IndexOutOfBoundsException\",\n"
+                + "          \"message\": \"Index 0 out of bounds\"\n"
+                + "        }\n"
+                + "      ]\n"
+                + "    }\n"
+                + "  ]\n"
+                + "}");
   }
 
   @Test
@@ -58,7 +105,7 @@ public class NoticeContainerTest {
     context.put("nullField", null);
     container.addValidationNotice(
         new TestValidationNotice("test_notice", context, SeverityLevel.ERROR));
-    assertThat(container.exportValidationNotices())
+    assertThat(container.exportValidationNotices(false))
         .isEqualTo(
             "{\"notices\":[{\"code\":\"test_notice\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":1,\"notices\":[{\"nullField\":null}]}]}");
@@ -72,7 +119,7 @@ public class NoticeContainerTest {
             "test_notice",
             ImmutableMap.of("infinityField", Double.POSITIVE_INFINITY),
             SeverityLevel.ERROR));
-    assertThat(container.exportValidationNotices())
+    assertThat(container.exportValidationNotices(false))
         .isEqualTo(
             "{\"notices\":[{\"code\":\"test_notice\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":1,\"notices\":[{\"infinityField\":Infinity}]}]}");
@@ -87,7 +134,7 @@ public class NoticeContainerTest {
         new TestValidationNotice("notice_b", ImmutableMap.of("keyB", 2), SeverityLevel.ERROR));
     container.addValidationNotice(
         new TestValidationNotice("notice_a", ImmutableMap.of("keyC", 3), SeverityLevel.INFO));
-    assertThat(container.exportValidationNotices())
+    assertThat(container.exportValidationNotices(false))
         .isEqualTo(
             "{\"notices\":["
                 + "{\"code\":\"notice_a\",\"severity\":\"INFO\",\"totalNotices\":1,"

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -80,7 +80,7 @@ public class Arguments {
   @Parameter(
       names = {"-p", "--pretty"},
       description = "Pretty json output")
-  private Boolean pretty = false;
+  private boolean pretty = false;
 
   public String getFeedName() {
     return feedName;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -77,6 +77,11 @@ public class Arguments {
       help = true)
   private boolean help = false;
 
+  @Parameter(
+      names = {"-p", "--pretty"},
+      description = "Pretty json output")
+  private Boolean pretty = false;
+
   public String getFeedName() {
     return feedName;
   }
@@ -121,5 +126,9 @@ public class Arguments {
 
   public boolean getHelp() {
     return help;
+  }
+
+  public boolean getPretty() {
+    return pretty;
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -152,10 +152,10 @@ public class Main {
     try {
       Files.write(
           Paths.get(args.getOutputBase(), args.getValidationReportName()),
-          noticeContainer.exportValidationNotices().getBytes(StandardCharsets.UTF_8));
+          noticeContainer.exportValidationNotices(args.getPretty()).getBytes(StandardCharsets.UTF_8));
       Files.write(
           Paths.get(args.getOutputBase(), args.getSystemErrorsReportName()),
-          noticeContainer.exportSystemErrors().getBytes(StandardCharsets.UTF_8));
+          noticeContainer.exportSystemErrors(args.getPretty()).getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");
     }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -17,10 +17,8 @@
 package org.mobilitydata.gtfsvalidator.cli;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 
 import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
 import org.junit.Test;
 
 public class ArgumentsTest {
@@ -123,42 +121,5 @@ public class ArgumentsTest {
     assertThat(underTest.getOutputBase()).matches("output value");
     assertThat(underTest.getCountryCode()).matches("ca");
     assertThat(underTest.getNumThreads()).isEqualTo(1);
-  }
-
-  @Test
-  public void pretty_takesNoValue() {
-    String[] commandLineArgumentAsStringArray = {
-      "--input", "input value",
-      "--output_base", "output value",
-      "--pretty", "true"
-    };
-    Arguments underTest = new Arguments();
-    ;
-    assertThrows(
-        ParameterException.class,
-        () -> new JCommander(underTest).parse(commandLineArgumentAsStringArray));
-  }
-
-  @Test
-  public void pretty_provided_isTrue() {
-    String[] commandLineArgumentAsStringArray = {
-      "--input", "input value",
-      "--output_base", "output value",
-      "--pretty", ""
-    };
-    Arguments underTest = new Arguments();
-    new JCommander(underTest).parse(commandLineArgumentAsStringArray);
-    assertThat(underTest.getPretty()).isTrue();
-  }
-
-  @Test
-  public void pretty_notProvided_isFalse() {
-    String[] commandLineArgumentAsStringArray = {
-      "--input", "input value",
-      "--output_base", "output value",
-    };
-    Arguments underTest = new Arguments();
-    new JCommander(underTest).parse(commandLineArgumentAsStringArray);
-    assertThat(underTest.getPretty()).isFalse();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -17,8 +17,10 @@
 package org.mobilitydata.gtfsvalidator.cli;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 import org.junit.Test;
 
 public class ArgumentsTest {
@@ -121,5 +123,42 @@ public class ArgumentsTest {
     assertThat(underTest.getOutputBase()).matches("output value");
     assertThat(underTest.getCountryCode()).matches("ca");
     assertThat(underTest.getNumThreads()).isEqualTo(1);
+  }
+
+  @Test
+  public void pretty_takesNoValue() {
+    String[] commandLineArgumentAsStringArray = {
+      "--input", "input value",
+      "--output_base", "output value",
+      "--pretty", "true"
+    };
+    Arguments underTest = new Arguments();
+    ;
+    assertThrows(
+        ParameterException.class,
+        () -> new JCommander(underTest).parse(commandLineArgumentAsStringArray));
+  }
+
+  @Test
+  public void pretty_provided_isTrue() {
+    String[] commandLineArgumentAsStringArray = {
+      "--input", "input value",
+      "--output_base", "output value",
+      "--pretty", ""
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(commandLineArgumentAsStringArray);
+    assertThat(underTest.getPretty()).isTrue();
+  }
+
+  @Test
+  public void pretty_notProvided_isFalse() {
+    String[] commandLineArgumentAsStringArray = {
+      "--input", "input value",
+      "--output_base", "output value",
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(commandLineArgumentAsStringArray);
+    assertThat(underTest.getPretty()).isFalse();
   }
 }


### PR DESCRIPTION
closes #838 

**Summary:**

This PR provides support for an additional CLI parameter : `-p`/ `--pretty` which takes no value. This is used to bautfy the generated reports.

**Expected behavior:** 

Sample usage 
```
-u http://webapps.thebus.org/transitdata/Production/google_transit.zip -t 4 -p -o output
```
### `report.json`

<img width="928" alt="Capture d’écran, le 2021-05-11 à 15 06 33" src="https://user-images.githubusercontent.com/35747326/117870779-8e620c80-b26a-11eb-98ff-f23488035b98.png">

### `system_errors.json`

<img width="809" alt="Capture d’écran, le 2021-05-11 à 15 06 41" src="https://user-images.githubusercontent.com/35747326/117870833-a2a60980-b26a-11eb-81da-e84cc0f6832a.png">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
