### PR TITLE
refactor: add standardized constructor to notices

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
@@ -30,7 +30,7 @@ import com.univocity.parsers.common.TextParsingException;
 public class CsvParsingFailedNotice extends ValidationNotice {
 
   /**
-   * Constructor used for extracting information to be used in yaml dump.
+   * Constructor used while extracting notice information.
    *
    * @param filename the name of the file
    * @param exception the exception thrown

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
@@ -28,15 +28,38 @@ import com.univocity.parsers.common.TextParsingException;
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class CsvParsingFailedNotice extends ValidationNotice {
+
+  /**
+   * Constructor used for extracting information to be used in yaml dump.
+   *
+   * @param filename the name of the file
+   * @param exception the exception thrown
+   */
   public CsvParsingFailedNotice(String filename, TextParsingException exception) {
+    this(filename, exception.getCharIndex(), exception.getColumnIndex(), exception.getLineIndex(),
+        exception.getMessage(), exception.getParsedContent());
+  }
+
+  /**
+   * Default constructor for notice.
+   *
+   * @param filename the name of the file
+   * @param charIndex the index of character
+   * @param columnIndex the index of column
+   * @param lineIndex the index of line
+   * @param message the exception message
+   * @param parsedContent the parsed content of the exception
+   */
+  public CsvParsingFailedNotice(String filename, long charIndex, long columnIndex, long lineIndex,
+      String message, String parsedContent) {
     super(
         new ImmutableMap.Builder<String, Object>()
             .put("filename", filename)
-            .put("charIndex", exception.getCharIndex())
-            .put("columnIndex", exception.getColumnIndex())
-            .put("lineIndex", exception.getLineIndex())
-            .put("message", Strings.nullToEmpty(exception.getMessage()))
-            .put("content", Strings.nullToEmpty(exception.getParsedContent()))
+            .put("charIndex", charIndex)
+            .put("columnIndex", columnIndex)
+            .put("lineIndex", lineIndex)
+            .put("message", Strings.nullToEmpty(message))
+            .put("content", Strings.nullToEmpty(parsedContent))
             .build(),
         SeverityLevel.ERROR);
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -256,20 +256,45 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
    */
   static class BlockTripsWithOverlappingStopTimesNotice extends ValidationNotice {
 
-    BlockTripsWithOverlappingStopTimesNotice(
-        GtfsTrip tripA, GtfsTrip tripB, GtfsDate intersection) {
+    /**
+     * Constructor used for extracting information to be used in yaml dump.
+     *
+     * @param csvRowNumberA first trip csv row number
+     * @param tripIdA first trip id
+     * @param serviceIdA first trip service id
+     * @param csvRowNumberB other trip csv row number
+     * @param tripIdB other trip id
+     * @param serviceIdB other trip service id
+     * @param blockId trip block it
+     * @param intersection date intersection on which the two trips overlap
+     */
+    BlockTripsWithOverlappingStopTimesNotice(long csvRowNumberA, String tripIdA, String serviceIdA,
+        long csvRowNumberB, String tripIdB, String serviceIdB, String blockId,
+        String intersection) {
       super(
           new ImmutableMap.Builder<String, Object>()
-              .put("csvRowNumberA", tripA.csvRowNumber())
-              .put("tripIdA", tripA.tripId())
-              .put("serviceIdA", tripA.serviceId())
-              .put("csvRowNumberB", tripB.csvRowNumber())
-              .put("tripIdB", tripB.tripId())
-              .put("serviceIdB", tripB.serviceId())
-              .put("blockId", tripA.blockId())
-              .put("intersection", intersection.toYYYYMMDD())
+              .put("csvRowNumberA", csvRowNumberA)
+              .put("tripIdA", tripIdA)
+              .put("serviceIdA", serviceIdA)
+              .put("csvRowNumberB", csvRowNumberB)
+              .put("tripIdB", tripIdB)
+              .put("serviceIdB", serviceIdB)
+              .put("blockId", blockId)
+              .put("intersection", intersection)
               .build(),
           SeverityLevel.ERROR);
+    }
+
+    /**
+     * Default constructor for notice.
+     * @param tripA first overlapping trip
+     * @param tripB other overlapping trip
+     * @param intersection date intersection on which the two trips overlap
+     */
+    BlockTripsWithOverlappingStopTimesNotice(
+        GtfsTrip tripA, GtfsTrip tripB, GtfsDate intersection) {
+      this(tripA.csvRowNumber(), tripA.tripId(), tripA.serviceId(), tripB.csvRowNumber(),
+          tripB.tripId(), tripB.serviceId(), tripA.blockId(), intersection.toYYYYMMDD());
     }
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -257,7 +257,7 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
   static class BlockTripsWithOverlappingStopTimesNotice extends ValidationNotice {
 
     /**
-     * Constructor used for extracting information to be used in yaml dump.
+     * Constructor used while extracting notice information.
      *
      * @param csvRowNumberA first trip csv row number
      * @param tripIdA first trip id

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -74,7 +74,7 @@ public class DuplicateRouteNameValidator extends FileValidator {
   static class DuplicateRouteNameNotice extends ValidationNotice {
 
     /**
-     * Constructor used for extracting information to be used in yaml dump.
+     * Constructor used while extracting notice information.
      *
      * @param csvRowNumber1 the first route's csv row number
      * @param routeId1 the first route's id

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -72,19 +72,47 @@ public class DuplicateRouteNameValidator extends FileValidator {
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class DuplicateRouteNameNotice extends ValidationNotice {
-    DuplicateRouteNameNotice(GtfsRoute route1, GtfsRoute route2) {
+
+    /**
+     * Constructor used for extracting information to be used in yaml dump.
+     *
+     * @param csvRowNumber1 the first route's csv row number
+     * @param routeId1 the first route's id
+     * @param csvRowNumber2 the other route's csv row number
+     * @param routeId2 the other route's id
+     * @param routeShortName the duplicate route short name
+     * @param routeLongName the duplicate route long name
+     * @param routeTypeValue the route type value
+     * @param agencyId the agency id
+     */
+    DuplicateRouteNameNotice(long csvRowNumber1, String routeId1, long csvRowNumber2,
+        String routeId2, String routeShortName, String routeLongName, int routeTypeValue,
+        String agencyId) {
       super(
           new ImmutableMap.Builder<String, Object>()
-              .put("csvRowNumber1", route1.csvRowNumber())
-              .put("routeId1", route1.routeId())
-              .put("csvRowNumber2", route2.csvRowNumber())
-              .put("routeId2", route2.routeId())
-              .put("routeShortName", route1.routeShortName())
-              .put("routeLongName", route1.routeLongName())
-              .put("routeType", route1.routeTypeValue())
-              .put("agencyId", route1.agencyId())
+              .put("csvRowNumber1", csvRowNumber1)
+              .put("routeId1", routeId1)
+              .put("csvRowNumber2", csvRowNumber2)
+              .put("routeId2", routeId2)
+              .put("routeShortName", routeShortName)
+              .put("routeLongName", routeLongName)
+              .put("routeType", routeTypeValue)
+              .put("agencyId", agencyId)
               .build(),
           SeverityLevel.WARNING);
+    }
+
+    /**
+     * Default constructor for notice.
+     *
+     * @param route1 the first route to extract information from.
+     * @param route2 the other route to extract information from.
+     */
+    DuplicateRouteNameNotice(GtfsRoute route1, GtfsRoute route2) {
+      this(
+          route1.csvRowNumber(), route1.routeId(), route2.csvRowNumber(), route2.routeId(),
+          route1.routeShortName(), route1.routeLongName(), route1.routeTypeValue(),
+          route1.agencyId());
     }
   }
 }


### PR DESCRIPTION
This relates to #899 

**Summary:**

This PR provides additional constructors to notices such as:
-  `CsvParsingFailedNotice`
- `DuplicateRouteNameNotice`
- `BlockTripsWithOverlappingStopTimesNotice` 

This change is the following: in the process to extract metadata from the `ValidationNotice` subclasses, we intend to leverage the constructor's parameters. However, the aforementioned notices use take exceptions or GtfsRoute as parameters (from which information is extracted in the call to `super`). Having this additional constructor allows to directly extract information about the parameters for said notices from their constructor.

**Expected behavior:** 

No changed behavior.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
