### PR TITLE
feat: Split the default 50 km/h threshold

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -587,11 +587,12 @@ A transit vehicle moves too fast between two consecutive stops. The speed thresh
 | 2          | Rail        | 500             |
 | 3          | Bus         | 150             |
 | 4          | Ferry       |  80             |
-| 5          | Cable tram  | 100             |
+| 5          | Cable tram  |  30             |
 | 6          | Aerial lift |  50             |
 | 7          | Funicular   |  50             |
 | 11         | Trolleybus  | 150             |
 | 12         | Monorail    | 150             |
+| -          | Unknown     | 200             |
 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -293,8 +293,16 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
         return 150;
       case FERRY:
         return 80;
-      default:
+      case CABLE_TRAM:
+        // The average speed of a cable car is 15 km/h. Add some safety gap.
+        return 30;
+      case AERIAL_LIFT:
+      case FUNICULAR:
+        // Fast aerial tramways operate at 43 km/h.
         return 50;
+      default:
+        // High speed threshold for unknown/unsupported vehicle types.
+        return 200;
     }
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -298,7 +298,7 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
         return 30;
       case AERIAL_LIFT:
       case FUNICULAR:
-        // Fast aerial tramways operate at 43 km/h.
+        // Fast aerial tramways operate at 43 km/h. Add some safety gap.
         return 50;
       default:
         // High speed threshold for unknown/unsupported vehicle types.


### PR DESCRIPTION
* Raise speed threshold for unknown vehicle type to 200 km/h
* Set aerial lift and funicular threshold to 50 km/h
* Lower cable tram threshold to 30 km/h

GTFS Validator emits warnings for unknown vehicle types. Numerous
providers use extended route types [1]. This change effectively disables
speed checks for them by setting a high threshold. We can revisit this
later and add support for extended route types, as in Google adoption of
the open-source validator.

[1] https://developers.google.com/transit/gtfs/reference/extended-route-types