### PR TITLE
chore: Protect against infinite loop in getStopOrParentLatLng

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/StopUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/StopUtil.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.geometry.S2LatLng;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+
+/** Utility functions for {@code stops.txt} */
+public class StopUtil {
+
+  /**
+   * Returns coordinates of the stop. If they are missing, coordinates of the parent are used.
+   *
+   * <p>Supports up to 3 levels of location hierarchy: station, stop, boarding area.
+   *
+   * <p>Returns (0, 0) if no coordinates are found in parent chain.
+   */
+  public static S2LatLng getStopOrParentLatLng(GtfsStopTableContainer stopTable, String stopId) {
+    // Do not do an infinite loop since there may be a data bug and an infinite cycle of parents.
+    for (int i = 0; i < 3; ++i) {
+      GtfsStop stop = stopTable.byStopId(stopId);
+      if (stop.hasStopLatLon()) {
+        return stop.stopLatLon();
+      }
+      if (stop.hasParentStation()) {
+        stopId = stop.parentStation();
+      } else {
+        break;
+      }
+    }
+    return S2LatLng.CENTER;
+  }
+
+  private StopUtil() {}
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/StopUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/StopUtilTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.util;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.geometry.S2LatLng;
+import com.google.common.truth.Expect;
+import javax.annotation.Nullable;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+
+@RunWith(JUnit4.class)
+public class StopUtilTest {
+  @Rule public final Expect expect = Expect.create();
+
+  private static String numberToStopId(int number) {
+    return "s" + number;
+  }
+
+  private static GtfsStop createStop(
+      int id, @Nullable Double stopLat, @Nullable Double stopLon, @Nullable String parentStation) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(id)
+        .setStopId(numberToStopId(id))
+        .setStopLat(stopLat)
+        .setStopLon(stopLon)
+        .setParentStation(parentStation)
+        .build();
+  }
+
+  @Test
+  public void getStopOrParentLatLng_valid() {
+    ImmutableList<GtfsStop> stops =
+        ImmutableList.of(
+            createStop(0, 10.0, 11.0, null),
+            createStop(1, 20.0, 21.0, numberToStopId(0)),
+            createStop(2, null, null, numberToStopId(0)),
+            createStop(3, null, null, numberToStopId(2)));
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
+
+    expect
+        .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(0)))
+        .isEqualTo(stops.get(0).stopLatLon());
+    expect
+        .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(1)))
+        .isEqualTo(stops.get(1).stopLatLon());
+    expect
+        .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(2)))
+        .isEqualTo(stops.get(0).stopLatLon());
+    expect
+        .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(3)))
+        .isEqualTo(stops.get(0).stopLatLon());
+  }
+
+  @Test
+  public void getStopOrParentLatLng_infiniteLoop() {
+    ImmutableList<GtfsStop> stops =
+        ImmutableList.of(
+            createStop(0, null, null, numberToStopId(1)),
+            createStop(1, null, null, numberToStopId(0)));
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
+
+    expect
+        .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(0)))
+        .isEqualTo(S2LatLng.CENTER);
+  }
+
+  @Test
+  public void getStopOrParentLatLng_noLatLng() {
+    ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(0, null, null, null));
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
+
+    expect
+        .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(0)))
+        .isEqualTo(S2LatLng.CENTER);
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidatorTest.java
@@ -18,7 +18,6 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 import static org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.getSpeedKphBetweenStops;
-import static org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.getStopLatLng;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.geometry.S2LatLng;
@@ -326,22 +325,5 @@ public final class StopTimeTravelSpeedValidatorTest {
     List<GtfsStopTime> stopTimes =
         createStopTimesSameDepartureArrival(ImmutableList.of(GtfsTime.fromString("08:00:00")));
     assertThat(getSpeedKphBetweenStops(2, stopTimes.get(0), stopTimes.get(0))).isEqualTo(120);
-  }
-
-  @Test
-  public void getStopLatLng_chain() {
-    List<GtfsStop> stops =
-        ImmutableList.of(
-            new GtfsStop.Builder().setStopId("boardingArea1").setParentStation("platform1").build(),
-            new GtfsStop.Builder().setStopId("platform1").setParentStation("station1").build(),
-            new GtfsStop.Builder().setStopId("station1").setStopLat(40.0).setStopLon(30.0).build(),
-            new GtfsStop.Builder().setStopId("stop1").setStopLat(50.0).setStopLon(60.0).build());
-    GtfsStopTableContainer stopTable =
-        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
-    assertThat(getStopLatLng(stopTable, "boardingArea1")).isEqualTo(stops.get(2).stopLatLon());
-    assertThat(getStopLatLng(stopTable, "platform1")).isEqualTo(stops.get(2).stopLatLon());
-    assertThat(getStopLatLng(stopTable, "station1")).isEqualTo(stops.get(2).stopLatLon());
-
-    assertThat(getStopLatLng(stopTable, "stop1")).isEqualTo(stops.get(3).stopLatLon());
   }
 }


### PR DESCRIPTION
Also move getStopOrParentLatLng to a separate class to make it reusable.
