### PR TITLE
ci: publish a new docker image on every push on master

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,8 @@
 name: Docker image
 
 on:
+  push:
+    branches: [ master ]
   release:
     types: [ prereleased, released ]
 
@@ -75,7 +77,7 @@ jobs:
           fi
           TAGS="${DOCKER_IMAGE}:${VERSION}"
           if [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="${DOCKER_IMAGE}:sha-${GITHUB_SHA::8},$TAGS"
+            TAGS="${DOCKER_IMAGE}:latest"
           fi
           echo ::set-output name=version::${VERSION}
           echo ::set-output name=tags::${TAGS}


### PR DESCRIPTION
Relates to https://github.com/MobilityData/gtfs-validator/pull/905

**Summary:**

At present, a new Docker image is only published at release. Said docker image should be published on every commit on the `master` branch. 

**Expected behavior:** 

A new Docker image should be published each time a branch is merged to `master`. 

- Running `docker pull ghcr.io/mobilitydata/gtfs-validator` should automatically point to the latest version of the docker image. 
<img width="830" alt="Capture d’écran, le 2021-06-17 à 13 12 09" src="https://user-images.githubusercontent.com/35747326/122443473-a0bc1e00-cf6d-11eb-9562-a95490444f01.png">

- The `latest` version should be available on [this page](https://github.com/MobilityData/gtfs-validator/pkgs/container/gtfs-validator)
<img width="815" alt="Capture d’écran, le 2021-06-17 à 13 13 58" src="https://user-images.githubusercontent.com/35747326/122443818-ee388b00-cf6d-11eb-92c5-debb1c54d9bd.png">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- ~[] Linked all relevant issues~
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
