### PR TITLE
chore: Use the latest version of s2-geometry library from Google-owned location

### DIFF
--- a/main/build.gradle
+++ b/main/build.gradle
@@ -71,7 +71,7 @@ dependencies {
     implementation 'com.google.flogger:flogger:0.5.1'
     implementation 'com.google.flogger:flogger-system-backend:0.5.1'
     implementation 'com.univocity:univocity-parsers:2.9.0'
-    implementation 'io.sgr:s2-geometry-library-java:1.0.1'
+    implementation 'com.google.geometry:s2-geometry:2.0.0'
     implementation 'org.locationtech.spatial4j:spatial4j:0.7'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.google.flogger:flogger:0.5.1'
     implementation 'com.univocity:univocity-parsers:2.9.0'
-    implementation 'io.sgr:s2-geometry-library-java:1.0.1'
+    implementation 'com.google.geometry:s2-geometry:2.0.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
 }
 


### PR DESCRIPTION
The previously used dependency at io.sgr was not owned nor maintained by
Google.

The Google-owned library now lives at
com.google.geometry:s2-geometry:2.0.0.
