### PR TITLE
chore: additional annotation for notice export

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/NoticeExport.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/NoticeExport.java
@@ -1,0 +1,7 @@
+package org.mobilitydata.gtfsvalidator.annotation;
+
+/**
+ * Annotation to be used on notice constructor. This specifies the constructor to be considered
+ * while exporting notice information.
+ */
+public @interface NoticeExport {}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.univocity.parsers.common.TextParsingException;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * Parsing of a CSV file failed.
@@ -28,6 +29,7 @@ import com.univocity.parsers.common.TextParsingException;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class CsvParsingFailedNotice extends ValidationNotice {
+  @NoticeExport
   public CsvParsingFailedNotice(String filename, TextParsingException exception) {
     super(
         new ImmutableMap.Builder<String, Object>()

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateKeyNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateKeyNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * The values of the given key and rows are duplicates.
@@ -45,6 +46,7 @@ public class DuplicateKeyNotice extends ValidationNotice {
         SeverityLevel.ERROR);
   }
 
+  @NoticeExport
   public DuplicateKeyNotice(
       String filename,
       long oldCsvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicatedColumnNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicatedColumnNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * The input file CSV header has the same column name repeated.
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class DuplicatedColumnNotice extends ValidationNotice {
   // Indices should start from 1.
+  @NoticeExport
   public DuplicatedColumnNotice(
       String filename, String fieldName, int firstIndex, int secondIndex) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A column name is empty. Such columns are skipped by the validator.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
 public class EmptyColumnNameNotice extends ValidationNotice {
+  @NoticeExport
   public EmptyColumnNameNotice(String filename, int index) {
     super(
         ImmutableMap.of(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyFileNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A CSV file is empty.
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class EmptyFileNotice extends ValidationNotice {
 
+  @NoticeExport
   public EmptyFileNotice(String filename) {
     super(ImmutableMap.of("filename", filename), SeverityLevel.ERROR);
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A row in the input file has only spaces.
@@ -28,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class EmptyRowNotice extends ValidationNotice {
 
+  @NoticeExport
   public EmptyRowNotice(String filename, long csvRowNumber) {
     super(
         ImmutableMap.of(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ForeignKeyViolationNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ForeignKeyViolationNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * The values of the given key and rows of one table cannot be found a values of the given key in
@@ -28,6 +29,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class ForeignKeyViolationNotice extends ValidationNotice {
+  @NoticeExport
   public ForeignKeyViolationNotice(
       String childFilename,
       String childFieldName,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidColorNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidColorNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field contains an invalid color value.
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidColorNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidColorNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field contains a wrong currency code.
@@ -31,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidCurrencyNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidCurrencyNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidDateNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidDateNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field cannot be parsed as date.
@@ -29,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidDateNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidDateNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field contains a malformed email address.
@@ -33,6 +34,7 @@ public class InvalidEmailNotice extends ValidationNotice {
    * Constructs a notice with given severity. This constructor may be used by users that want to
    * lower the priority to {@code WARNING}.
    */
+  @NoticeExport
   public InvalidEmailNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidFloatNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidFloatNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field cannot be parsed as a floating point number.
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidFloatNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidFloatNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidIntegerNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidIntegerNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field cannot be parsed as an integer.
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidIntegerNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidIntegerNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidLanguageCodeNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidLanguageCodeNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field contains a wrong language code.
@@ -30,6 +31,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidLanguageCodeNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidLanguageCodeNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field contains a malformed phone number.
@@ -33,6 +34,7 @@ public class InvalidPhoneNumberNotice extends ValidationNotice {
    * Constructs a notice with given severity. This constructor may be used by users that want to
    * lower the priority to {@code WARNING}.
    */
+  @NoticeExport
   public InvalidPhoneNumberNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidRowLengthNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidRowLengthNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A row in the input file has a different number of values than specified by the CSV header.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class InvalidRowLengthNotice extends ValidationNotice {
+  @NoticeExport
   public InvalidRowLengthNotice(
       String filename, long csvRowNumber, int rowLength, int headerCount) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimeNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimeNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field cannot be parsed as time.
@@ -28,7 +29,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class InvalidTimeNotice extends ValidationNotice {
-
+  @NoticeExport
   public InvalidTimeNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimezoneNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimezoneNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field cannot be parsed as a timezone.
@@ -31,6 +32,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class InvalidTimezoneNotice extends ValidationNotice {
 
+  @NoticeExport
   public InvalidTimezoneNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A field contains a malformed URL.
@@ -41,6 +42,7 @@ public class InvalidUrlNotice extends ValidationNotice {
    * Constructs a notice with given severity. This constructor may be used by users that want to
    * lower the priority to {@code WARNING}.
    */
+  @NoticeExport
   public InvalidUrlNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * The value in CSV file has leading or trailing whitespaces.
@@ -39,6 +40,7 @@ public class LeadingOrTrailingWhitespacesNotice extends ValidationNotice {
    * Constructs a notice with given severity. This constructor may be used by users that want to
    * lower the priority to {@code WARNING}.
    */
+  @NoticeExport
   public LeadingOrTrailingWhitespacesNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredColumnNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredColumnNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A required column is missing in the input file.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class MissingRequiredColumnNotice extends ValidationNotice {
+  @NoticeExport
   public MissingRequiredColumnNotice(String filename, String fieldName) {
     super(ImmutableMap.of("filename", filename, "fieldName", fieldName), SeverityLevel.ERROR);
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFieldNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * The given field has no value in some input row, even though values are required.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class MissingRequiredFieldNotice extends ValidationNotice {
+  @NoticeExport
   public MissingRequiredFieldNotice(String filename, long csvRowNumber, String fieldName) {
     super(
         ImmutableMap.of("filename", filename, "csvRowNumber", csvRowNumber, "fieldName", fieldName),

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFileNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A required file is missing.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class MissingRequiredFileNotice extends ValidationNotice {
+  @NoticeExport
   public MissingRequiredFileNotice(String filename) {
     super(ImmutableMap.of("filename", filename), SeverityLevel.ERROR);
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MoreThanOneEntityNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MoreThanOneEntityNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A notice that the file is expected to have a single entity but has more (e.g., "feed_info.txt").
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
 public class MoreThanOneEntityNotice extends ValidationNotice {
+  @NoticeExport
   public MoreThanOneEntityNotice(String filename, long entityCount) {
     super(ImmutableMap.of("filename", filename, "entityCount", entityCount), SeverityLevel.WARNING);
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NewLineInValueNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NewLineInValueNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A value in CSV file has a new line or carriage return.
@@ -36,6 +37,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class NewLineInValueNotice extends ValidationNotice {
 
+  @NoticeExport
   public NewLineInValueNotice(
       String filename, long csvRowNumber, String fieldName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * ID value contains something different from printable ASCII characters.
@@ -27,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
 public class NonAsciiOrNonPrintableCharNotice extends ValidationNotice {
+  @NoticeExport
   public NonAsciiOrNonPrintableCharNotice(
       String filename, long csvRowNumber, String columnName, String fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NumberOutOfRangeNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NumberOutOfRangeNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * The values in the given column of the input rows are out of range.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class NumberOutOfRangeNotice extends ValidationNotice {
+  @NoticeExport
   public NumberOutOfRangeNotice(
       String filename, long csvRowNumber, String fieldName, String fieldType, Object fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearOriginNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearOriginNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A point is too close to origin (0, 0).
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class PointNearOriginNotice extends ValidationNotice {
 
+  @NoticeExport
   public PointNearOriginNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A point is too close to the North or South Pole.
@@ -25,6 +26,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class PointNearPoleNotice extends ValidationNotice {
 
+  @NoticeExport
   public PointNearPoleNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeEqualNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeEqualNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * Start and end range fields are equal for a certain GTFS entity.
@@ -27,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class StartAndEndRangeEqualNotice extends ValidationNotice {
 
+  @NoticeExport
   public StartAndEndRangeEqualNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeOutOfOrderNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeOutOfOrderNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * Start and end range fields are out of order for a certain GTFS entity.
@@ -27,6 +28,7 @@ import com.google.common.collect.ImmutableMap;
  */
 public class StartAndEndRangeOutOfOrderNotice extends ValidationNotice {
 
+  @NoticeExport
   public StartAndEndRangeOutOfOrderNotice(
       String filename,
       long csvRowNumber,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnexpectedEnumValueNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnexpectedEnumValueNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * An enum has an unexpected value.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.WARNING}
  */
 public class UnexpectedEnumValueNotice extends ValidationNotice {
+  @NoticeExport
   public UnexpectedEnumValueNotice(
       String filename, long csvRowNumber, String fieldName, int fieldValue) {
     super(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownColumnNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownColumnNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A column name is unknown.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.INFO}
  */
 public class UnknownColumnNotice extends ValidationNotice {
+  @NoticeExport
   public UnknownColumnNotice(String filename, String fieldName, int index) {
     super(
         ImmutableMap.of(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownFileNotice.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 
 /**
  * A file is unknown.
@@ -24,6 +25,7 @@ import com.google.common.collect.ImmutableMap;
  * <p>Severity: {@code SeverityLevel.INFO}
  */
 public class UnknownFileNotice extends ValidationNotice {
+  @NoticeExport
   public UnknownFileNotice(String filename) {
     super(ImmutableMap.of("filename", filename), SeverityLevel.INFO);
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -21,6 +21,7 @@ import java.time.ZoneId;
 import java.util.Locale;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
@@ -106,6 +107,7 @@ public class AgencyConsistencyValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class InconsistentAgencyLangNotice extends ValidationNotice {
+    @NoticeExport
     InconsistentAgencyLangNotice(long csvRowNumber, String expected, String actual) {
       super(
           ImmutableMap.of(
@@ -122,6 +124,7 @@ public class AgencyConsistencyValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class InconsistentAgencyTimezoneNotice extends ValidationNotice {
+    @NoticeExport
     InconsistentAgencyTimezoneNotice(long csvRowNumber, String expected, String actual) {
       super(
           ImmutableMap.of(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -55,6 +56,7 @@ public class AttributionWithoutRoleValidator extends SingleEntityValidator<GtfsA
    */
   static class AttributionWithoutRoleNotice extends ValidationNotice {
 
+    @NoticeExport
     AttributionWithoutRoleNotice(long csvRowNumber, String attributionId) {
       super(
           ImmutableMap.of("csvRowNumber", csvRowNumber, "attributionId", attributionId),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -256,6 +257,7 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
    */
   static class BlockTripsWithOverlappingStopTimesNotice extends ValidationNotice {
 
+    @NoticeExport
     BlockTripsWithOverlappingStopTimesNotice(
         GtfsTrip tripA, GtfsTrip tripB, GtfsDate intersection) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -257,7 +257,6 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
    */
   static class BlockTripsWithOverlappingStopTimesNotice extends ValidationNotice {
 
-    @NoticeExport
     /**
      * Constructor used while extracting notice information.
      *
@@ -270,6 +269,7 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
      * @param blockId trip block it
      * @param intersection date intersection on which the two trips overlap
      */
+    @NoticeExport
     BlockTripsWithOverlappingStopTimesNotice(
         long csvRowNumberA,
         String tripIdA,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareRuleZoneIdFieldsValidator.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -100,6 +101,7 @@ public class DuplicateFareRuleZoneIdFieldsValidator extends FileValidator {
    */
   static class DuplicateFareRuleZoneIdFieldsNotice extends ValidationNotice {
 
+    @NoticeExport
     DuplicateFareRuleZoneIdFieldsNotice(
         long csvRowNumber, String fareId, long previousCsvRowNumber, String previousFareId) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -72,6 +73,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class DuplicateRouteNameNotice extends ValidationNotice {
+    @NoticeExport
     DuplicateRouteNameNotice(GtfsRoute route1, GtfsRoute route2) {
       super(
           new ImmutableMap.Builder<String, Object>()

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import java.time.LocalDate;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
@@ -75,6 +76,7 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
   }
 
   static class FeedExpirationDateNotice extends ValidationNotice {
+    @NoticeExport
     FeedExpirationDateNotice(
         long csvRowNumber,
         GtfsDate currentDate,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -50,6 +51,7 @@ public class FeedServiceDateValidator extends SingleEntityValidator<GtfsFeedInfo
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class MissingFeedInfoDateNotice extends ValidationNotice {
+    @NoticeExport
     MissingFeedInfoDateNotice(long csvRowNumber, String fieldName) {
       super(
           ImmutableMap.of("csvRowNumber", csvRowNumber, "fieldName", fieldName),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -74,6 +75,7 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class StationWithParentStationNotice extends ValidationNotice {
+    @NoticeExport
     StationWithParentStationNotice(
         long csvRowNumber, String stopId, String stopName, String parentStation) {
       super(
@@ -99,6 +101,7 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class LocationWithoutParentStationNotice extends ValidationNotice {
+    @NoticeExport
     LocationWithoutParentStationNotice(
         long csvRowNumber, String stopId, String stopName, int locationType) {
       super(
@@ -123,6 +126,7 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class PlatformWithoutParentStationNotice extends ValidationNotice {
+    @NoticeExport
     PlatformWithoutParentStationNotice(long csvRowNumber, String stopId, String stopName) {
       super(
           ImmutableMap.of("csvRowNumber", csvRowNumber, "stopId", stopId, "stopName", stopName),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import java.util.Locale;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -92,6 +93,7 @@ public class MatchingFeedAndAgencyLangValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class FeedInfoLangAndAgencyLangMismatchNotice extends ValidationNotice {
+    @NoticeExport
     FeedInfoLangAndAgencyLangMismatchNotice(
         long csvRowNumber, String agencyId, String agencyName, String agencyLang, String feedLang) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidator.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import com.google.common.collect.ImmutableMap;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -61,6 +62,7 @@ public class MissingCalendarAndCalendarDateValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class MissingCalendarAndCalendarDateFilesNotice extends ValidationNotice {
+    @NoticeExport
     MissingCalendarAndCalendarDateFilesNotice() {
       super(ImmutableMap.of(), SeverityLevel.ERROR);
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -101,6 +102,7 @@ public class MissingTripEdgeValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class MissingTripEdgeNotice extends ValidationNotice {
+    @NoticeExport
     MissingTripEdgeNotice(
         long csvRowNumber, int stopSequence, String tripId, String specifiedField) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -70,6 +71,7 @@ public class OverlappingFrequencyValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class OverlappingFrequencyNotice extends ValidationNotice {
+    @NoticeExport
     OverlappingFrequencyNotice(
         long prevCsvRowNumber,
         GtfsTime prevEndTime,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import com.google.common.collect.ImmutableMap;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -84,6 +85,7 @@ public class ParentLocationTypeValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class WrongParentLocationTypeNotice extends ValidationNotice {
+    @NoticeExport
     WrongParentLocationTypeNotice(
         long csvRowNumber,
         String stopId,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteColorContrastValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteColorContrastValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -63,6 +64,7 @@ public class RouteColorContrastValidator extends SingleEntityValidator<GtfsRoute
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class RouteColorContrastNotice extends ValidationNotice {
+    @NoticeExport
     RouteColorContrastNotice(
         String routeId, long csvRowNumber, GtfsColor routeColor, GtfsColor routeTextColor) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -20,6 +20,7 @@ import static org.mobilitydata.gtfsvalidator.table.GtfsRouteTableLoader.FILENAME
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -93,6 +94,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class RouteBothShortAndLongNameMissingNotice extends ValidationNotice {
+    @NoticeExport
     RouteBothShortAndLongNameMissingNotice(String routeId, long csvRowNumber) {
       super(
           ImmutableMap.of(
@@ -108,6 +110,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class RouteShortAndLongNameEqualNotice extends ValidationNotice {
+    @NoticeExport
     RouteShortAndLongNameEqualNotice(
         String routeId, long csvRowNumber, String routeShortName, String routeLongName) {
       super(
@@ -127,6 +130,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class RouteShortNameTooLongNotice extends ValidationNotice {
+    @NoticeExport
     RouteShortNameTooLongNotice(String routeId, long csvRowNumber, String routeShortName) {
       super(
           ImmutableMap.of(
@@ -147,6 +151,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
+    @NoticeExport
     SameNameAndDescriptionForRouteNotice(
         long csvRowNumber, String routeId, String routeDesc, String routeShortOrLongName) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Multimaps;
 import java.util.List;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -75,6 +76,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class DecreasingOrEqualShapeDistanceNotice extends ValidationNotice {
+    @NoticeExport
     DecreasingOrEqualShapeDistanceNotice(
         String shapeId,
         long csvRowNumber,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeUsageValidator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -63,6 +64,7 @@ public class ShapeUsageValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class UnusedShapeNotice extends ValidationNotice {
+    @NoticeExport
     UnusedShapeNotice(String shapeId, long csvRowNumber) {
       super(
           ImmutableMap.of(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Multimaps;
 import java.util.List;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -94,6 +95,7 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class StopTimeWithArrivalBeforePreviousDepartureTimeNotice extends ValidationNotice {
+    @NoticeExport
     StopTimeWithArrivalBeforePreviousDepartureTimeNotice(
         long csvRowNumber,
         long prevCsvRowNumber,
@@ -117,6 +119,7 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class StopTimeWithOnlyArrivalOrDepartureTimeNotice extends ValidationNotice {
+    @NoticeExport
     StopTimeWithOnlyArrivalOrDepartureTimeNotice(
         long csvRowNumber, String tripId, int stopSequence, String specifiedField) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -21,6 +21,7 @@ import com.google.common.collect.Multimaps;
 import java.util.List;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -77,6 +78,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class DecreasingOrEqualStopTimeDistanceNotice extends ValidationNotice {
+    @NoticeExport
     DecreasingOrEqualStopTimeDistanceNotice(
         String tripId,
         long csvRowNumber,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTooFarFromTripShapeValidator.java
@@ -30,6 +30,7 @@ import org.locationtech.spatial4j.shape.Shape;
 import org.locationtech.spatial4j.shape.ShapeFactory;
 import org.locationtech.spatial4j.shape.SpatialRelation;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -210,6 +211,7 @@ public class StopTooFarFromTripShapeValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class StopTooFarFromTripShapeNotice extends ValidationNotice {
+    @NoticeExport
     StopTooFarFromTripShapeNotice(
         final String stopId,
         final int stopSequence,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -71,6 +72,7 @@ public class TimepointTimeValidator extends SingleEntityValidator<GtfsStopTime> 
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class StopTimeTimepointWithoutTimesNotice extends ValidationNotice {
+    @NoticeExport
     StopTimeTimepointWithoutTimesNotice(
         final long csvRowNumber,
         final String tripId,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TooFastTravelValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TooFastTravelValidator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map.Entry;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -153,6 +154,7 @@ public class TooFastTravelValidator extends FileValidator {
    * <p>SeverityLevel: {@code SeverityLevel.WARNING}
    */
   static class TooFastTravelNotice extends ValidationNotice {
+    @NoticeExport
     TooFastTravelNotice(
         String tripId, double speedkmh, int firstStopSequence, int lastStopSequence) {
       super(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
@@ -19,6 +19,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 import com.google.common.collect.ImmutableMap;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -59,6 +60,7 @@ public class TripUsabilityValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class UnusableTripNotice extends ValidationNotice {
+    @NoticeExport
     UnusableTripNotice(long csvRowNumber, String tripId) {
       super(
           ImmutableMap.of(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.NoticeExport;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
@@ -62,6 +63,7 @@ public class TripUsageValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class UnusedTripNotice extends ValidationNotice {
+    @NoticeExport
     UnusedTripNotice(String tripId, long csvRowNumber) {
       super(
           ImmutableMap.of(


### PR DESCRIPTION
**Summary:**

This PR provides support to define a new annotation `NoticeExport`.  This annotation is to be used on notice constructor. This specifies the constructor to be considered while exporting notice information.

This relates to https://github.com/MobilityData/gtfs-validator/issues/899

**Expected behavior:** 

No code change for now. Same tests should pass.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
