### PR TITLE
feat: Validate field presence and key integrity for translations.txt

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -108,6 +108,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`StationWithParentStationNotice`](#StationWithParentStationNotice)                                             | A station has `parent_station` field set.                                                                                                              |
 | [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) | Backwards time travel between stops in `stop_times.txt`                                                                                                |
 | [`StopTimeWithOnlyArrivalOrDepartureTimeNotice`](#StopTimeWithOnlyArrivalOrDepartureTimeNotice)                 | Missing `stop_times.arrival_time` or `stop_times.departure_time`.                                                                                      |
+| [`TranslationUnexpectedValueNotice`](#TranslationUnexpectedValueNotice)                                         | A field in a translations row has value but must be empty.                                                                                             |
 | [`WrongParentLocationTypeNotice`](#WrongParentLocationTypeNotice)                                               | Incorrect type of the parent location.                                                                                                                 |
 
 <a name="WARNINGS"/>
@@ -145,6 +146,8 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	| Stop too far from trip shape.                                                                                                                               	|
 | [`StopWithoutStopTimeNotice`](#StopWithoutStopTimeNotice)                             | A stop in `stops.txt` is not referenced by any `stop_times.stop_id`.                                                                                          |
 | [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                              	| Stop without value for `stops.zone_id`.                                                                                                                     	|
+| [`TranslationForeignKeyViolationNotice`](#TranslationForeignKeyViolationNotice)       | An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.                                                             |
+| [`TranslationUnknownTableNameNotice`](#TranslationUnknownTableNameNotice)             | A translation references an unknown or missing GTFS table.                                                                                                    |
 | [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	| An enum has an unexpected value.                                                                                                                            	|
 | [`UnusableTripNotice`](#UnusableTripNotice)                                       	| Trips must have more than one stop to be usable.                                                                                                            	|
 | [`UnusedShapeNotice`](#UnusedShapeNotice)                                         	| Shape is not used in GTFS file `trips.txt`.                                                                                                                 	|
@@ -540,6 +543,15 @@ Missing `stop_time.arrival_time` or `stop_time.departure_time`
 ##### References:
 * [stop_times.txt specification](http://gtfs.org/reference/static/#stop_timestxt)
 
+<a name="TranslationUnexpectedValueNotice"/>
+
+#### TranslationUnexpectedValueNotice
+
+A field in a translations row has value but must be empty.
+
+##### References:
+* [translations.txt specification](http://gtfs.org/reference/static/#translationstxt)
+
 <a name="WrongParentLocationTypeNotice"/>
 
 #### WrongParentLocationTypeNotice
@@ -859,6 +871,24 @@ Per GTFS specification, `stops.zone_id` should be provided if fare information i
 
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)
+
+<a name="TranslationForeignKeyViolationNotice"/>
+
+#### TranslationForeignKeyViolationNotice
+
+An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.
+
+##### References:
+* [translations.txt specification](http://gtfs.org/reference/static/#translationstxt)
+
+<a name="TranslationUnknownTableNameNotice"/>
+
+#### TranslationUnknownTableNameNotice
+
+A translation references an unknown or missing GTFS table.
+
+##### References:
+* [translations.txt specification](http://gtfs.org/reference/static/#translationstxt)
 
 <a name="UnexpectedEnumValueNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -44,6 +44,7 @@
 | `station_with_parent_station`                          	| [`StationWithParentStationNotice`](#StationWithParentStationNotice)                                             	|
 | `stop_time_wit_arrival_before_previous_departure_time` 	| [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) 	|
 | `stop_time_with_only_arrival_or_departure_time`        	| [`StopTimeWithOnlyArrivalOrDepartureTimeNotice`](#StopTimeWithOnlyArrivalOrDepartureTimeNotice)                 	|
+| `translation_unexpected_value`                           	| [`TranslationUnexpectedValueNotice`](#TranslationUnexpectedValueNotice)                                               	|
 | `wrong_parent_location_type`                           	| [`WrongParentLocationTypeNotice`](#WrongParentLocationTypeNotice)                                               	|
 
 #### [`BlockTripsWithOverlappingStopTimesNotice`](/RULES.md#BlockTripsWithOverlappingStopTimesNotice)
@@ -575,6 +576,18 @@
 ##### Affected files
 * [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
 
+#### [`TranslationUnexpectedValueNotice`](/RULES.md#TranslationUnexpectedValueNotice)
+##### Fields description
+
+| Field name        | Description                                  	            | Type    	|
+|-------------------|-----------------------------------------------------------|---------	|
+| `csvRowNumber`    | The row number of the faulty record.         	            | Long    	|
+| `fieldName`       | The name of the field that was expected to be empty.      | String  	|
+| `fieldValue`      | Actual value of the field that was expected to be empty.  | String 	|
+
+##### Affected files
+* [`translations.txt`](http://gtfs.org/reference/static#translationstxt)
+
 #### [`WrongParentLocationTypeNotice`](/RULES.md#WrongParentLocationTypeNotice)
 ##### Fields description
 
@@ -627,6 +640,8 @@
 | `stop_too_far_from_trip_shape`            	| [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	|
 | `stop_without_zone_id`                     	| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                 	            |
 | `too_fast_travel`                          	| [`TooFastTravelNotice`](#TooFastTravelNotice)                                     	|
+| `translation_foreign_key_violation`           | [`TranslationForeignKeyViolationNotice`](#TranslationForeignKeyViolationNotice)	    |
+| `translation_unknown_table_name`              | [`TranslationUnknownTableNameNotice`](#TranslationUnknownTableNameNotice)	            |
 | `unexpected_enum_value`                    	| [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	|
 | `unusable_trip`                            	| [`UnusableTripNotice`](#UnusableTripNotice)                                       	|
 | `unused_shape`                             	| [`UnusedShapeNotice`](#UnusedShapeNotice)                                         	|
@@ -1013,6 +1028,30 @@
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 * [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
 * [`trips.txt`](http://gtfs.org/reference/static#tripstxt)
+
+#### [`TranslationForeignKeyViolationNotice`](/RULES.md#TranslationForeignKeyViolationNotice)
+##### Fields description
+
+| Field name       | Description                            | Type    	|
+|------------------|----------------------------------------|-------	|
+| `csvRowNumber`   | The row number of the faulty record.   | Long    	|
+| `tableName`      | `table_name` of the faulty record.     | String  	|
+| `recordId`       | `record_id` of the faulty record.      | String  	|
+| `recordSubId`    | `record_sub_id` of the faulty record.  | String  	|
+
+##### Affected files
+* [`translations.txt`](http://gtfs.org/reference/static#translationstxt)
+
+#### [`TranslationUnknownTableNameNotice`](/RULES.md#TranslationUnknownTableNameNotice)
+##### Fields description
+
+| Field name       | Description                            | Type    	|
+|------------------|----------------------------------------|-------	|
+| `csvRowNumber`   | The row number of the faulty record.   | Long    	|
+| `tableName`      | `table_name` of the faulty record.     | String  	|
+
+##### Affected files
+* [`translations.txt`](http://gtfs.org/reference/static#translationstxt)
 
 #### [UnexpectedEnumValueNotice](/RULES.md#UnexpectedEnumValueNotice)
 ##### Fields description

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTranslation;
+import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableLoader;
+
+/**
+ * Validates that translations are provided in accordance with GTFS Specification.
+ *
+ * <p>Checks that fields and values provided in translations are correct and checks that a
+ * translation references existing entity.
+ *
+ * <p>This validator gracefully handles legacy Google translations format. If {@code
+ * translations.txt} does not follow the new format, then no validations are performed.
+ */
+@GtfsValidator
+public class TranslationFieldAndReferenceValidator extends FileValidator {
+  private final GtfsTranslationTableContainer translationTable;
+  private final GtfsFeedContainer feedContainer;
+
+  @Inject
+  TranslationFieldAndReferenceValidator(
+      GtfsTranslationTableContainer translationTable, GtfsFeedContainer feedContainer) {
+    this.translationTable = translationTable;
+    this.feedContainer = feedContainer;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    // The legacy Google translation format does not define `translations.table_name` field.
+    if (!translationTable.getHeader().hasColumn(GtfsTranslationTableLoader.TABLE_NAME_FIELD_NAME)) {
+      // Skip validation if legacy Google translation format is detected.
+      return;
+    }
+    // If GtfsTranslationSchema.java is patched to enable the legacy Google format, then
+    // fields field_name, language and table_name become optional. Here we have detected that
+    // table_name header is present, so this is the standard GTFS translation format. Check that the
+    // standard required fields are present.
+    if (!validateStandardRequiredFields(noticeContainer)) {
+      return;
+    }
+    for (GtfsTranslation translation : translationTable.getEntities()) {
+      validateTranslation(translation, noticeContainer);
+    }
+  }
+
+  /**
+   * Emits errors for missing required fields field_name, language and table_name.
+   *
+   * @return true if all required fields are set for all entities, false otherwise
+   */
+  private boolean validateStandardRequiredFields(NoticeContainer noticeContainer) {
+    boolean isValid = true;
+    for (GtfsTranslation translation : translationTable.getEntities()) {
+      if (!translation.hasFieldName()) {
+        noticeContainer.addValidationNotice(
+            new MissingRequiredFieldNotice(
+                GtfsTranslationTableLoader.FILENAME,
+                translation.csvRowNumber(),
+                GtfsTranslationTableLoader.FIELD_NAME_FIELD_NAME));
+        isValid = false;
+      }
+      if (!translation.hasLanguage()) {
+        noticeContainer.addValidationNotice(
+            new MissingRequiredFieldNotice(
+                GtfsTranslationTableLoader.FILENAME,
+                translation.csvRowNumber(),
+                GtfsTranslationTableLoader.LANGUAGE_FIELD_NAME));
+        isValid = false;
+      }
+      if (!translation.hasTableName()) {
+        noticeContainer.addValidationNotice(
+            new MissingRequiredFieldNotice(
+                GtfsTranslationTableLoader.FILENAME,
+                translation.csvRowNumber(),
+                GtfsTranslationTableLoader.TABLE_NAME_FIELD_NAME));
+        isValid = false;
+      }
+    }
+    return isValid;
+  }
+
+  /** Validates a single row in {@code translations.txt}. */
+  private void validateTranslation(GtfsTranslation translation, NoticeContainer noticeContainer) {
+    if (translation.hasFieldValue()) {
+      if (translation.hasRecordId()) {
+        noticeContainer.addValidationNotice(
+            new TranslationUnexpectedValueNotice(
+                translation,
+                GtfsTranslationTableLoader.RECORD_ID_FIELD_NAME,
+                translation.recordId()));
+      }
+      if (translation.hasRecordSubId()) {
+        noticeContainer.addValidationNotice(
+            new TranslationUnexpectedValueNotice(
+                translation,
+                GtfsTranslationTableLoader.RECORD_SUB_ID_FIELD_NAME,
+                translation.recordSubId()));
+      }
+    }
+    Optional<GtfsTableContainer<?>> parentTable =
+        feedContainer.getTableForFilename(translation.tableName() + ".txt");
+    if (!parentTable.isPresent() || parentTable.get().isMissingFile()) {
+      noticeContainer.addValidationNotice(new TranslationUnknownTableNameNotice(translation));
+    } else if (!translation.hasFieldValue()) {
+      validateReferenceIntegrity(translation, parentTable.get(), noticeContainer);
+    }
+  }
+
+  /**
+   * Checks that {@code record_id, record_sub_id} fields are properly assigned and reference an
+   * existing row in the parent table.
+   */
+  private void validateReferenceIntegrity(
+      GtfsTranslation translation,
+      GtfsTableContainer<?> parentTable,
+      NoticeContainer noticeContainer) {
+    ImmutableList<String> keyColumnNames = parentTable.getKeyColumnNames();
+    if (isMissingOrUnexpectedField(
+            translation,
+            translation.hasRecordId(),
+            keyColumnNames.size() >= 1,
+            GtfsTranslationTableLoader.RECORD_ID_FIELD_NAME,
+            translation.recordId(),
+            noticeContainer)
+        || isMissingOrUnexpectedField(
+            translation,
+            translation.hasRecordSubId(),
+            keyColumnNames.size() >= 2,
+            GtfsTranslationTableLoader.RECORD_SUB_ID_FIELD_NAME,
+            translation.recordSubId(),
+            noticeContainer)) {
+      return;
+    }
+    if (!parentTable.byPrimaryKey(translation.recordId(), translation.recordSubId()).isPresent()) {
+      noticeContainer.addValidationNotice(new TranslationForeignKeyViolationNotice(translation));
+    }
+  }
+
+  /**
+   * Checks that a field is present (or missing) as expected and emits errors if not.
+   *
+   * @return whether the field is missing or unexpected
+   */
+  private static boolean isMissingOrUnexpectedField(
+      GtfsTranslation translation,
+      boolean actualPresence,
+      boolean expectedPresence,
+      String fieldName,
+      String fieldValue,
+      NoticeContainer noticeContainer) {
+    if (expectedPresence != actualPresence) {
+      if (actualPresence) {
+        noticeContainer.addValidationNotice(
+            new TranslationUnexpectedValueNotice(translation, fieldName, fieldValue));
+      } else {
+        noticeContainer.addValidationNotice(
+            new MissingRequiredFieldNotice(
+                GtfsTranslationTableLoader.FILENAME, translation.csvRowNumber(), fieldName));
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /** A translation references an unknown or missing GTFS table. */
+  static class TranslationUnknownTableNameNotice extends ValidationNotice {
+    private final long csvRowNumber;
+    private final String tableName;
+
+    TranslationUnknownTableNameNotice(GtfsTranslation translation) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = translation.csvRowNumber();
+      this.tableName = translation.tableName();
+    }
+  }
+
+  /** A field in a translations row has value but must be empty. */
+  static class TranslationUnexpectedValueNotice extends ValidationNotice {
+    private final long csvRowNumber;
+    private final String fieldName;
+    private final String fieldValue;
+
+    TranslationUnexpectedValueNotice(
+        GtfsTranslation translation, String fieldName, String fieldValue) {
+      super(SeverityLevel.ERROR);
+      this.csvRowNumber = translation.csvRowNumber();
+      this.fieldValue = fieldValue;
+      this.fieldName = fieldName;
+    }
+  }
+
+  /**
+   * An entity with the given {@code record_id, record_sub_id} cannot be found in the referenced
+   * table.
+   */
+  static class TranslationForeignKeyViolationNotice extends ValidationNotice {
+    private final long csvRowNumber;
+    private final String tableName;
+    private final String recordId;
+    private final String recordSubId;
+
+    TranslationForeignKeyViolationNotice(GtfsTranslation translation) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = translation.csvRowNumber();
+      this.tableName = translation.tableName();
+      this.recordId = translation.recordId();
+      this.recordSubId = translation.recordSubId();
+    }
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -189,18 +189,6 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
     return true;
   }
 
-  /** A translation references an unknown or missing GTFS table. */
-  static class TranslationUnknownTableNameNotice extends ValidationNotice {
-    private final long csvRowNumber;
-    private final String tableName;
-
-    TranslationUnknownTableNameNotice(GtfsTranslation translation) {
-      super(SeverityLevel.WARNING);
-      this.csvRowNumber = translation.csvRowNumber();
-      this.tableName = translation.tableName();
-    }
-  }
-
   /** A field in a translations row has value but must be empty. */
   static class TranslationUnexpectedValueNotice extends ValidationNotice {
     private final long csvRowNumber;
@@ -213,6 +201,18 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
       this.csvRowNumber = translation.csvRowNumber();
       this.fieldValue = fieldValue;
       this.fieldName = fieldName;
+    }
+  }
+
+  /** A translation references an unknown or missing GTFS table. */
+  static class TranslationUnknownTableNameNotice extends ValidationNotice {
+    private final long csvRowNumber;
+    private final String tableName;
+
+    TranslationUnknownTableNameNotice(GtfsTranslation translation) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = translation.csvRowNumber();
+      this.tableName = translation.tableName();
     }
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -175,18 +175,18 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
       String fieldName,
       String fieldValue,
       NoticeContainer noticeContainer) {
-    if (expectedPresence != actualPresence) {
-      if (actualPresence) {
-        noticeContainer.addValidationNotice(
-            new TranslationUnexpectedValueNotice(translation, fieldName, fieldValue));
-      } else {
-        noticeContainer.addValidationNotice(
-            new MissingRequiredFieldNotice(
-                GtfsTranslationTableLoader.FILENAME, translation.csvRowNumber(), fieldName));
-      }
-      return true;
+    if (expectedPresence == actualPresence) {
+      return false;
     }
-    return false;
+    if (actualPresence) {
+      noticeContainer.addValidationNotice(
+          new TranslationUnexpectedValueNotice(translation, fieldName, fieldValue));
+    } else {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice(
+              GtfsTranslationTableLoader.FILENAME, translation.csvRowNumber(), fieldName));
+    }
+    return true;
   }
 
   /** A translation references an unknown or missing GTFS table. */

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidatorTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.Locale;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
+import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfoTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTranslation;
+import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableContainer;
+import org.mobilitydata.gtfsvalidator.validator.TranslationFieldAndReferenceValidator.TranslationForeignKeyViolationNotice;
+import org.mobilitydata.gtfsvalidator.validator.TranslationFieldAndReferenceValidator.TranslationUnexpectedValueNotice;
+import org.mobilitydata.gtfsvalidator.validator.TranslationFieldAndReferenceValidator.TranslationUnknownTableNameNotice;
+
+@RunWith(JUnit4.class)
+public final class TranslationFieldAndReferenceValidatorTest {
+  private static final GtfsAgency AGENCY = new GtfsAgency.Builder().setAgencyId("agency0").build();
+  private static final GtfsStopTime STOP_TIME =
+      new GtfsStopTime.Builder().setTripId("trip0").setStopSequence(0).build();
+  private static final GtfsFeedInfo FEED_INFO =
+      new GtfsFeedInfo.Builder().setFeedLang(Locale.CANADA).build();
+
+  private static final String[] NEW_FORMAT_CSV_HEADERS =
+      new String[] {
+        "table_name",
+        "field_name",
+        "language",
+        "translation",
+        "record_id",
+        "record_sub_id",
+        "field_value",
+      };
+
+  private static List<ValidationNotice> generateNotices(
+      CsvHeader translationHeader, List<GtfsTranslation> translations) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsTranslationTableContainer translationTable =
+        GtfsTranslationTableContainer.forHeaderAndEntities(
+            translationHeader, translations, noticeContainer);
+    new TranslationFieldAndReferenceValidator(
+            translationTable,
+            new GtfsFeedContainer(
+                ImmutableList.of(
+                    translationTable,
+                    GtfsAgencyTableContainer.forEntities(ImmutableList.of(AGENCY), noticeContainer),
+                    GtfsStopTimeTableContainer.forEntities(
+                        ImmutableList.of(STOP_TIME), noticeContainer),
+                    GtfsFeedInfoTableContainer.forEntities(
+                        ImmutableList.of(FEED_INFO), noticeContainer))))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  @Test
+  public void legacyFormat_yieldsNoNotice() {
+    GtfsTranslation translation = new GtfsTranslation.Builder().setCsvRowNumber(2).build();
+    assertThat(generateNotices(CsvHeader.EMPTY, ImmutableList.of(translation))).isEmpty();
+  }
+
+  @Test
+  public void missingRequiredStandardFields_yieldsNotice() {
+    GtfsTranslation translation = new GtfsTranslation.Builder().setCsvRowNumber(2).build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(
+            new MissingRequiredFieldNotice("translations.txt", 2, "table_name"),
+            new MissingRequiredFieldNotice("translations.txt", 2, "field_name"),
+            new MissingRequiredFieldNotice("translations.txt", 2, "language"));
+  }
+
+  @Test
+  public void wrongTableName_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("wrong")
+            .setFieldName("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(new TranslationUnknownTableNameNotice(translation));
+  }
+
+  @Test
+  public void fieldValueDefined_yieldsNoNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("agency")
+            .setFieldName("any")
+            .setFieldValue("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .isEmpty();
+  }
+
+  @Test
+  public void recordIdAndFieldValueDefined_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("agency")
+            .setFieldName("any")
+            .setRecordId("id")
+            .setFieldValue("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(new TranslationUnexpectedValueNotice(translation, "record_id", "id"));
+  }
+
+  @Test
+  public void recordSubIdAndFieldValueDefined_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("agency")
+            .setFieldName("any")
+            .setRecordSubId("sub_id")
+            .setFieldValue("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(
+            new TranslationUnexpectedValueNotice(translation, "record_sub_id", "sub_id"));
+  }
+
+  @Test
+  public void noRecordIdForStopTable_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("agency")
+            .setFieldName("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(new MissingRequiredFieldNotice("translations.txt", 2, "record_id"));
+  }
+
+  @Test
+  public void wrongRecordIdForStopTable_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("agency")
+            .setFieldName("any")
+            .setRecordId("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(new TranslationForeignKeyViolationNotice(translation));
+  }
+
+  @Test
+  public void feedInfoTranslation_yieldsNoNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("feed_info")
+            .setFieldName("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .isEmpty();
+  }
+
+  @Test
+  public void unexpectedRecordIdForFeedInfo_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("feed_info")
+            .setFieldName("any")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .setRecordId("feed-id")
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(new TranslationUnexpectedValueNotice(translation, "record_id", "feed-id"));
+  }
+
+  @Test
+  public void agencyTranslation_yieldsNoNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("agency")
+            .setFieldName("any")
+            .setRecordId("agency0")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .isEmpty();
+  }
+
+  @Test
+  public void stopTimeTranslation_yieldsNoNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("stop_times")
+            .setFieldName("any")
+            .setRecordId("trip0")
+            .setRecordSubId("0")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .isEmpty();
+  }
+
+  @Test
+  public void unparsableIntegerForStopTime_yieldsNotice() {
+    GtfsTranslation translation =
+        new GtfsTranslation.Builder()
+            .setCsvRowNumber(2)
+            .setTableName("stop_times")
+            .setFieldName("any")
+            .setRecordId("trip0")
+            .setRecordSubId("not-an-int")
+            .setLanguage(Locale.forLanguageTag("en"))
+            .build();
+    assertThat(
+            generateNotices(new CsvHeader(NEW_FORMAT_CSV_HEADERS), ImmutableList.of(translation)))
+        .containsExactly(new TranslationForeignKeyViolationNotice(translation));
+  }
+}


### PR DESCRIPTION
Checks that fields and values provided in translations are correct and checks that a
translation references existing entity.

This validator gracefully handles legacy Google translations format. If translations.txt
does not follow the new format, then no validations are performed.