### PR TITLE
chore: check stop name and desc

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -130,6 +130,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	| Insufficient route color contrast.                                                                                                                          	|
 | [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	| Short and long name are equal for a route.                                                                                                                  	|
 | [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	| Short name of a route is too long (more than 12 characters).                                                                                                	|
+| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)         | Same name and description for route.                                                                                                                      	|
 | [`StartAndEndTimeEqualNotice`](#StartAndEndTimeEqualNotice)                       	| Equal `frequencies.start_time` and `frequencies.end_time`.                                                                                                  	|
 | [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	| `arrival_time` or `departure_time` not specified for timepoint.                                                                                             	|
 | [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	| Stop too far from trip shape.                                                                                                                               	|
@@ -683,6 +684,17 @@ Short name of a route is too long (more than 12 characters).
 
 ##### References:
 * [routes.txt Best Practices](https://gtfs.org/best-practices/#routestxt)
+
+<a name="SameNameAndDescriptionForStopNotice"/>
+
+#### SameNameAndDescriptionForStopNotice
+
+The GTFS spec defines `stops.txt` [stop_description](https://gtfs.org/reference/static/#stopstxt) as:
+
+> Description of the location that provides useful, quality information. Do not simply duplicate the name of the location.
+
+##### References:
+[stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
 
 <a name="StartAndEndTimeEqualNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -640,6 +640,7 @@
 | `route_color_contrastNotice`               	| [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	|
 | `route_short_and_long_name_equalNotice`    	| [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	|
 | `route_short_name_too_longNotice`          	| [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	|
+| `same_name_and_description_for_stop`        	| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)       	|
 | `start_and_end_time_equalNotice`           	| [`StartAndEndTimeEqualNotice`](#StartAndEndTimeEqualNotice)                       	|
 | `stop_time_timepoint_without_timesNotice`  	| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	|
 | `stop_too_far_from_trip_shapeNotice`       	| [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	|
@@ -824,6 +825,18 @@
 
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
+
+#### [SameNameAndDescriptionForStopNotice](/RULES.md#SameNameAndDescriptionForStopNotice)
+##### Fields description
+
+| Field name     	| Description                             	| Type   	|
+|----------------	|-----------------------------------------	|--------	|
+| `csvRowNumber`   	| The row number of the faulty record.    	| String 	|
+| `stopId`        	| The id of the faulty record.            	| Long   	|
+| `routeDesc`    	| The faulty record's `stop_desc`.       	| String 	|
+
+##### Affected files
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
 #### [StopTimeTimepointWithoutTimesNotice](/RULES.md#StopTimeTimepointWithoutTimesNotice)
 ##### Fields description

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC, MobilityData IO
+ * Copyright 2021 MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.ImmutableMap;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.annotation.SchemaExport;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+
+/**
+ * Validates {@code stops.stop_name} and {@code stops.stop_desc} for a single {@code GtfsStop}.
+ *
+ * <p>Generated notices:
+ *
+ * <ul>
+ *   <li>{@link SameNameAndDescriptionForStopNotice}
+ * </ul>
+ */
+@GtfsValidator
+public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
+
+  @Override
+  public void validate(GtfsStop stop, NoticeContainer noticeContainer) {
+    if (!stop.hasStopName() || !stop.hasStopDesc()) {
+      return;
+    }
+    if (!isValidRouteDesc(stop.stopDesc(), stop.stopName())) {
+      noticeContainer.addValidationNotice(
+          new SameNameAndDescriptionForStopNotice(
+              stop.csvRowNumber(), stop.stopId(), stop.stopDesc()));
+    }
+  }
+
+  private boolean isValidRouteDesc(String stopDesc, String stopName) {
+    // ignore lower case and upper case difference
+    return !stopDesc.equalsIgnoreCase(stopName);
+  }
+
+  /**
+   * A {@code GtfsStop} has identical value for {@code stops.route_desc} and {@code
+   * stops.stop_name}
+   *
+   * <p>"Do not simply duplicate the name of the location."
+   * (http://gtfs.org/reference/static#stopstxt)
+   *
+   * <p>Severity: {@code SeverityLevel.WARNING} - To be upgraded to {@code SeverityLevel.ERROR}
+   */
+  static class SameNameAndDescriptionForStopNotice extends ValidationNotice {
+
+    @SchemaExport
+    SameNameAndDescriptionForStopNotice(
+        long csvRowNumber, String stopId, String routeDesc) {
+      super(
+          new ImmutableMap.Builder<String, Object>()
+              .put("stopId", stopId)
+              .put("csvRowNumber", csvRowNumber)
+              .put("routeDesc", routeDesc)
+              .build(),
+          SeverityLevel.WARNING);
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidatorTest.java
@@ -1,0 +1,66 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.validator.StopNameValidator.SameNameAndDescriptionForStopNotice;
+
+@RunWith(JUnit4.class)
+public class StopNameValidatorTest {
+
+  private static GtfsStop createStop(
+      int csvRowNumber,
+      String stopId,
+      @Nullable String stopName,
+      @Nullable String stopDesc) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(stopId)
+        .setStopName(stopName)
+        .setStopDesc(stopDesc)
+        .build();
+  }
+
+  private static List<ValidationNotice> generateNotices(GtfsStop stop) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new StopNameValidator().validate(stop, noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  @Test
+  public void sameStopNameAndDesc_generatesNotice() {
+    assertThat(
+        generateNotices(createStop(4, "stop id value", "duplicate value", "duplicate value")))
+        .containsExactly(
+            new SameNameAndDescriptionForStopNotice(4, "stop id value", "duplicate value")
+        );
+  }
+
+  @Test
+  public void differentStopNameAndDesc_noNotice() {
+    assertThat(
+        generateNotices(createStop(4, "stop id value", "stop name value", "stop desc value")))
+        .isEmpty();
+  }
+
+  @Test
+  public void missingStopName_noNotice() {
+    assertThat(
+        generateNotices(createStop(4, "stop id value", null, "stop desc value")))
+        .isEmpty();
+  }
+
+  @Test
+  public void missingStopDesc_noNotice() {
+    assertThat(
+        generateNotices(createStop(4, "stop id value", "stop name value", null)))
+        .isEmpty();
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 MobilityData IO
+ * Copyright 2021 MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidatorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2020 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;


### PR DESCRIPTION
closes #910 

**Summary:**

This PR provides support to implement a new rule described in #910 

**Expected behavior:** 

New `ValidationNotice`: `SameNameAndDescriptionForStopNotice` (severity level: `WARNING` - to be upgraded to `ERROR` in the future. 

A notice should be generated for each record from `stops.txt` where `stops.stop_des == stops.stop_name`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
