### PR TITLE
fix: add compileJava option to main/build.gradle

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -54,6 +54,7 @@ shadowJar {
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 mainClassName = 'org.mobilitydata.gtfsvalidator.cli.Main'
+compileJava.options.encoding = "UTF-8"
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
**Summary:**

This PR provides support to fix #934.

**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).

The following should no longer be witnessed when running the validator with `--help` CLI parameter on Windows 10

```
gtfs-validator\main\src\main\java\org\mobilitydata\gtfsvalidator\cli\Main.java:59: error: unmappable character (0x8F) for encoding windows-1252
          "⚠�? Note that parameters marked with an asterisk (*) in the help menu are mandatory.");
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
