### PR TITLE
feat: Serialize S2LatLng fields in Notice subclasses

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -17,10 +17,12 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.base.CaseFormat;
+import com.google.common.geometry.S2LatLng;
 import com.google.gson.ExclusionStrategy;
 import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
@@ -40,6 +42,7 @@ public abstract class Notice {
           .registerTypeAdapter(GtfsColor.class, new GtfsColorSerializer())
           .registerTypeAdapter(GtfsDate.class, new GtfsDateSerializer())
           .registerTypeAdapter(GtfsTime.class, new GtfsTimeSerializer())
+          .registerTypeAdapter(S2LatLng.class, new S2LatLngSerializer())
           .serializeSpecialFloatingPointValues()
           .create();
 
@@ -143,6 +146,17 @@ public abstract class Notice {
     @Override
     public JsonElement serialize(GtfsTime src, Type typeOfSrc, JsonSerializationContext context) {
       return new JsonPrimitive(src.toHHMMSS());
+    }
+  }
+
+  /** Serializes {@link S2LatLng} as {@code [latDegrees, lngDegrees]} array. */
+  private static class S2LatLngSerializer implements JsonSerializer<S2LatLng> {
+    @Override
+    public JsonElement serialize(S2LatLng src, Type typeOfSrc, JsonSerializationContext context) {
+      JsonArray latLng = new JsonArray(2);
+      latLng.add(src.latDegrees());
+      latLng.add(src.lngDegrees());
+      return latLng;
     }
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGenerator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGenerator.java
@@ -18,6 +18,7 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
+import com.google.common.geometry.S2LatLng;
 import com.google.common.reflect.ClassPath;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -195,6 +196,19 @@ public class NoticeSchemaGenerator {
     private static final String INTEGER = "integer";
     private static final String STRING = "string";
     private static final String BOOLEAN = "boolean";
+    private static final String ARRAY = "array";
+  }
+
+  static JsonObject s2LatLngToJsonType() {
+    JsonObject contains = new JsonObject();
+    contains.addProperty("type", JsonTypes.NUMBER);
+
+    JsonObject typeDef = new JsonObject();
+    typeDef.addProperty("type", JsonTypes.ARRAY);
+    typeDef.add("contains", contains);
+    typeDef.addProperty("minItems", 2);
+    typeDef.addProperty("maxItems", 2);
+    return typeDef;
   }
 
   static JsonArray objectToJsonType() {
@@ -238,6 +252,9 @@ public class NoticeSchemaGenerator {
   }
 
   static JsonObject fieldTypeSchema(Class<?> fieldType) {
+    if (fieldType == S2LatLng.class) {
+      return s2LatLngToJsonType();
+    }
     JsonObject schema = new JsonObject();
     schema.add("type", javaTypeToJson(fieldType));
     return schema;

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
@@ -20,12 +20,14 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.geometry.S2LatLng;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import java.io.IOException;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.GtfsTypesValidationNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.S2LatLngNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.TestValidator.TestInnerNotice;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
@@ -44,6 +46,7 @@ public class NoticeSchemaGeneratorTest {
             DoubleFieldNotice.class,
             TestInnerNotice.class,
             GtfsTypesValidationNotice.class,
+            S2LatLngNotice.class,
             StringFieldNotice.class);
   }
 
@@ -68,6 +71,8 @@ public class NoticeSchemaGeneratorTest {
                 "GtfsTypesValidationNotice",
                 ImmutableMap.of(
                     "color", GtfsColor.class, "date", GtfsDate.class, "time", GtfsTime.class),
+                "S2LatLngNotice",
+                ImmutableMap.of("point", S2LatLng.class),
                 "StringFieldNotice",
                 ImmutableMap.of("someField", String.class)));
   }
@@ -119,6 +124,34 @@ public class NoticeSchemaGeneratorTest {
             NoticeSchemaGenerator.jsonSchemaForNotice(
                 "DuplicateKeyNotice",
                 NoticeSchemaGenerator.contextFieldsForNotice(DuplicateKeyNotice.class)))
+        .isEqualTo(expected);
+  }
+
+  @Test
+  public void jsonSchemaForNotice_s2LatLngNotice() {
+    JsonElement expected =
+        new Gson()
+            .toJsonTree(
+                ImmutableMap.of(
+                    "type",
+                    "object",
+                    "properties",
+                    ImmutableMap.of(
+                        "point",
+                        ImmutableMap.of(
+                            "type",
+                            "array",
+                            "contains",
+                            ImmutableMap.of("type", "number"),
+                            "minItems",
+                            2,
+                            "maxItems",
+                            2))));
+
+    assertThat(
+            NoticeSchemaGenerator.jsonSchemaForNotice(
+                "S2LatLngNotice",
+                NoticeSchemaGenerator.contextFieldsForNotice(S2LatLngNotice.class)))
         .isEqualTo(expected);
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
@@ -2,12 +2,15 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.geometry.S2LatLng;
+import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.GtfsTypesValidationNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.S2LatLngNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -75,6 +78,18 @@ public class NoticeTest {
                     GtfsTime.fromString("12:20:34"))
                 .getContext())
         .isEqualTo(expected);
+  }
+
+  @Test
+  public void getContext_s2LatLng() {
+    S2LatLng latLng = S2LatLng.fromDegrees(45, 48);
+    JsonObject expected = new JsonObject();
+    JsonArray point = new JsonArray();
+    point.add(latLng.latDegrees());
+    point.add(latLng.lngDegrees());
+    expected.add("point", point);
+
+    assertThat(new S2LatLngNotice(latLng).getContext()).isEqualTo(expected);
   }
 
   @Test

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/S2LatLngNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/S2LatLngNotice.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice.testnotices;
+
+import com.google.common.geometry.S2LatLng;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+
+public class S2LatLngNotice extends ValidationNotice {
+  private final S2LatLng point;
+
+  public S2LatLngNotice(S2LatLng point) {
+    super(SeverityLevel.ERROR);
+    this.point = point;
+  }
+}


### PR DESCRIPTION
We will add notices with S2LatLng fields and we need to serialize them
to JSON. An S2LatLng will be serialized as array of two numbers:
latitude and longitude, in degrees:

```
"montreal": [45.505331312, -73.55249779]
```

This is similar to GeoJSON format for points:

```
"geometry": {
    "type": "Point",
    "coordinates": [102.0, 0.5]
}
```