### PR TITLE
feat: Return JsonObject from NoticeContainer methods

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -16,11 +16,8 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
-import static org.mobilitydata.gtfsvalidator.notice.Notice.GSON;
-
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.MultimapBuilder;
-import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import java.util.ArrayList;
@@ -35,8 +32,6 @@ import java.util.List;
  * own NoticeContainer, and after execution is complete the results are merged.
  */
 public class NoticeContainer {
-  private static final Gson PRETTY_GSON = GSON.newBuilder().setPrettyPrinting().create();
-
   /** Limit on the amount of exported notices of the same type and severity. */
   private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
 
@@ -100,13 +95,13 @@ public class NoticeContainer {
   }
 
   /** Exports all validation notices as JSON. */
-  public String exportValidationNotices(boolean isPretty) {
-    return exportJson(validationNotices, isPretty);
+  public JsonObject exportValidationNotices() {
+    return exportJson(validationNotices);
   }
 
   /** Exports all system errors as JSON. */
-  public String exportSystemErrors(boolean isPretty) {
-    return exportJson(systemErrors, isPretty);
+  public JsonObject exportSystemErrors() {
+    return exportJson(systemErrors);
   }
 
   /**
@@ -114,7 +109,7 @@ public class NoticeContainer {
    *
    * <p>Up to {@link #MAX_EXPORTS_PER_NOTICE_TYPE} is exported per each type+severity.
    */
-  public static <T extends Notice> String exportJson(List<T> notices, boolean isPretty) {
+  private static <T extends Notice> JsonObject exportJson(List<T> notices) {
     JsonObject root = new JsonObject();
     JsonArray jsonNotices = new JsonArray();
     root.add("notices", jsonNotices);
@@ -139,7 +134,7 @@ public class NoticeContainer {
       }
     }
 
-    return (isPretty ? PRETTY_GSON : GSON).toJson(root);
+    return root;
   }
 
   private static <T extends Notice> ListMultimap<String, T> groupNoticesByTypeAndSeverity(

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.gson.Gson;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,7 +27,7 @@ import org.junit.runners.JUnit4;
 public class NoticeContainerTest {
 
   @Test
-  public void exportJson_defaultPrint() {
+  public void exportNotices() {
     NoticeContainer container = new NoticeContainer();
     container.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
     container.addValidationNotice(new MissingRequiredFileNotice("agency.txt"));
@@ -34,13 +35,13 @@ public class NoticeContainerTest {
         new RuntimeExceptionInValidatorError(
             "FaultyValidator", new IndexOutOfBoundsException("Index 0 out of bounds")));
 
-    assertThat(container.exportValidationNotices(false))
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
         .isEqualTo(
             "{\"notices\":["
                 + "{\"code\":\"missing_required_file\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":2,\"notices\":"
                 + "[{\"filename\":\"stops.txt\"},{\"filename\":\"agency.txt\"}]}]}");
-    assertThat(container.exportSystemErrors(false))
+    assertThat(new Gson().toJson(container.exportSystemErrors()))
         .isEqualTo(
             "{\"notices\":[{\"code\":\"runtime_exception_in_validator_error\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":1,\"notices\":[{\"validator\":\"FaultyValidator\",\"exception\":\"java.lang.IndexOutOfBoundsException\",\"message\":\"Index"
@@ -48,59 +49,11 @@ public class NoticeContainerTest {
   }
 
   @Test
-  public void exportJson_prettyPrint() {
-    NoticeContainer container = new NoticeContainer();
-    container.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
-    container.addValidationNotice(new MissingRequiredFileNotice("agency.txt"));
-    container.addSystemError(
-        new RuntimeExceptionInValidatorError(
-            "FaultyValidator", new IndexOutOfBoundsException("Index 0 out of bounds")));
-
-    assertThat(container.exportValidationNotices(true))
-        .isEqualTo(
-            "{\n"
-                + "  \"notices\": [\n"
-                + "    {\n"
-                + "      \"code\": \"missing_required_file\",\n"
-                + "      \"severity\": \"ERROR\",\n"
-                + "      \"totalNotices\": 2,\n"
-                + "      \"notices\": [\n"
-                + "        {\n"
-                + "          \"filename\": \"stops.txt\"\n"
-                + "        },\n"
-                + "        {\n"
-                + "          \"filename\": \"agency.txt\"\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  ]\n"
-                + "}");
-    assertThat(container.exportSystemErrors(true))
-        .isEqualTo(
-            "{\n"
-                + "  \"notices\": [\n"
-                + "    {\n"
-                + "      \"code\": \"runtime_exception_in_validator_error\",\n"
-                + "      \"severity\": \"ERROR\",\n"
-                + "      \"totalNotices\": 1,\n"
-                + "      \"notices\": [\n"
-                + "        {\n"
-                + "          \"validator\": \"FaultyValidator\",\n"
-                + "          \"exception\": \"java.lang.IndexOutOfBoundsException\",\n"
-                + "          \"message\": \"Index 0 out of bounds\"\n"
-                + "        }\n"
-                + "      ]\n"
-                + "    }\n"
-                + "  ]\n"
-                + "}");
-  }
-
-  @Test
   public void exportInfinityInContext() {
     NoticeContainer container = new NoticeContainer();
     container.addValidationNotice(
         new DoubleFieldNotice(Double.POSITIVE_INFINITY, SeverityLevel.ERROR));
-    assertThat(container.exportValidationNotices(false))
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
         .isEqualTo(
             "{\"notices\":[{\"code\":\"double_field\",\"severity\":\"ERROR\","
                 + "\"totalNotices\":1,\"notices\":[{\"doubleField\":Infinity}]}]}");
@@ -113,7 +66,7 @@ public class NoticeContainerTest {
     container.addValidationNotice(new DoubleFieldNotice(2.0, SeverityLevel.ERROR));
     container.addValidationNotice(new StringFieldNotice("3", SeverityLevel.INFO));
 
-    assertThat(container.exportValidationNotices(false))
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
         .isEqualTo(
             "{\"notices\":["
                 + "{\"code\":\"double_field\",\"severity\":\"ERROR\",\"totalNotices\":1,\"notices\":[{\"doubleField\":2.0}]},"

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -68,6 +68,7 @@ dependencies {
     implementation 'com.beust:jcommander:1.48'
     implementation 'javax.inject:javax.inject:1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.10.0'
+    implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.guava:guava:29.0-jre'
     implementation 'com.google.flogger:flogger:0.5.1'
     implementation 'com.google.flogger:flogger-system-backend:0.5.1'

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -19,6 +19,8 @@ package org.mobilitydata.gtfsvalidator.cli;
 import com.beust.jcommander.JCommander;
 import com.google.common.base.Strings;
 import com.google.common.flogger.FluentLogger;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -146,18 +148,25 @@ public class Main {
     System.out.println(feedContainer.tableTotals());
   }
 
+  private static Gson createGson(boolean pretty) {
+    GsonBuilder builder = new GsonBuilder();
+    if (pretty) {
+      builder.setPrettyPrinting();
+    }
+    return builder.create();
+  }
+
   /** Generates and exports reports for both validation notices and system errors reports. */
   private static void exportReport(final NoticeContainer noticeContainer, final Arguments args) {
     new File(args.getOutputBase()).mkdirs();
+    Gson gson = createGson(args.getPretty());
     try {
       Files.write(
           Paths.get(args.getOutputBase(), args.getValidationReportName()),
-          noticeContainer
-              .exportValidationNotices(args.getPretty())
-              .getBytes(StandardCharsets.UTF_8));
+          gson.toJson(noticeContainer.exportValidationNotices()).getBytes(StandardCharsets.UTF_8));
       Files.write(
           Paths.get(args.getOutputBase(), args.getSystemErrorsReportName()),
-          noticeContainer.exportSystemErrors(args.getPretty()).getBytes(StandardCharsets.UTF_8));
+          gson.toJson(noticeContainer.exportSystemErrors()).getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");
     }


### PR DESCRIPTION
The caller can decide how to format JSON string:
* pretty printing
* HTML safe (escape <>&=)
* lenient
* etc.
