### PR TITLE
feat: verify conditional requirement of levels.txt presence

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -125,6 +125,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`InconsistentAgencyLangNotice`](#InconsistentAgencyLangNotice)                   	| Inconsistent language among agencies.                                                                                                                       	|
 | [`LeadingOrTrailingWhitespacesNotice`](#LeadingOrTrailingWhitespacesNotice)         | The value in CSV file has leading or trailing whitespaces.                                                                                                  	|
 | [`MissingFeedInfoDateNotice`](#MissingFeedInfoDateNotice)                         	| `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided.                   	|
+| [`MissingLevelNotice`](#MissingLevelNotice)       	                                | `levels.txt` is conditionally required.                                                                                                                	    |
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	| More than one row in CSV.                                                                                                                                   	|
 | [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	| Non ascii or non printable char in  `id`.                                                                                                                   	|
 | [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	| A platform has no `parent_station` field set.                                                                                                               	|
@@ -658,6 +659,15 @@ Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one
 
 ##### References:
 * [feed_info.txt Best practices](http://gtfs.org/best-practices/#feed_infotxt)
+
+<a name="MissingLevelNotice"/>
+
+#### MissingLevelNotice
+
+GTFS file `levels.txt` is required for elevator (`pathway_mode=5`).
+
+##### References:
+* [levels.txt specification](http://gtfs.org/reference/static/#levelstxt)
 
 <a name="MoreThanOneEntityNotice"/>
 

--- a/RULES.md
+++ b/RULES.md
@@ -664,7 +664,7 @@ Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one
 
 #### MissingLevelNotice
 
-GTFS file `levels.txt` is required for elevator (`pathway_mode=5`).
+GTFS file `levels.txt` is required for elevator (`pathway_mode=5`). Here, the values passed to `pathways.pathway_mode` are assumed to be correct.
 
 ##### References:
 * [levels.txt specification](http://gtfs.org/reference/static/#levelstxt)

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -610,6 +610,7 @@
 | `inconsistent_agency_lang`                 	| [`InconsistentAgencyLangNotice`](#InconsistentAgencyLangNotice)                   	|
 | `leading_or_trailing_whitespaces`           | [`LeadingOrTrailingWhitespacesNotice`](#LeadingOrTrailingWhitespacesNotice)         |
 | `missing_feed_info_date`                   	| [`MissingFeedInfoDateNotice`](#MissingFeedInfoDateNotice)                         	|
+| `missing_level`                              	| [`MissingLevelNotice`](#MissingLevelNotice)                                       	|
 | `more_than_one_entity`                     	| [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	|
 | `non_ascii_or_non_printable_char`          	| [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	|
 | `platform_without_parent_station`          	| [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	|
@@ -744,6 +745,17 @@
 
 ##### Affected files
 * [`feed_info.txt`](http://gtfs.org/reference/static#feed_infotxt)
+
+#### [MissingLevelNotice](/RULES.md#MissingLevelNotice)
+##### Fields description
+
+| Field name    	| Description                         	| Type   	|
+|---------------	|-----------------------------------	|--------	|
+| `csvRowNumber`  	| The row number of the faulty record. 	| Long   	|
+| `pathwayId` 	    | The id of the faulty record.         	| String   	|
+
+##### Affected files
+* [`levels.txt`](http://gtfs.org/reference/static#levelstxt)
 
 #### [MoreThanOneEntityNotice](/RULES.md#MoreThanOneEntityNotice)
 ##### Fields description

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -749,10 +749,10 @@
 #### [MissingLevelNotice](/RULES.md#MissingLevelNotice)
 ##### Fields description
 
-| Field name    	| Description                         	| Type   	|
-|---------------	|-----------------------------------	|--------	|
-| `csvRowNumber`  	| The row number of the faulty record. 	| Long   	|
-| `pathwayId` 	    | The id of the faulty record.         	| String   	|
+| Field name    	| Description                                                      	 | Type   	|
+|---------------	|------------------------------------------------------------------- |--------	|
+| `csvRowNumber`  | The row number of the faulty record. 	                             | Long   	|
+| `pathwayId` 	  | The id of the record from pathways.txt that refers to `levels.txt`.| String   |
 
 ##### Affected files
 * [`levels.txt`](http://gtfs.org/reference/static#levelstxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -67,8 +67,7 @@ public class LevelPresenceValidator extends FileValidator {
    * A row from pathways.txt has {@code pathways.pathway_mode=5} but levels.txt is empty or not
    * provided.
    *
-   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded to {@code SeverityLevel.ERROR}.
-``
+   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded to {@code SeverityLevel.ERROR}. ``
    */
   static class MissingLevelNotice extends ValidationNotice {
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -60,8 +60,7 @@ public class LevelPresenceValidator extends FileValidator {
     }
     GtfsPathway pathway = byPathwayModeMap.get(GtfsPathwayMode.ELEVATOR).get(0);
     noticeContainer.addValidationNotice(
-        new MissingLevelNotice(pathway.csvRowNumber(), pathway.pathwayId())
-    );
+        new MissingLevelNotice(pathway.csvRowNumber(), pathway.pathwayId()));
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsLevelTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayMode;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
+
+/**
+ * Checks that levels.txt is provided if at least a row from pathways.txt has {@code
+ * pathway.pathway_mode=5}.
+ *
+ * <p>Generated notice: {@link MissingLevelNotice}.
+ */
+@GtfsValidator
+public class LevelPresenceValidator extends FileValidator {
+
+  private final GtfsLevelTableContainer levels;
+  private final GtfsPathwayTableContainer pathways;
+
+  @Inject
+  LevelPresenceValidator(GtfsLevelTableContainer levels, GtfsPathwayTableContainer pathways) {
+    this.levels = levels;
+    this.pathways = pathways;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    if (levels.entityCount() != 0) {
+      return;
+    }
+    ListMultimap<GtfsPathwayMode, GtfsPathway> byPathwayModeMap = ArrayListMultimap.create();
+    for (GtfsPathway pathway : pathways.getEntities()) {
+      byPathwayModeMap.put(pathway.pathwayMode(), pathway);
+    }
+    if (byPathwayModeMap.get(GtfsPathwayMode.ELEVATOR) == null) {
+      return;
+    }
+    GtfsPathway pathway = byPathwayModeMap.get(GtfsPathwayMode.ELEVATOR).get(0);
+    noticeContainer.addValidationNotice(
+        new MissingLevelNotice(pathway.csvRowNumber(), pathway.pathwayId())
+    );
+  }
+
+  /**
+   * A row from pathways.txt has {@code pathways.pathway_mode=5} but levels.txt is empty or not
+   * provided.
+   *
+   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded as an ERROR.
+   */
+  static class MissingLevelNotice extends ValidationNotice {
+
+    private final long csvRowNumber;
+    private final String pathwayId;
+
+    MissingLevelNotice(long csvRowNumber, String pathwayId) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = csvRowNumber;
+      this.pathwayId = pathwayId;
+    }
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -67,7 +67,8 @@ public class LevelPresenceValidator extends FileValidator {
    * A row from pathways.txt has {@code pathways.pathway_mode=5} but levels.txt is empty or not
    * provided.
    *
-   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded as an ERROR.
+   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded to {@code SeverityLevel.ERROR}.
+``
    */
   static class MissingLevelNotice extends ValidationNotice {
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -68,7 +68,7 @@ public class LevelPresenceValidator extends FileValidator {
    * A row from pathways.txt has {@code pathways.pathway_mode=5} but levels.txt is empty or not
    * provided.
    *
-   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded to {@code SeverityLevel.ERROR}. ``
+   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded to {@code SeverityLevel.ERROR}.
    */
   static class MissingLevelNotice extends ValidationNotice {
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -30,7 +30,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
 
 /**
  * Checks that levels.txt is provided if at least a row from pathways.txt has {@code
- * pathway.pathway_mode=5}.
+ * pathway.pathway_mode=5}. Only one notice is generated here assuming that the content of {@code
+ * pathways.txt} is correct.
  *
  * <p>Generated notice: {@link MissingLevelNotice}.
  */

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidatorTest.java
@@ -16,6 +16,8 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.junit.Test;
@@ -30,28 +32,25 @@ import org.mobilitydata.gtfsvalidator.table.GtfsPathwayMode;
 import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
 import org.mobilitydata.gtfsvalidator.validator.LevelPresenceValidator.MissingLevelNotice;
 
-import static com.google.common.truth.Truth.assertThat;
-
 @RunWith(JUnit4.class)
 public class LevelPresenceValidatorTest {
 
-  private static List<ValidationNotice> generateNotices(List<GtfsLevel> levels,
-      List<GtfsPathway> pathways) {
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsLevel> levels, List<GtfsPathway> pathways) {
     NoticeContainer noticeContainer = new NoticeContainer();
-    new LevelPresenceValidator(GtfsLevelTableContainer.forEntities(levels, noticeContainer),
-        GtfsPathwayTableContainer.forEntities(pathways, noticeContainer)).validate(noticeContainer);
+    new LevelPresenceValidator(
+            GtfsLevelTableContainer.forEntities(levels, noticeContainer),
+            GtfsPathwayTableContainer.forEntities(pathways, noticeContainer))
+        .validate(noticeContainer);
     return noticeContainer.getValidationNotices();
   }
 
   private static GtfsLevel createLevel(String levelId, long csvRowNumber) {
-    return new GtfsLevel.Builder()
-        .setLevelId(levelId)
-        .setCsvRowNumber(csvRowNumber)
-        .build();
+    return new GtfsLevel.Builder().setLevelId(levelId).setCsvRowNumber(csvRowNumber).build();
   }
 
-  private static GtfsPathway createPathway(String pathwayId, long csvRowNumber,
-      GtfsPathwayMode pathwayMode) {
+  private static GtfsPathway createPathway(
+      String pathwayId, long csvRowNumber, GtfsPathwayMode pathwayMode) {
     return new GtfsPathway.Builder()
         .setPathwayId(pathwayId)
         .setCsvRowNumber(csvRowNumber)
@@ -63,32 +62,29 @@ public class LevelPresenceValidatorTest {
 
   @Test
   public void nonEmptyLevelWithPathwayModeFive_yieldsZeroNotice() {
-    assertThat(generateNotices(
-        ImmutableList.of(
-            createLevel("level id value", 44),
-            createLevel("other level id value", 55),
-            createLevel("some level id value", 66)
-        ),
-        ImmutableList.of(
-            createPathway("elevator id value", 77, GtfsPathwayMode.ELEVATOR),
-            createPathway("exit gate id value", 1, GtfsPathwayMode.EXIT_GATE),
-            createPathway("stairs id value", 189, GtfsPathwayMode.STAIRS)
-        )
-    )).isEmpty();
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createLevel("level id value", 44),
+                    createLevel("other level id value", 55),
+                    createLevel("some level id value", 66)),
+                ImmutableList.of(
+                    createPathway("elevator id value", 77, GtfsPathwayMode.ELEVATOR),
+                    createPathway("exit gate id value", 1, GtfsPathwayMode.EXIT_GATE),
+                    createPathway("stairs id value", 189, GtfsPathwayMode.STAIRS))))
+        .isEmpty();
   }
 
   @Test
   public void emptyLevelWithPathwayModeFive_yieldsNotice() {
-    assertThat(generateNotices(
-        ImmutableList.of(),
-        ImmutableList.of(
-            createPathway("elevator id value", 77, GtfsPathwayMode.ELEVATOR),
-            createPathway("other elevator id value", 1, GtfsPathwayMode.ELEVATOR),
-            createPathway("exit gate id value", 144, GtfsPathwayMode.EXIT_GATE),
-            createPathway("stairs id value", 277, GtfsPathwayMode.STAIRS)
-        )
-    )).containsExactly(
-        new MissingLevelNotice(77, "elevator id value")
-    );
+    assertThat(
+            generateNotices(
+                ImmutableList.of(),
+                ImmutableList.of(
+                    createPathway("elevator id value", 77, GtfsPathwayMode.ELEVATOR),
+                    createPathway("other elevator id value", 1, GtfsPathwayMode.ELEVATOR),
+                    createPathway("exit gate id value", 144, GtfsPathwayMode.EXIT_GATE),
+                    createPathway("stairs id value", 277, GtfsPathwayMode.STAIRS))))
+        .containsExactly(new MissingLevelNotice(77, "elevator id value"));
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidatorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2021 MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsLevel;
+import org.mobilitydata.gtfsvalidator.table.GtfsLevelTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayMode;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
+import org.mobilitydata.gtfsvalidator.validator.LevelPresenceValidator.MissingLevelNotice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+@RunWith(JUnit4.class)
+public class LevelPresenceValidatorTest {
+
+  private static List<ValidationNotice> generateNotices(List<GtfsLevel> levels,
+      List<GtfsPathway> pathways) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new LevelPresenceValidator(GtfsLevelTableContainer.forEntities(levels, noticeContainer),
+        GtfsPathwayTableContainer.forEntities(pathways, noticeContainer)).validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  private static GtfsLevel createLevel(String levelId, long csvRowNumber) {
+    return new GtfsLevel.Builder()
+        .setLevelId(levelId)
+        .setCsvRowNumber(csvRowNumber)
+        .build();
+  }
+
+  private static GtfsPathway createPathway(String pathwayId, long csvRowNumber,
+      GtfsPathwayMode pathwayMode) {
+    return new GtfsPathway.Builder()
+        .setPathwayId(pathwayId)
+        .setCsvRowNumber(csvRowNumber)
+        .setFromStopId("from stop id value")
+        .setToStopId("to stop id value")
+        .setPathwayMode(pathwayMode)
+        .build();
+  }
+
+  @Test
+  public void nonEmptyLevelWithPathwayModeFive_yieldsZeroNotice() {
+    assertThat(generateNotices(
+        ImmutableList.of(
+            createLevel("level id value", 44),
+            createLevel("other level id value", 55),
+            createLevel("some level id value", 66)
+        ),
+        ImmutableList.of(
+            createPathway("elevator id value", 77, GtfsPathwayMode.ELEVATOR),
+            createPathway("exit gate id value", 1, GtfsPathwayMode.EXIT_GATE),
+            createPathway("stairs id value", 189, GtfsPathwayMode.STAIRS)
+        )
+    )).isEmpty();
+  }
+
+  @Test
+  public void emptyLevelWithPathwayModeFive_yieldsNotice() {
+    assertThat(generateNotices(
+        ImmutableList.of(),
+        ImmutableList.of(
+            createPathway("elevator id value", 77, GtfsPathwayMode.ELEVATOR),
+            createPathway("other elevator id value", 1, GtfsPathwayMode.ELEVATOR),
+            createPathway("exit gate id value", 144, GtfsPathwayMode.EXIT_GATE),
+            createPathway("stairs id value", 277, GtfsPathwayMode.STAIRS)
+        )
+    )).containsExactly(
+        new MissingLevelNotice(77, "elevator id value")
+    );
+  }
+}


### PR DESCRIPTION
**Summary:**

This PR provides support to verify conditionnal requirements on `levels.txt`. 
- `levels.txt` must be provided and non-empty if a row from `pathways.txt` has `pathways.pathway_mode=5`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
