### PR TITLE
feat: Add NoticeSchemaGenerator

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -43,7 +43,7 @@ public abstract class Notice {
           .serializeSpecialFloatingPointValues()
           .create();
 
-  private static final String NOTICE_SUFFIX = "_notice";
+  private static final String NOTICE_SUFFIX = "Notice";
 
   private final SeverityLevel severityLevel;
 
@@ -65,9 +65,17 @@ public abstract class Notice {
    * @return notice code, e.g., "foreign_key_violation".
    */
   public String getCode() {
-    return StringUtils.removeEnd(
-        CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, getClass().getSimpleName()),
-        NOTICE_SUFFIX);
+    return getCode(getClass().getSimpleName());
+  }
+
+  /**
+   * Returns a descriptive type-specific name for this notice class simple name.
+   *
+   * @return notice code, e.g., "foreign_key_violation".
+   */
+  static String getCode(String className) {
+    return CaseFormat.UPPER_CAMEL.to(
+        CaseFormat.LOWER_UNDERSCORE, StringUtils.removeEnd(className, NOTICE_SUFFIX));
   }
 
   @Override

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGenerator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGenerator.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.ClassPath;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.mobilitydata.gtfsvalidator.type.GtfsColor;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+import org.mobilitydata.gtfsvalidator.validator.FileValidator;
+import org.mobilitydata.gtfsvalidator.validator.SingleEntityValidator;
+
+/** Exports schema describing all possible notices and their contexts. */
+public class NoticeSchemaGenerator {
+  /** Default packages to find notices in open-source validator. */
+  public static final ImmutableList<String> DEFAULT_NOTICE_PACKAGES =
+      ImmutableList.of(
+          "org.mobilitydata.gtfsvalidator.notice", "org.mobilitydata.gtfsvalidator.validator");
+
+  /**
+   * Exports JSON schema for all notices in given packages. This includes notices that are declared
+   * inside validators.
+   *
+   * <p>See https://json-schema.org/ for more information on JSON schema.
+   *
+   * <p>The returned object looks like that:
+   *
+   * <pre>{@code
+   * {
+   *   "attribution_without_role": {
+   *     "type": "object",
+   *     "properties": {
+   *       "attributionId": {
+   *         "type": "string"
+   *       },
+   *       "csvRowNumber": {
+   *         "type": "integer"
+   *       }
+   *     }
+   *   },
+   *   "duplicate_fare_rule_zone_id_fields": {
+   *     "type": "object",
+   *     "properties": {
+   *       "csvRowNumber": {
+   *         "type": "integer"
+   *       },
+   *       "fareId": {
+   *         "type": "string"
+   *       },
+   *       "previousCsvRowNumber": {
+   *         "type": "integer"
+   *       },
+   *       "previousFareId": {
+   *         "type": "string"
+   *       }
+   *     }
+   *   },
+   *   ...
+   * }
+   * }</pre>
+   *
+   * @param packages List of packages where notices are declared. Use {@link
+   *     #DEFAULT_NOTICE_PACKAGES} and add your custom Java packages here, if any
+   * @return a {@link JsonObject} describing all notices in given packages (see above)
+   * @throws IOException
+   */
+  public static JsonObject jsonSchemaForPackages(List<String> packages) throws IOException {
+    JsonObject schema = new JsonObject();
+    for (Map.Entry<String, Map<String, Class<?>>> entry :
+        contextFieldsInPackages(packages).entrySet()) {
+      schema.add(
+          Notice.getCode(entry.getKey()), jsonSchemaForNotice(entry.getKey(), entry.getValue()));
+    }
+    return schema;
+  }
+
+  /**
+   * Convenient function to find all notices in given packages and describe their fields.
+   *
+   * <p>The returned map has looks this way:
+   *
+   * <pre>{@code
+   * {
+   *   "AttributionWithoutRoleNotice": {
+   *     "attributionId": String.class,
+   *     "csvRowNumber": Long.class,
+   *   }
+   * }
+   * }</pre>
+   *
+   * @param packages List of packages where notices are declared
+   * @return a map describing all notices in given packages (see above)
+   * @throws IOException
+   */
+  @VisibleForTesting
+  static Map<String, Map<String, Class<?>>> contextFieldsInPackages(List<String> packages)
+      throws IOException {
+    // Return a sorted TreeMap for stable results.
+    Map<String, Map<String, Class<?>>> contextFieldsByNotice = new TreeMap<>();
+    for (Class<Notice> noticeClass : findNoticeSubclasses(packages)) {
+      contextFieldsByNotice.put(noticeClass.getSimpleName(), contextFieldsForNotice(noticeClass));
+    }
+
+    return contextFieldsByNotice;
+  }
+
+  @VisibleForTesting
+  static Map<String, Class<?>> contextFieldsForNotice(Class<? extends Notice> noticeClass) {
+    // Return a sorted TreeMap for stable results.
+    Map<String, Class<?>> fields = new TreeMap<>();
+    for (Field field : noticeClass.getDeclaredFields()) {
+      fields.put(field.getName(), field.getType());
+    }
+    return fields;
+  }
+
+  private static boolean isSubclassOf(Class<?> parent, Class<?> child) {
+    return !child.equals(parent) && parent.isAssignableFrom(child);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void maybeAddNoticeClass(Class<?> clazz, List<Class<Notice>> notices) {
+    if (isSubclassOf(Notice.class, clazz)) {
+      notices.add((Class<Notice>) clazz);
+    }
+  }
+
+  private static boolean belongsToAnyPackage(ClassPath.ClassInfo classInfo, List<String> packages) {
+    for (String packageName : packages) {
+      if (classInfo.getName().startsWith(packageName)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isValidatorClass(Class<?> clazz) {
+    return isSubclassOf(FileValidator.class, clazz)
+        || isSubclassOf(SingleEntityValidator.class, clazz);
+  }
+
+  /**
+   * Finds all subclasses of {@link Notice} that belong to the given packages.
+   *
+   * <p>This function also dives into validator classes that may contain inner notice classes.
+   */
+  @VisibleForTesting
+  static List<Class<Notice>> findNoticeSubclasses(List<String> packages) throws IOException {
+    List<Class<Notice>> notices = new ArrayList<>();
+    for (ClassPath.ClassInfo classInfo :
+        ClassPath.from(ClassLoader.getSystemClassLoader()).getTopLevelClasses()) {
+      if (!belongsToAnyPackage(classInfo, packages)) {
+        continue;
+      }
+      Class<?> clazz = classInfo.load();
+      maybeAddNoticeClass(clazz, notices);
+      if (isValidatorClass(clazz)) {
+        // Validator classes often have notice classes inside.
+        for (Class<?> innerClass : clazz.getDeclaredClasses()) {
+          maybeAddNoticeClass(innerClass, notices);
+        }
+      }
+    }
+    return notices;
+  }
+
+  private static final class JsonTypes {
+
+    private static final String NUMBER = "number";
+    private static final String INTEGER = "integer";
+    private static final String STRING = "string";
+    private static final String BOOLEAN = "boolean";
+  }
+
+  static JsonArray objectToJsonType() {
+    JsonArray array = new JsonArray();
+    array.add(JsonTypes.STRING);
+    array.add(JsonTypes.INTEGER);
+    array.add(JsonTypes.NUMBER);
+    return array;
+  }
+
+  static JsonElement javaTypeToJson(Class<?> type) {
+    if (type == int.class
+        || type == long.class
+        || type == short.class
+        || type == byte.class
+        || type == Integer.class
+        || type == Long.class
+        || type == Short.class
+        || type == Byte.class) {
+      return new JsonPrimitive(JsonTypes.INTEGER);
+    }
+    if (type == double.class
+        || type == float.class
+        || type == Double.class
+        || type == Float.class) {
+      return new JsonPrimitive(JsonTypes.NUMBER);
+    }
+    if (type == boolean.class || type == Boolean.class) {
+      return new JsonPrimitive(JsonTypes.BOOLEAN);
+    }
+    if (type == String.class
+        || type == GtfsColor.class
+        || type == GtfsDate.class
+        || type == GtfsTime.class) {
+      return new JsonPrimitive(JsonTypes.STRING);
+    }
+    if (type == Object.class) {
+      return objectToJsonType();
+    }
+    throw new IllegalArgumentException(String.format("Unsupported Java type for JSON: %s", type));
+  }
+
+  static JsonObject fieldTypeSchema(Class<?> fieldType) {
+    JsonObject schema = new JsonObject();
+    schema.add("type", javaTypeToJson(fieldType));
+    return schema;
+  }
+
+  @VisibleForTesting
+  static JsonObject jsonSchemaForNotice(String noticeClass, Map<String, Class<?>> fields) {
+    JsonObject properties = new JsonObject();
+
+    for (Map.Entry<String, Class<?>> field : fields.entrySet()) {
+      try {
+        properties.add(field.getKey(), fieldTypeSchema(field.getValue()));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalStateException(
+            String.format("Cannot generate schema for %s.%s", noticeClass, field.getKey()), e);
+      }
+    }
+    JsonObject schema = new JsonObject();
+    schema.addProperty("type", "object");
+    schema.add("properties", properties);
+    return schema;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -22,6 +22,8 @@ import com.google.gson.Gson;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
 
 @RunWith(JUnit4.class)
 public class NoticeContainerTest {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
@@ -91,7 +91,7 @@ public class NoticeSchemaGeneratorTest {
   }
 
   @Test
-  public void jsonSchemaForNotice_foreignKeyViolationNotice() {
+  public void jsonSchemaForNotice_duplicateKeyNotice() {
     JsonElement expected =
         new Gson()
             .toJsonTree(

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import java.io.IOException;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.GtfsTypesValidationNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.TestValidator.TestInnerNotice;
+import org.mobilitydata.gtfsvalidator.type.GtfsColor;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+public class NoticeSchemaGeneratorTest {
+  private static final String OPEN_SOURCE_NOTICES_PACKAGE = "org.mobilitydata.gtfsvalidator";
+  private static final String TEST_NOTICES_PACKAGE =
+      "org.mobilitydata.gtfsvalidator.notice.testnotices";
+
+  @Test
+  public void findNoticeSubclasses() throws IOException {
+    assertThat(NoticeSchemaGenerator.findNoticeSubclasses(ImmutableList.of(TEST_NOTICES_PACKAGE)))
+        .containsExactly(
+            DoubleFieldNotice.class,
+            TestInnerNotice.class,
+            GtfsTypesValidationNotice.class,
+            StringFieldNotice.class);
+  }
+
+  @Test
+  public void jsonSchemaForPackages_succeeds() throws IOException {
+    assertThat(
+            NoticeSchemaGenerator.jsonSchemaForPackages(
+                ImmutableList.of(OPEN_SOURCE_NOTICES_PACKAGE)))
+        .isNotNull();
+  }
+
+  @Test
+  public void contextFieldsInPackages_testNotices() throws IOException {
+    assertThat(
+            NoticeSchemaGenerator.contextFieldsInPackages(ImmutableList.of(TEST_NOTICES_PACKAGE)))
+        .isEqualTo(
+            ImmutableMap.of(
+                "DoubleFieldNotice",
+                ImmutableMap.of("doubleField", double.class),
+                "TestInnerNotice",
+                ImmutableMap.of("intField", int.class),
+                "GtfsTypesValidationNotice",
+                ImmutableMap.of(
+                    "color", GtfsColor.class, "date", GtfsDate.class, "time", GtfsTime.class),
+                "StringFieldNotice",
+                ImmutableMap.of("someField", String.class)));
+  }
+
+  @Test
+  public void contextFieldsForNotice_foreignKeyViolationNotice() {
+    assertThat(NoticeSchemaGenerator.contextFieldsForNotice(ForeignKeyViolationNotice.class))
+        .containsExactly(
+            "childFieldName",
+            String.class,
+            "childFilename",
+            String.class,
+            "csvRowNumber",
+            long.class,
+            "fieldValue",
+            String.class,
+            "parentFieldName",
+            String.class,
+            "parentFilename",
+            String.class);
+  }
+
+  @Test
+  public void jsonSchemaForNotice_foreignKeyViolationNotice() {
+    JsonElement expected =
+        new Gson()
+            .toJsonTree(
+                ImmutableMap.of(
+                    "type",
+                    "object",
+                    "properties",
+                    new ImmutableMap.Builder<String, Object>()
+                        .put("fieldName1", ImmutableMap.of("type", "string"))
+                        .put("fieldName2", ImmutableMap.of("type", "string"))
+                        .put(
+                            "fieldValue1",
+                            ImmutableMap.of(
+                                "type", ImmutableList.of("string", "integer", "number")))
+                        .put(
+                            "fieldValue2",
+                            ImmutableMap.of(
+                                "type", ImmutableList.of("string", "integer", "number")))
+                        .put("filename", ImmutableMap.of("type", "string"))
+                        .put("newCsvRowNumber", ImmutableMap.of("type", "integer"))
+                        .put("oldCsvRowNumber", ImmutableMap.of("type", "integer"))
+                        .build()));
+
+    assertThat(
+            NoticeSchemaGenerator.jsonSchemaForNotice(
+                "DuplicateKeyNotice",
+                NoticeSchemaGenerator.contextFieldsForNotice(DuplicateKeyNotice.class)))
+        .isEqualTo(expected);
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
@@ -6,6 +6,9 @@ import com.google.gson.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.GtfsTypesValidationNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
@@ -97,19 +100,6 @@ public class NoticeTest {
     public OtherStringFieldNotice(String someField, SeverityLevel severityLevel) {
       super(severityLevel);
       this.someField = someField;
-    }
-  }
-
-  private static class GtfsTypesValidationNotice extends Notice {
-    private final GtfsColor color;
-    private final GtfsDate date;
-    private final GtfsTime time;
-
-    public GtfsTypesValidationNotice(GtfsColor color, GtfsDate date, GtfsTime time) {
-      super(SeverityLevel.ERROR);
-      this.color = color;
-      this.date = date;
-      this.time = time;
     }
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/DoubleFieldNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/DoubleFieldNotice.java
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package org.mobilitydata.gtfsvalidator.notice;
+package org.mobilitydata.gtfsvalidator.notice.testnotices;
 
-class StringFieldNotice extends ValidationNotice {
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 
-  private final String someField;
+public class DoubleFieldNotice extends ValidationNotice {
 
-  public StringFieldNotice(String someField, SeverityLevel severityLevel) {
+  private final double doubleField;
+
+  public DoubleFieldNotice(double doubleField, SeverityLevel severityLevel) {
     super(severityLevel);
-    this.someField = someField;
+    this.doubleField = doubleField;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/GtfsTypesValidationNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/GtfsTypesValidationNotice.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice.testnotices;
+
+import org.mobilitydata.gtfsvalidator.notice.Notice;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.type.GtfsColor;
+import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+public class GtfsTypesValidationNotice extends Notice {
+
+  private final GtfsColor color;
+  private final GtfsDate date;
+  private final GtfsTime time;
+
+  public GtfsTypesValidationNotice(GtfsColor color, GtfsDate date, GtfsTime time) {
+    super(SeverityLevel.ERROR);
+    this.color = color;
+    this.date = date;
+    this.time = time;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/StringFieldNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/StringFieldNotice.java
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package org.mobilitydata.gtfsvalidator.notice;
+package org.mobilitydata.gtfsvalidator.notice.testnotices;
 
-class DoubleFieldNotice extends ValidationNotice {
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 
-  private final double doubleField;
+public class StringFieldNotice extends ValidationNotice {
 
-  public DoubleFieldNotice(double doubleField, SeverityLevel severityLevel) {
+  private final String someField;
+
+  public StringFieldNotice(String someField, SeverityLevel severityLevel) {
     super(severityLevel);
-    this.doubleField = doubleField;
+    this.someField = someField;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/TestValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/TestValidator.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice.testnotices;
+
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.validator.FileValidator;
+
+public class TestValidator extends FileValidator {
+
+  public static class TestInnerNotice extends ValidationNotice {
+    private final int intField;
+
+    public TestInnerNotice() {
+      super(SeverityLevel.ERROR);
+      this.intField = 0;
+    }
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {}
+}


### PR DESCRIPTION
It is currently not plugged into cli/Main.java.

The schema generator uses Java reflection to find all notice 
classes and describe their fields.

The schema generator currently exports JSON schema for the notices. It
may also export other schema formats in future (e.g., SQL-friendly
schema).

Sample output.

```
{
  "attribution_without_role": {
    "type": "object",
    "properties": {
      "attributionId": {
        "type": "string"
      },
      "csvRowNumber": {
        "type": "integer"
      }
    }
  },
  "block_trips_with_overlapping_stop_times": {
    "type": "object",
    "properties": {
      "blockId": {
        "type": "string"
      },
      "csvRowNumberA": {
        "type": "integer"
      },
      "csvRowNumberB": {
        "type": "integer"
      },
      "intersection": {
        "type": "string"
      },
      "serviceIdA": {
        "type": "string"
      },
      "serviceIdB": {
        "type": "string"
      },
      "tripIdA": {
        "type": "string"
      },
      "tripIdB": {
        "type": "string"
      }
    }
  },
```