### PR TITLE
chore: check stops.zone_id presence

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -133,6 +133,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`StartAndEndTimeEqualNotice`](#StartAndEndTimeEqualNotice)                       	| Equal `frequencies.start_time` and `frequencies.end_time`.                                                                                                  	|
 | [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	| `arrival_time` or `departure_time` not specified for timepoint.                                                                                             	|
 | [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	| Stop too far from trip shape.                                                                                                                               	|
+| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                              	| Stop without value for `stops.zone_id`.                                                                                                                     	|
 | [`TooFastTravelNotice`](#TooFastTravelNotice)                                     	| Fast travel between stops in `stop_times.txt`.                                                                                                              	|
 | [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	| An enum has an unexpected value.                                                                                                                            	|
 | [`UnusableTripNotice`](#UnusableTripNotice)                                       	| Trips must have more than one stop to be usable.                                                                                                            	|
@@ -710,6 +711,15 @@ Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100
 
 ##### References:
 * [GTFS Best Practices shapes.txt](https://gtfs.org/best-practices/#shapestxt)
+
+<a name="StopWithoutZoneIdNotice"/>
+
+#### StopWithoutZoneIdNotice
+
+Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a stop or en entrance (i.e. `stops.location_type = 1 or 2`).
+
+##### References:
+* [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)
 
 <a name="TooFastTravelNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -643,6 +643,7 @@
 | `start_and_end_time_equalNotice`           	| [`StartAndEndTimeEqualNotice`](#StartAndEndTimeEqualNotice)                       	|
 | `stop_time_timepoint_without_timesNotice`  	| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	|
 | `stop_too_far_from_trip_shapeNotice`       	| [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	|
+| `stop_without_zone_id`                       	| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                 	            |
 | `too_fast_travelNotice`                    	| [`TooFastTravelNotice`](#TooFastTravelNotice)                                     	|
 | `unexpected_enum_valueNotice`              	| [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	|
 | `unusable_tripNotice`                      	| [`UnusableTripNotice`](#UnusableTripNotice)                                       	|
@@ -852,6 +853,18 @@
 ##### Affected files
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 * [`trips.txt`](http://gtfs.org/reference/static#tripstxt)
+
+#### [StopWithoutZoneIdNotice](/RULES.md#StopWithoutZoneIdNotice)
+##### Fields description
+
+| Field name               	| Description                                	| Type   	|
+|--------------------------	|--------------------------------------------	|--------	|
+| `stopId`                 	| The faulty record's id.                    	| String 	|
+| `csvRowNumber`        	| The row number of the faulty record.       	| Long   	|
+
+##### Affected files
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
+* [`fare_rules.txt`](http://gtfs.org/reference/static#farerulestxt)
 
 #### [TooFastTravelNotice](/RULES.md#TooFastTravelNotice)
 ##### Fields description

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.ImmutableMap;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.SchemaExport;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+
+/**
+ * Validates that all stops in "stops.txt" have a value for {@code stops.zone_id} if fare
+ * information is provided using "fare_rules.txt". This rule does not apply if a record from
+ * "stops.txt" represents a station or station entrance i.e {@code stops.location_type = 1 or 2}.
+ *
+ * <p>Generated notice: {@link StopWithoutZoneIdNotice}.
+ */
+@GtfsValidator
+public class StopZoneIdValidator extends FileValidator {
+
+  private final GtfsStopTableContainer stopTable;
+  private final GtfsFareRuleTableContainer fareRuleTable;
+
+  @Inject
+  StopZoneIdValidator(GtfsStopTableContainer stopTable, GtfsFareRuleTableContainer fareRuleTable) {
+    this.stopTable = stopTable;
+    this.fareRuleTable = fareRuleTable;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    if (fareRuleTable.getEntities().isEmpty()) {
+      return;
+    }
+    for (GtfsStop stop : stopTable.getEntities()) {
+      if (isStationOrEntrance(stop)) {
+        return;
+      }
+      if (stop.hasZoneId()) {
+        return;
+      }
+      noticeContainer
+          .addValidationNotice(new StopWithoutZoneIdNotice(stop.stopId(), stop.csvRowNumber()));
+    }
+  }
+
+  private boolean isStationOrEntrance(GtfsStop stop) {
+    return stop.locationType().equals(GtfsLocationType.STATION) || stop.locationType()
+        .equals(GtfsLocationType.STOP);
+  }
+
+  /**
+   * A {@code GtfsShape} should be referred to at least once in {@code GtfsTripTableContainer}
+   * station).
+   *
+   * <p>Severity: {@code SeverityLevel.WARNING} - Will be upgraded to {@code SeverityLevel.ERROR}
+   */
+  static class StopWithoutZoneIdNotice extends ValidationNotice {
+
+    @SchemaExport
+    StopWithoutZoneIdNotice(String stopId, long csvRowNumber) {
+      super(
+          ImmutableMap.of(
+              "stopId", stopId,
+              "csvRowNumber", csvRowNumber),
+          SeverityLevel.WARNING);
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -1,0 +1,118 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRule;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.validator.StopZoneIdValidator.StopWithoutZoneIdNotice;
+
+@RunWith(JUnit4.class)
+public class StopZoneIdValidatorTest {
+
+  private static GtfsStop createStop(long csvRowNumber, GtfsLocationType locationType,
+      String zoneId, String stopId) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(stopId)
+        .setLocationType(locationType)
+        .setZoneId(zoneId)
+        .build();
+  }
+
+  private static GtfsFareRule createFareRule(long csvRowNumber, String fareId) {
+    return new GtfsFareRule.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setFareId(fareId)
+        .build();
+  }
+
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsStop> stops, List<GtfsFareRule> fareRules) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new StopZoneIdValidator(
+        GtfsStopTableContainer.forEntities(stops, noticeContainer),
+        GtfsFareRuleTableContainer.forEntities(fareRules, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  @Test
+  public void emptyFareRuleNoZoneId_noNotice() {
+    assertThat(
+        generateNotices(
+            ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, null, "stop id value")),
+            ImmutableList.of()
+        )).isEmpty();
+  }
+
+  @Test
+  public void emptyFareRuleZoneId_noNotice() {
+    assertThat(
+        generateNotices(
+            ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, "zone id value",
+                "stop id value")),
+            ImmutableList.of()
+        )).isEmpty();
+  }
+
+  @Test
+  public void fareRuleProvidedNoZoneId_generatesNotices() {
+    StopWithoutZoneIdNotice[] validationNotices = {
+        new StopWithoutZoneIdNotice("stop id value", 3),
+        new StopWithoutZoneIdNotice("other stop id value", 5)
+    };
+    assertThat(
+        generateNotices(
+            ImmutableList.of(
+                createStop(3, GtfsLocationType.BOARDING_AREA, null, "stop id value"),
+                createStop(5, GtfsLocationType.GENERIC_NODE, null, "other stop id value")),
+            ImmutableList.of(createFareRule(5, "fare id value"))
+        )).containsExactlyElementsIn(validationNotices);
+  }
+
+  @Test
+  public void fareRuleProvidedZoneId_noNotice() {
+    assertThat(
+        generateNotices(
+            ImmutableList.of(
+                createStop(3, GtfsLocationType.BOARDING_AREA, "zone id value", "stop id value"),
+                createStop(5, GtfsLocationType.GENERIC_NODE, "other zone id value",
+                    "other stop id value")),
+            ImmutableList.of(createFareRule(5, "fare id value"))
+        )).isEmpty();
+  }
+
+  @Test
+  public void fareRuleProvided_stopLocationEqualsStop_noNotice() {
+    assertThat(
+        generateNotices(
+            ImmutableList.of(
+                createStop(3, GtfsLocationType.STOP, "zone id value", "stop id value"),
+                createStop(5, GtfsLocationType.STOP, "other zone id value",
+                    "other stop id value")),
+            ImmutableList.of(createFareRule(5, "fare id value"))
+        )).isEmpty();
+  }
+
+  @Test
+  public void fareRuleProvided_stopLocationEqualsEntrance_noNotice() {
+    assertThat(
+        generateNotices(
+            ImmutableList.of(
+                createStop(3, GtfsLocationType.ENTRANCE, "zone id value", "stop id value"),
+                createStop(5, GtfsLocationType.ENTRANCE, "other zone id value",
+                    "other stop id value")),
+            ImmutableList.of(createFareRule(5, "fare id value"))
+        )).isEmpty();
+  }
+}


### PR DESCRIPTION
closes #237 

**Summary:**

This PR provides support to implement https://github.com/MobilityData/gtfs-validator/issues/237

**Expected behavior:** 

New notice: 
- `StopWithoutZoneIdNotice` (severity level = `WARNING` - to be upgraded to `ERROR` in the future).

Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt` - if this requirement is not met, a notice should be emitted. 

Note that this rule does not apply to records from `stops.txt` that represent a stop or en entrance (i.e. `stops.location_type = 1 or 2`) - in this case, no notice should be emitted.

Gtfs specification reference:

> |  `zone_id` | ID | **Conditionally Required** | Identifies the fare zone for a stop. If this record represents a station or station entrance, the `zone_id` is ignored.<br><br>Conditionally Required:<br>- **Required** if providing fare information using [fare_rules.txt](#fare_rulestxt) <br>- Optional otherwise.|

_from https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt_


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
