### PR TITLE
fix: Remove unused annotation NoticeExport

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/NoticeExport.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/NoticeExport.java
@@ -1,7 +1,0 @@
-package org.mobilitydata.gtfsvalidator.annotation;
-
-/**
- * Annotation to be used on notice constructor. This specifies the constructor to be considered
- * while exporting notice information.
- */
-public @interface NoticeExport {}


### PR DESCRIPTION
It was replaced by SchemaExport that was removed.