### PR TITLE
ci: verify gradle wrapper 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,7 +7,13 @@ on:
     types: [ prereleased, released ]
 
 jobs:
+  validate_gradle_wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
   test:
+    needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -5,7 +5,13 @@ on:
     branches: [ master, extend-end-to-end ] #<-- replace extend-end-to-end by the name of the agency/publisher
 
 jobs:
+  validate_gradle_wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
   run-on-data:
+    needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -5,7 +5,13 @@ on:
     branches: [ master, extend-end-to-end ] #<-- replace extend-end-to-end by the name of the agency/publisher
 
 jobs:
+  validate_gradle_wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
   run-on-data:
+    needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/end_to_end_big.yml
+++ b/.github/workflows/end_to_end_big.yml
@@ -5,7 +5,13 @@ on:
     branches: [ master, extend-end-to-end ] #<-- replace transport-agency-name by the name of the agency/publisher
 
 jobs:
+  validate_gradle_wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
   run-on-data:
+    needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -13,7 +13,13 @@ on:
     types: [ prereleased, released ]
 
 jobs:
+  validate_gradle_wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gradle/wrapper-validation-action@v1
   test:
+    needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
relates to #734 

**Summary:**

This PR provides support to verify the gradle wrapper by adding a job to the `test_pack_doc`workflow.

> This adds additional security/integrity to ensure that any changes to the wrapper match an official Gradle release.
(from https://github.com/MobilityData/gtfs-validator/pull/963#pullrequestreview-731891885)

 Said job is required to execute test, packaging and documentation jobs. 

**Expected behavior:** 

Workflows fail if the SHA-256 checksum does not match an official release from Gradle. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- ~[ ] Run the unit tests with `gradle test` to make sure you didn't break anything~
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
