### PR TITLE
chore: upgrade notice severity

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -76,6 +76,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)                                                             | Duplicated column in CSV.                                                                                                                              |
 | [`DuplicateFareRuleZoneIdFieldsNotice`](#DuplicateFareRuleZoneIdFieldsNotice)                                   | Duplicate rows from `fare_rules.txt` based on `fare_rules.route_id`, `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id`. |
 | [`DuplicateKeyNotice`](#DuplicateKeyNotice)                                                                     | Duplicated entity.                                                                                                                                     |
+| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                 	| A column name is empty.                                                                                                                                     	|
 | [`EmptyFileNotice`](#EmptyFileNotice)                                                                           | A CSV file is empty.                                                                                                                                   |
 | [`ForeignKeyViolationNotice`](#ForeignKeyViolationNotice)                                                       | Wrong foreign key.                                                                                                                                     |
 | [`InconsistentAgencyTimezoneNotice`](#InconsistentAgencyTimezoneNotice)                                         | Inconsistent Timezone among agencies.                                                                                                                  |
@@ -93,10 +94,12 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`InvalidUrlNotice`](#InvalidUrlNotice)                                                                         | A field contains a malformed URL.                                                                                                                      |
 | [`LocationTypeStationForStopOnPathwayNotice`](#LocationTypeStationForStopOnPathwayNotice)                       | A stop used in `pathways.txt` must not have `location_type=1`.                                                                                          |
 | [`LocationWithoutParentStationNotice`](#LocationWithoutParentStationNotice)                                     | A location that must have `parent_station` field does not have it.                                                                                     |
+| [`LocationWithUnexpectedStopTimeNotice`](#LocationWithUnexpectedStopTimeNotice)       | A location in `stops.txt` that is not a stop is referenced by some `stop_times.stop_id`.                                                                      |
 | [`MissingCalendarAndCalendarDateFilesNotice`](#MissingCalendarAndCalendarDateFilesNotice)                       | Missing GTFS files `calendar.txt` and `calendar_dates.txt`.                                                                                            |
 | [`MissingRequiredColumnNotice`](#MissingRequiredColumnNotice)                                                   | A required column is missing in the input file.                                                                                                        |
 | [`MissingRequiredFieldNotice`](#MissingRequiredFieldNotice)                                                     | A required field is missing.                                                                                                                           |
 | [`MissingRequiredFileNotice`](#MissingRequiredFileNotice)                                                       | A required file is missing.                                                                                                                            |
+| [`MissingLevelNotice`](#MissingLevelNotice)       	                                | `levels.txt` is conditionally required.                                                                                                                	    |
 | [`MissingTripEdgeNotice`](#MissingTripEdgeNotice)                                                               | Missing trip edge `arrival_time` or `departure_time`.                                                                                                  |
 | [`NewLineInValueNotice`](#NewLineInValueNotice)                                                                 | New line or carriage return in a value in CSV file.                                                                                                    |
 | [`NumberOutOfRangeNotice`](#NumberOutOfRangeNotice)                                                             | Out of range value.                                                                                                                                    |
@@ -104,11 +107,14 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`PathwayToPlatformWithBoardingAreasNotice`](#PathwayToPlatformWithBoardingAreasNotice)                         | A pathway has an endpoint that is a platform which has boarding areas.                                                                                 |
 | [`PathwayToWrongLocationTypeNotice`](#PathwayToWrongLocationTypeNotice)                                             | A pathway has an endpoint that is a station.                                                                                                           |
 | [`RouteBothShortAndLongNameMissingNotice`](#RouteBothShortAndLongNameMissingNotice)                             | Missing route short name and long name.                                                                                                                |
+| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)       | Same name and description for stop.                                                                                                                      	    |
 | [`StartAndEndRangeEqualNotice`](#StartAndEndRangeEqualNotice)                                                   | Two date or time fields are equal.                                                                                                                     |
 | [`StartAndEndRangeOutOfOrderNotice`](#StartAndEndRangeOutOfOrderNotice)                                         | Two date or time fields are out of order.                                                                                                              |
 | [`StationWithParentStationNotice`](#StationWithParentStationNotice)                                             | A station has `parent_station` field set.                                                                                                              |
+| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	| `arrival_time` or `departure_time` not specified for timepoint.                                                                                             	|
 | [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) | Backwards time travel between stops in `stop_times.txt`                                                                                                |
 | [`StopTimeWithOnlyArrivalOrDepartureTimeNotice`](#StopTimeWithOnlyArrivalOrDepartureTimeNotice)                 | Missing `stop_times.arrival_time` or `stop_times.departure_time`.                                                                                      |
+| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                              	| Stop without value for `stops.zone_id`.                                                                                                                     	|
 | [`WrongParentLocationTypeNotice`](#WrongParentLocationTypeNotice)                                               | Incorrect type of the parent location.                                                                                                                 |
 
 <a name="WARNINGS"/>
@@ -119,7 +125,6 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 |-----------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------------------------------	|
 | [`AttributionWithoutRoleNotice`](#AttributionWithoutRoleNotice)                   	| Attribution with no role.                                                                                                                                   	|
 | [`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)                           	| Duplicate  `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name`  and `routes.route_short_name`. 	|
-| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                 	| A column name is empty.                                                                                                                                     	|
 | [`EmptyRowNotice`](#EmptyRowNotice)                                               	| A row in the input file has only spaces.                                                                                                                      |
 | [`FastTravelBetweenConsecutiveStopsNotice`](#FastTravelBetweenConsecutiveStopsNotice) | A transit vehicle moves too fast between two consecutive stops.                                                                            	                |
 | [`FastTravelBetweenFarStopsNotice`](#FastTravelBetweenFarStopsNotice)                 | A transit vehicle moves too fast between two far stops.                                                                            	                        |
@@ -127,9 +132,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`FeedInfoLangAndAgencyMismatchNotice`](#FeedInfoLangAndAgencyLangMismatchNotice) 	| Mismatching feed and agency language fields.                                                                                                                	|
 | [`InconsistentAgencyLangNotice`](#InconsistentAgencyLangNotice)                   	| Inconsistent language among agencies.                                                                                                                       	|
 | [`LeadingOrTrailingWhitespacesNotice`](#LeadingOrTrailingWhitespacesNotice)         | The value in CSV file has leading or trailing whitespaces.                                                                                                  	|
-| [`LocationWithUnexpectedStopTimeNotice`](#LocationWithUnexpectedStopTimeNotice)       | A location in `stops.txt` that is not a stop is referenced by some `stop_times.stop_id`.                                                                      |
 | [`MissingFeedInfoDateNotice`](#MissingFeedInfoDateNotice)                         	| `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided.                   	|
-| [`MissingLevelNotice`](#MissingLevelNotice)       	                                | `levels.txt` is conditionally required.                                                                                                                	    |
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	| More than one row in CSV.                                                                                                                                   	|
 | [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	| Non ascii or non printable char in  `id`.                                                                                                                   	|
 | [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	| A platform has no `parent_station` field set.                                                                                                               	|
@@ -137,14 +140,11 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	| Short and long name are equal for a route.                                                                                                                  	|
 | [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	| Short name of a route is too long (more than 12 characters).                                                                                                	|
 | [`SameNameAndDescriptionForRouteNotice`](#SameNameAndDescriptionForRouteNotice)     | Same name and description for route.                                                                                                                        	|
-| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)       | Same name and description for stop.                                                                                                                      	    |
 | [`SameRouteAndAgencyUrlNotice`](#SameRouteAndAgencyUrlNotice)                       | Same `routes.route_url` and `agency.agency_url`.                                                                                                  	        |
 | [`SameStopAndAgencyUrlNotice`](#SameStopAndAgencyUrlNotice)                         | Same `stops.stop_url` and `agency.agency_url`.                                                                                                  	            |
 | [`SameStopAndRouteUrlNotice`](#SameStopAndRouteUrlNotice)                          	| Same `stops.stop_url` and `routes.route_url`.                                                                                                  	            |
-| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	| `arrival_time` or `departure_time` not specified for timepoint.                                                                                             	|
 | [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	| Stop too far from trip shape.                                                                                                                               	|
 | [`StopWithoutStopTimeNotice`](#StopWithoutStopTimeNotice)                             | A stop in `stops.txt` is not referenced by any `stop_times.stop_id`.                                                                                          |
-| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                              	| Stop without value for `stops.zone_id`.                                                                                                                     	|
 | [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	| An enum has an unexpected value.                                                                                                                            	|
 | [`UnusableTripNotice`](#UnusableTripNotice)                                       	| Trips must have more than one stop to be usable.                                                                                                            	|
 | [`UnusedShapeNotice`](#UnusedShapeNotice)                                         	| Shape is not used in GTFS file `trips.txt`.                                                                                                                 	|
@@ -232,6 +232,15 @@ The values of the given key and rows are duplicates.
 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)
+
+<a name="EmptyColumnNameNotice"/>
+
+#### EmptyColumnNameNotice
+
+A column name has not been provided. Such columns are skipped by the validator.
+
+##### References:
+* [GTFS file requirements](http://gtfs.org/reference/static/#file-requirements)
 
 <a name="EmptyFileNotice"/>
 
@@ -388,6 +397,12 @@ A location that must have `parent_station` field does not have it. The following
 ##### References:
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
 
+<a name="LocationWithUnexpectedStopTimeNotice"/>
+
+#### LocationWithUnexpectedStopTimeNotice
+
+Referenced locations (using `stop_times.stop_id`) must be stops/platforms, i.e. their `stops.location_type` value must be 0 or empty.
+
 <a name="MissingCalendarAndCalendarDateFilesNotice"/>
 
 #### MissingCalendarAndCalendarDateFilesNotice
@@ -424,6 +439,15 @@ A required file is missing.
 
 ##### References:
 * [GTFS terms definition](https://gtfs.org/reference/static/#term-definitions)
+
+<a name="MissingLevelNotice"/>
+
+#### MissingLevelNotice
+
+GTFS file `levels.txt` is required for elevator (`pathway_mode=5`). Here, the values passed to `pathways.pathway_mode` are assumed to be correct.
+
+##### References:
+* [levels.txt specification](http://gtfs.org/reference/static/#levelstxt)
 
 <a name="MissingTripEdgeNotice"/>
 
@@ -495,6 +519,17 @@ Both short_name and long_name are missing for a route.
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 
+<a name="SameNameAndDescriptionForStopNotice"/>
+
+#### SameNameAndDescriptionForStopNotice
+
+The GTFS spec defines `stops.txt` [stop_description](https://gtfs.org/reference/static/#stopstxt) as:
+
+> Description of the location that provides useful, quality information. Do not simply duplicate the name of the location.
+
+##### References:
+[stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
+
 <a name="StartAndEndRangeEqualNotice"/>
 
 #### StartAndEndRangeEqualNotice
@@ -522,6 +557,15 @@ Field `parent_station` must be empty when `location_type` is 1.
 ##### References:
 [stop.txt](http://gtfs.org/reference/static/#stopstxt)
 
+<a name="StopTimeTimepointWithoutTimeNotice"/>
+
+### StopTimeTimepointWithoutTimesNotice
+
+Any record with `stop_times.timepoint` set to 1 should define a value for `stop_times.arrival_time` and `stop_times.departure_time` fields. 
+
+##### References:
+* [GTFS stop_times.txt specification](https://gtfs.org/reference/static#stoptimestxt)
+
 <a name="StopTimeWithArrivalBeforePreviousDepartureTimeNotice"/>
 
 #### StopTimeWithArrivalBeforePreviousDepartureTimeNotice
@@ -548,6 +592,15 @@ Missing `stop_time.arrival_time` or `stop_time.departure_time`
 
 ##### References:
 * [stop_times.txt specification](http://gtfs.org/reference/static/#stop_timestxt)
+
+<a name="StopWithoutZoneIdNotice"/>
+
+#### StopWithoutZoneIdNotice
+
+Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a stop or en entrance (i.e. `stops.location_type = 1 or 2`).
+
+##### References:
+* [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)
 
 <a name="WrongParentLocationTypeNotice"/>
 
@@ -588,14 +641,6 @@ Note that there may be valid cases where routes have the same short and long nam
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 * [routes.txt best practices](http://gtfs.org/best-practices/#routestxt)
-<a name="EmptyColumnNameNotice"/>
-
-#### EmptyColumnNameNotice
-
-A column name has not been provided. Such columns are skipped by the validator.
-
-##### References:
-* [GTFS file requirements](http://gtfs.org/reference/static/#file-requirements)
 
 <a name="EmptyRowNotice"/>
 
@@ -685,12 +730,6 @@ The value in CSV file has leading or trailing whitespaces.
 ##### References:
 * [GTFS file requirements](http://gtfs.org/reference/static/#file-requirements)
 
-<a name="LocationWithUnexpectedStopTimeNotice"/>
-
-#### LocationWithUnexpectedStopTimeNotice
-
-Referenced locations (using `stop_times.stop_id`) must be stops/platforms, i.e. their `stops.location_type` value must be 0 or empty.
-
 ##### References:
 * [stop_times.txt GTFS specification](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stoptimestxt)
 
@@ -702,15 +741,6 @@ Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one
 
 ##### References:
 * [feed_info.txt Best practices](http://gtfs.org/best-practices/#feed_infotxt)
-
-<a name="MissingLevelNotice"/>
-
-#### MissingLevelNotice
-
-GTFS file `levels.txt` is required for elevator (`pathway_mode=5`). Here, the values passed to `pathways.pathway_mode` are assumed to be correct.
-
-##### References:
-* [levels.txt specification](http://gtfs.org/reference/static/#levelstxt)
 
 <a name="MoreThanOneEntityNotice"/>
 
@@ -781,17 +811,6 @@ See the GTFS and GTFS Best Practices links below for more examples of how to pop
 [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 [routes.txt Best Practices](https://gtfs.org/best-practices/#routestxt)
 
-<a name="SameNameAndDescriptionForStopNotice"/>
-
-#### SameNameAndDescriptionForStopNotice
-
-The GTFS spec defines `stops.txt` [stop_description](https://gtfs.org/reference/static/#stopstxt) as:
-
-> Description of the location that provides useful, quality information. Do not simply duplicate the name of the location.
-
-##### References:
-[stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
-
 <a name="SameRouteAndAgencyUrlNotice"/>
 
 #### SameRouteAndAgencyUrlNotice
@@ -819,15 +838,6 @@ A stop should not have the same `stop.stop_url` as a record from `routes.txt`.
 ##### References:
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
 
-<a name="StopTimeTimepointWithoutTimeNotice"/>
-
-### StopTimeTimepointWithoutTimesNotice
-
-Any record with `stop_times.timepoint` set to 1 should define a value for `stop_times.arrival_time` and `stop_times.departure_time` fields. 
-
-##### References:
-* [GTFS stop_times.txt specification](https://gtfs.org/reference/static#stoptimestxt)
-
 <a name="StopTooFarFromTripShapeNotice"/>
 
 #### StopTooFarFromTripShapeNotice
@@ -843,15 +853,6 @@ Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100
 
 A stop in `stops.txt` is not referenced by any `stop_times.stop_id`, so it is not used by any trip.
 Such stops normally do not provide user value. This notice may indicate a typo in `stop_times.txt`.
-
-<a name="StopWithoutZoneIdNotice"/>
-
-#### StopWithoutZoneIdNotice
-
-Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a stop or en entrance (i.e. `stops.location_type = 1 or 2`).
-
-##### References:
-* [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)
 
 <a name="UnexpectedEnumValueNotice"/>
 

--- a/RULES.md
+++ b/RULES.md
@@ -403,6 +403,9 @@ A location that must have `parent_station` field does not have it. The following
 
 Referenced locations (using `stop_times.stop_id`) must be stops/platforms, i.e. their `stops.location_type` value must be 0 or empty.
 
+##### References:
+* [stop_times.txt specification](http://gtfs.org/reference/static/#stop_timestxt)
+
 <a name="MissingCalendarAndCalendarDateFilesNotice"/>
 
 #### MissingCalendarAndCalendarDateFilesNotice

--- a/RULES.md
+++ b/RULES.md
@@ -107,7 +107,6 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`PathwayToPlatformWithBoardingAreasNotice`](#PathwayToPlatformWithBoardingAreasNotice)                         | A pathway has an endpoint that is a platform which has boarding areas.                                                                                 |
 | [`PathwayToWrongLocationTypeNotice`](#PathwayToWrongLocationTypeNotice)                                             | A pathway has an endpoint that is a station.                                                                                                           |
 | [`RouteBothShortAndLongNameMissingNotice`](#RouteBothShortAndLongNameMissingNotice)                             | Missing route short name and long name.                                                                                                                |
-| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)       | Same name and description for stop.                                                                                                                      	    |
 | [`StartAndEndRangeEqualNotice`](#StartAndEndRangeEqualNotice)                                                   | Two date or time fields are equal.                                                                                                                     |
 | [`StartAndEndRangeOutOfOrderNotice`](#StartAndEndRangeOutOfOrderNotice)                                         | Two date or time fields are out of order.                                                                                                              |
 | [`StationWithParentStationNotice`](#StationWithParentStationNotice)                                             | A station has `parent_station` field set.                                                                                                              |
@@ -139,6 +138,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	| Insufficient route color contrast.                                                                                                                          	|
 | [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	| Short and long name are equal for a route.                                                                                                                  	|
 | [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	| Short name of a route is too long (more than 12 characters).                                                                                                	|
+| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)       | Same name and description for stop.                                                                                                                      	    |
 | [`SameNameAndDescriptionForRouteNotice`](#SameNameAndDescriptionForRouteNotice)     | Same name and description for route.                                                                                                                        	|
 | [`SameRouteAndAgencyUrlNotice`](#SameRouteAndAgencyUrlNotice)                       | Same `routes.route_url` and `agency.agency_url`.                                                                                                  	        |
 | [`SameStopAndAgencyUrlNotice`](#SameStopAndAgencyUrlNotice)                         | Same `stops.stop_url` and `agency.agency_url`.                                                                                                  	            |
@@ -522,17 +522,6 @@ Both short_name and long_name are missing for a route.
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 
-<a name="SameNameAndDescriptionForStopNotice"/>
-
-#### SameNameAndDescriptionForStopNotice
-
-The GTFS spec defines `stops.txt` [stop_description](https://gtfs.org/reference/static/#stopstxt) as:
-
-> Description of the location that provides useful, quality information. Do not simply duplicate the name of the location.
-
-##### References:
-[stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
-
 <a name="StartAndEndRangeEqualNotice"/>
 
 #### StartAndEndRangeEqualNotice
@@ -813,6 +802,17 @@ See the GTFS and GTFS Best Practices links below for more examples of how to pop
 ##### References:
 [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 [routes.txt Best Practices](https://gtfs.org/best-practices/#routestxt)
+
+<a name="SameNameAndDescriptionForStopNotice"/>
+
+#### SameNameAndDescriptionForStopNotice
+
+The GTFS spec defines `stops.txt` [stop_description](https://gtfs.org/reference/static/#stopstxt) as:
+
+> Description of the location that provides useful, quality information. Do not simply duplicate the name of the location.
+
+##### References:
+[stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
 
 <a name="SameRouteAndAgencyUrlNotice"/>
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
@@ -19,14 +19,14 @@ package org.mobilitydata.gtfsvalidator.notice;
 /**
  * A column name is empty. Such columns are skipped by the validator.
  *
- * <p>Severity: {@code SeverityLevel.WARNING}
+ * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class EmptyColumnNameNotice extends ValidationNotice {
   private final String filename;
   private final int index;
 
   public EmptyColumnNameNotice(String filename, int index) {
-    super(SeverityLevel.WARNING);
+    super(SeverityLevel.ERROR);
     this.filename = filename;
     this.index = index;
   }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidatorTest.java
@@ -123,6 +123,6 @@ public class TableHeaderValidatorTest {
     assertThat(container.getValidationNotices())
         .containsExactly(
             new EmptyColumnNameNotice("stops.txt", 2), new EmptyColumnNameNotice("stops.txt", 4));
-    assertThat(container.hasValidationErrors()).isFalse();
+    assertThat(container.hasValidationErrors()).isTrue();
   }
 }

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -14,6 +14,7 @@
 | `duplicated_column`                                    	| [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)                                                             	|
 | `duplicate_fare_rule_zone_id_fields`                   	| [`DuplicateFareRuleZoneIdFieldsNotice`](#DuplicateFareRuleZoneIdFieldsNotice)                                   	|
 | `duplicate_key`                                        	| [`DuplicateKeyNotice`](#DuplicateKeyNotice)                                                                     	|
+| `empty_column_name`                                   	| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                 	|
 | `empty_file`                                           	| [`EmptyFileNotice`](#EmptyFileNotice)                                                                           	|
 | `foreign_key_violation`                                	| [`ForeignKeyViolationNotice`](#ForeignKeyViolationNotice)                                                       	|
 | `inconsistent_agency_timezone`                         	| [`InconsistentAgencyTimezoneNotice`](#InconsistentAgencyTimezoneNotice)                                         	|
@@ -29,8 +30,12 @@
 | `invalid_time`                                         	| [`InvalidTimeNotice`](#InvalidTimeNotice)                                                                       	|
 | `invalid_timezone`                                     	| [`InvalidTimezoneNotice`](#InvalidTimezoneNotice)                                                               	|
 | `invalid_url`                                          	| [`InvalidUrlNotice`](#InvalidUrlNotice)                                                                         	|
+| `leading_or_trailing_whitespaces`                         | [`LeadingOrTrailingWhitespacesNotice`](#LeadingOrTrailingWhitespacesNotice)         |
+| `location_type_station_for_stop_on_pathway`               | [`LocationTypeStationForStopOnPathwayNotice`](#LocationTypeStationForStopOnPathwayNotice)|
 | `location_without_parent_station`                      	| [`LocationWithoutParentStationNotice`](#LocationWithoutParentStationNotice)                                     	|
+| `location_with_unexpected_stop_time`                      | [`LocationWithUnexpectedStopTimeNotice`](#LocationWithUnexpectedStopTimeNotice)	      |
 | `missing_calendar_and_calendar_date_files`             	| [`MissingCalendarAndCalendarDateFilesNotice`](#MissingCalendarAndCalendarDateFilesNotice)                       	|
+| `missing_level`                                       	| [`MissingLevelNotice`](#MissingLevelNotice)                                       	|
 | `missing_required_column`                              	| [`MissingRequiredColumnNotice`](#MissingRequiredColumnNotice)                                                   	|
 | `missing_required_field`                               	| [`MissingRequiredFieldNotice`](#MissingRequiredFieldNotice)                                                     	|
 | `missing_required_file`                                	| [`MissingRequiredFileNotice`](#MissingRequiredFileNotice)                                                       	|
@@ -39,11 +44,14 @@
 | `number_out_of_range`                                  	| [`NumberOutOfRangeNotice`](#NumberOutOfRangeNotice)                                                             	|
 | `overlapping_frequency`                                	| [`OverlappingFrequencyNotice`](#OverlappingFrequencyNotice)                                                     	|
 | `route_both_short_and_long_name_missing`               	| [`RouteBothShortAndLongNameMissingNotice`](#RouteBothShortAndLongNameMissingNotice)                             	|
+| `same_name_and_description_for_stop`       	            | [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)     	|
 | `start_and_end_range_equal`                            	| [`StartAndEndRangeEqualNotice`](#StartAndEndRangeEqualNotice)                                                   	|
 | `start_and_end_range_out_of_order`                     	| [`StartAndEndRangeOutOfOrderNotice`](#StartAndEndRangeOutOfOrderNotice)                                         	|
 | `station_with_parent_station`                          	| [`StationWithParentStationNotice`](#StationWithParentStationNotice)                                             	|
-| `stop_time_wit_arrival_before_previous_departure_time` 	| [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) 	|
+| `stop_time_timepoint_without_times`                   	| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	|
+| `stop_time_with_arrival_before_previous_departure_time` 	| [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) 	|
 | `stop_time_with_only_arrival_or_departure_time`        	| [`StopTimeWithOnlyArrivalOrDepartureTimeNotice`](#StopTimeWithOnlyArrivalOrDepartureTimeNotice)                 	|
+| `stop_without_zone_id`                                   	| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                 	            |
 | `wrong_parent_location_type`                           	| [`WrongParentLocationTypeNotice`](#WrongParentLocationTypeNotice)                                               	|
 
 #### [`BlockTripsWithOverlappingStopTimesNotice`](/RULES.md#BlockTripsWithOverlappingStopTimesNotice)
@@ -149,6 +157,17 @@
 | `fieldValue1`    	| Composite key's first value.       	| Object 	|
 | `fieldName2`     	| Composite key's second field name. 	| String 	|
 | `fieldValue2`    	| Composite key's second value.      	| Object 	|
+
+##### Affected files
+[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
+
+#### [EmptyColumnNameNotice](/RULES.md#EmptyColumnNameNotice)
+##### Fields description
+
+| Field name 	| Description                    	  | Type    	|
+|------------	|---------------------------------	|---------	|
+| `filename`   	| The name of the faulty file.   	| String   	|
+| `index`      	| The index of the empty column. 	| Integer 	|
 
 ##### Affected files
 [All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
@@ -380,6 +399,32 @@
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 * [`translations.txt`](http://gtfs.org/reference/static#translationstxt)
 
+#### [LeadingOrTrailingWhitespacesNotice](/RULES.md#LeadingOrTrailingWhitespacesNotice)
+##### Fields description
+
+| Field name   	| Description                   	| Type   	|
+|--------------	|-------------------------------	|--------	|
+| `filename`   	| The row of the faulty record. 	| String 	|
+| `csvRowNumber`| The row of the faulty record. 	| Long   	|
+| `fieldName`  	| Faulty record's field name.   	| String 	|
+| `fieldValue` 	| Faulty value.                 	| String 	|
+
+##### Affected files
+[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
+
+#### [LocationTypeStationForStopOnPathwayNotice](/RULES.md#LocationTypeStationForStopOnPathwayNotice)
+##### Fields description
+
+| Field name   	| Description                   	| Type   	|
+|--------------	|-------------------------------	|--------	|
+| `pathwayId`   	| The id of the faulty row from `pathways.txt`. 	| String 	|
+| `pathwayCsvRowNumber`| The row of the faulty record. 	| Long   	|
+| `stopId`  	| The id of the faulty row from `stops.txt`.   	| String 	|
+| `stopCsvRowNumber` 	| Faulty value.                 	| String 	|
+
+##### Affected files
+[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
+
 #### [`LocationWithoutParentStationNotice`](/RULES.md#LocationWithoutParentStationNotice)
 ##### Fields description
 
@@ -393,6 +438,20 @@
 ##### Affected files
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
+#### [LocationWithUnexpectedStopTimeNotice](/RULES.md#LocationWithUnexpectedStopTimeNotice)
+##### Fields description
+
+| Field name             	| Description                                                	| Type   	|
+|------------------------	|------------------------------------------------------------	|--------	|
+| `csvRowNumber`         	| The row number of the faulty record from `stops.txt`.      	| Long   	|
+| `stopId`               	| The id of the faulty record from `stops.txt`.              	| String 	|
+| `stopName`             	| The `stops.stop_name` of the faulty record.                	| String 	|
+| `stopTimeCsvRowNumber` 	| The row number of the faulty record from `stop_times.txt`. 	| Long   	|
+
+##### Affected files
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
+* [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
+
 #### [`MissingCalendarAndCalendarDateFilesNotice`](/RULES.md#MissingCalendarAndCalendarDateFilesNotice)
 ##### Fields description
 | Field name 	| Description 	| Type 	|
@@ -402,6 +461,17 @@
 ##### Affected files
 * [`calendar.txt`](http://gtfs.org/reference/static#calendartxt)
 * [`calendar_dates.txt`](http://gtfs.org/reference/static#calendar_datestxt)
+
+#### [MissingLevelNotice](/RULES.md#MissingLevelNotice)
+##### Fields description
+
+| Field name    	| Description                                                      	 | Type   	|
+|---------------	|------------------------------------------------------------------- |--------	|
+| `csvRowNumber`  | The row number of the faulty record. 	                             | Long   	|
+| `pathwayId` 	  | The id of the record from pathways.txt that refers to `levels.txt`.| String   |
+
+##### Affected files
+* [`levels.txt`](http://gtfs.org/reference/static#levelstxt)
 
 #### [`MissingRequiredColumnNotice`](/RULES.md#MissingRequiredColumnNotice)
 ##### Fields description
@@ -502,6 +572,18 @@
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
 
+#### [SameNameAndDescriptionForStopNotice](/RULES.md#SameNameAndDescriptionForStopNotice)
+##### Fields description
+
+| Field name     	| Description                             	| Type   	|
+|----------------	|-----------------------------------------	|--------	|
+| `csvRowNumber`  | The row number of the faulty record.      | Long 	  |
+| `stopId`        | The id of the faulty record.              | String  |
+| `routeDesc`    	| The faulty record's `stop_desc`.         	| String 	|
+
+##### Affected files
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
+
 #### [`StartAndEndRangeEqualNotice`](/RULES.md#StartAndEndRangeEqualNotice)
 ##### Fields description
 
@@ -548,6 +630,19 @@
 ##### Affected files
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
+#### [StopTimeTimepointWithoutTimesNotice](/RULES.md#StopTimeTimepointWithoutTimesNotice)
+##### Fields description
+
+| Field name     	  | Description                                	| Type   	|
+|-----------------	|--------------------------------------------	|--------	|
+| `csvRowNumber`   	| The row number of the faulty record.       	| Long   	|
+| `tripId`         	| The faulty record's id.                    	| String 	|
+| `stopSequence`   	| The faulty record's `stops.stop_sequence`. 	| String 	|
+| `specifiedField` 	| Either `departure_time` or `arrival_time`. 	| String 	|
+
+##### Affected files
+* [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
+
 #### [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](/RULES.md#StopTimeWithArrivalBeforePreviousDepartureTimeNotice)
 ##### Fields description
 
@@ -575,6 +670,18 @@
 ##### Affected files
 * [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
 
+#### [StopWithoutZoneIdNotice](/RULES.md#StopWithoutZoneIdNotice)
+##### Fields description
+
+| Field name               	| Description                                	| Type   	|
+|--------------------------	|--------------------------------------------	|--------	|
+| `stopId`                 	| The faulty record's id.                    	| String 	|
+| `csvRowNumber`        	  | The row number of the faulty record.       	| Long   	|
+
+##### Affected files
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
+* [`fare_rules.txt`](http://gtfs.org/reference/static#farerulestxt)
+
 #### [`WrongParentLocationTypeNotice`](/RULES.md#WrongParentLocationTypeNotice)
 ##### Fields description
 
@@ -601,17 +708,13 @@
 |--------------------------------------------	|-----------------------------------------------------------------------------------	|
 | `attribution_without_role`           	      | [`AttributionWithoutRoleNotice`](#AttributionWithoutRoleNotice)                   	|
 | `duplicate_route_name`                      | [`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)                           	|
-| `empty_column_name`                        	| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                 	|
 | `empty_row`                                	| [`EmptyRowNotice`](#EmptyRowNotice)                                               	|
 | `fast_travel_between_consecutive_stops`      	| [`FastTravelBetweenConsecutiveStopsNotice`](#FastTravelBetweenConsecutiveStopsNotice) |
 | `fast_travel_between_far_stops`               | [`FastTravelBetweenFarStopsNotice`](#FastTravelBetweenFarStopsNotice)                 |
 | `feed_expiration_date`                     	| [`FeedExpirationDateNotice`](#FeedExpirationDateNotice)                           	|
 | `feed_info_lang_and_agency_mismatch` 	      | [`FeedInfoLangAndAgencyMismatchNotice`](#FeedInfoLangAndAgencyLangMismatchNotice) 	|
 | `inconsistent_agency_lang`                 	| [`InconsistentAgencyLangNotice`](#InconsistentAgencyLangNotice)                   	|
-| `leading_or_trailing_whitespaces`           | [`LeadingOrTrailingWhitespacesNotice`](#LeadingOrTrailingWhitespacesNotice)         |
-| `location_type_station_for_stop_on_pathway`   | [`LocationTypeStationForStopOnPathwayNotice`](#LocationTypeStationForStopOnPathwayNotice)|
 | `missing_feed_info_date`                   	| [`MissingFeedInfoDateNotice`](#MissingFeedInfoDateNotice)                         	|
-| `missing_level`                              	| [`MissingLevelNotice`](#MissingLevelNotice)                                       	|
 | `more_than_one_entity`                     	| [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	|
 | `non_ascii_or_non_printable_char`          	| [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	|
 | `platform_without_parent_station`          	| [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	|
@@ -619,19 +722,15 @@
 | `route_short_and_long_name_equal`          	| [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	|
 | `route_short_name_too_long`                	| [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	|
 | `same_name_and_description_for_route`       | [`SameNameAndDescriptionForRouteNotice`](#SameNameAndDescriptionForRouteNotice)     |
-| `same_name_and_description_for_stop`       	| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)     	|
 | `same_route_and_agency_url`                	| [`SameRouteAndAgencyUrlNotice`](#SameRouteAndAgencyUrlNotice)                       |
 | `same_stop_and_agency_url`                 	| [`SameStopAndAgencyUrlNotice`](#SameStopAndAgencyUrlNotice)                         |
 | `same_stop_and_route_url`                  	| [`SameStopAndRouteUrlNotice`](#SameStopAndRouteUrlNotice)                           |
-| `stop_time_timepoint_without_times`        	| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	|
 | `stop_too_far_from_trip_shape`            	| [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	|
-| `stop_without_zone_id`                     	| [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                 	            |
 | `too_fast_travel`                          	| [`TooFastTravelNotice`](#TooFastTravelNotice)                                     	|
 | `unexpected_enum_value`                    	| [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	|
 | `unusable_trip`                            	| [`UnusableTripNotice`](#UnusableTripNotice)                                       	|
 | `unused_shape`                             	| [`UnusedShapeNotice`](#UnusedShapeNotice)                                         	|
 | `unused_trip`                              	| [`UnusedTripNotice`](#UnusedTripNotice)                                           	|
-| `wrong_stop_time_stop_location_type`        | [`WrongStopTimeStopLocationTypeNotice`](#WrongStopTimeStopLocationTypeNotice)	      |
 
 #### [AttributionWithoutRoleNotice](/RULES.md#AttributionWithoutRoleNotice)
 ##### Fields description
@@ -660,17 +759,6 @@
 
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
-
-#### [EmptyColumnNameNotice](/RULES.md#EmptyColumnNameNotice)
-##### Fields description
-
-| Field name 	| Description                    	  | Type    	|
-|------------	|---------------------------------	|---------	|
-| `filename`   	| The name of the faulty file.   	| String   	|
-| `index`      	| The index of the empty column. 	| Integer 	|
-
-##### Affected files
-[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
 
 #### [EmptyRowNotice](/RULES.md#EmptyRowNotice)
 ##### Fields description
@@ -723,32 +811,6 @@
 ##### Affected files
 * [`agency.txt`](http://gtfs.org/reference/static#agencytxt)
 
-#### [LeadingOrTrailingWhitespacesNotice](/RULES.md#LeadingOrTrailingWhitespacesNotice)
-##### Fields description
-
-| Field name   	| Description                   	| Type   	|
-|--------------	|-------------------------------	|--------	|
-| `filename`   	| The row of the faulty record. 	| String 	|
-| `csvRowNumber`| The row of the faulty record. 	| Long   	|
-| `fieldName`  	| Faulty record's field name.   	| String 	|
-| `fieldValue` 	| Faulty value.                 	| String 	|
-
-##### Affected files
-[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
-
-#### [LocationTypeStationForStopOnPathwayNotice](/RULES.md#LocationTypeStationForStopOnPathwayNotice)
-##### Fields description
-
-| Field name   	| Description                   	| Type   	|
-|--------------	|-------------------------------	|--------	|
-| `pathwayId`   	| The id of the faulty row from `pathways.txt`. 	| String 	|
-| `pathwayCsvRowNumber`| The row of the faulty record. 	| Long   	|
-| `stopId`  	| The id of the faulty row from `stops.txt`.   	| String 	|
-| `stopCsvRowNumber` 	| Faulty value.                 	| String 	|
-
-##### Affected files
-[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
-
 #### [MissingFeedInfoDateNotice](/RULES.md#MissingFeedInfoDateNotice)
 ##### Fields description
 
@@ -759,17 +821,6 @@
 
 ##### Affected files
 * [`feed_info.txt`](http://gtfs.org/reference/static#feed_infotxt)
-
-#### [MissingLevelNotice](/RULES.md#MissingLevelNotice)
-##### Fields description
-
-| Field name    	| Description                                                      	 | Type   	|
-|---------------	|------------------------------------------------------------------- |--------	|
-| `csvRowNumber`  | The row number of the faulty record. 	                             | Long   	|
-| `pathwayId` 	  | The id of the record from pathways.txt that refers to `levels.txt`.| String   |
-
-##### Affected files
-* [`levels.txt`](http://gtfs.org/reference/static#levelstxt)
 
 #### [MoreThanOneEntityNotice](/RULES.md#MoreThanOneEntityNotice)
 ##### Fields description
@@ -860,18 +911,6 @@
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
 
-#### [SameNameAndDescriptionForStopNotice](/RULES.md#SameNameAndDescriptionForStopNotice)
-##### Fields description
-
-| Field name     	| Description                             	| Type   	|
-|----------------	|-----------------------------------------	|--------	|
-| `csvRowNumber`  | The row number of the faulty record.      | Long 	  |
-| `stopId`        | The id of the faulty record.              | String  |
-| `routeDesc`    	| The faulty record's `stop_desc`.         	| String 	|
-
-##### Affected files
-* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
-
 #### [SameRouteAndAgencyUrlNotice](/RULES.md#SameRouteAndAgencyUrlNotice)
 ##### Fields description
 
@@ -916,19 +955,6 @@
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
-#### [StopTimeTimepointWithoutTimesNotice](/RULES.md#StopTimeTimepointWithoutTimesNotice)
-##### Fields description
-
-| Field name     	  | Description                                	| Type   	|
-|-----------------	|--------------------------------------------	|--------	|
-| `csvRowNumber`   	| The row number of the faulty record.       	| Long   	|
-| `tripId`         	| The faulty record's id.                    	| String 	|
-| `stopSequence`   	| The faulty record's `stops.stop_sequence`. 	| String 	|
-| `specifiedField` 	| Either `departure_time` or `arrival_time`. 	| String 	|
-
-##### Affected files
-* [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
-
 #### [StopTooFarFromTripShapeNotice](/RULES.md#StopTooFarFromTripShapeNotice)
 ##### Fields description
 
@@ -943,18 +969,6 @@
 ##### Affected files
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 * [`trips.txt`](http://gtfs.org/reference/static#tripstxt)
-
-#### [StopWithoutZoneIdNotice](/RULES.md#StopWithoutZoneIdNotice)
-##### Fields description
-
-| Field name               	| Description                                	| Type   	|
-|--------------------------	|--------------------------------------------	|--------	|
-| `stopId`                 	| The faulty record's id.                    	| String 	|
-| `csvRowNumber`        	  | The row number of the faulty record.       	| Long   	|
-
-##### Affected files
-* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
-* [`fare_rules.txt`](http://gtfs.org/reference/static#farerulestxt)
 
 #### [FastTravelBetweenConsecutiveStopsNotice](/RULES.md#FastTravelBetweenConsecutiveStopsNotice)
 ##### Fields description
@@ -1069,21 +1083,6 @@
 
 ##### Affected files
 * [`trips.txt`](http://gtfs.org/reference/static#tripstxt)
-* [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
-
-#### [WrongStopTimeStopLocationTypeNotice](/RULES.md#WrongStopTimeStopLocationTypeNotice)
-##### Fields description
-
-| Field name     	| Description                                            	| Type   	|
-|----------------	|--------------------------------------------------------	|--------	|
-| `csvRowNumber` 	| The row number of the faulty record.                   	| Long   	|
-| `tripId`       	| `stop_times.trip_id` value for the faulty record.      	| String 	|
-| `stopSequence` 	| The faulty record's `stops.stop_sequence`.             	| String 	|
-| `stopId`       	| `stop_times.stop_id` value for the faulty record.      	| String 	|
-| `locationType` 	| The `stops.location_type` the faulty record refers to. 	| String 	|
-
-##### Affected files
-* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 * [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
 
 ### Info

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -44,7 +44,6 @@
 | `number_out_of_range`                                  	| [`NumberOutOfRangeNotice`](#NumberOutOfRangeNotice)                                                             	|
 | `overlapping_frequency`                                	| [`OverlappingFrequencyNotice`](#OverlappingFrequencyNotice)                                                     	|
 | `route_both_short_and_long_name_missing`               	| [`RouteBothShortAndLongNameMissingNotice`](#RouteBothShortAndLongNameMissingNotice)                             	|
-| `same_name_and_description_for_stop`       	            | [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)     	|
 | `start_and_end_range_equal`                            	| [`StartAndEndRangeEqualNotice`](#StartAndEndRangeEqualNotice)                                                   	|
 | `start_and_end_range_out_of_order`                     	| [`StartAndEndRangeOutOfOrderNotice`](#StartAndEndRangeOutOfOrderNotice)                                         	|
 | `station_with_parent_station`                          	| [`StationWithParentStationNotice`](#StationWithParentStationNotice)                                             	|
@@ -572,18 +571,6 @@
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
 
-#### [SameNameAndDescriptionForStopNotice](/RULES.md#SameNameAndDescriptionForStopNotice)
-##### Fields description
-
-| Field name     	| Description                             	| Type   	|
-|----------------	|-----------------------------------------	|--------	|
-| `csvRowNumber`  | The row number of the faulty record.      | Long 	  |
-| `stopId`        | The id of the faulty record.              | String  |
-| `routeDesc`    	| The faulty record's `stop_desc`.         	| String 	|
-
-##### Affected files
-* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
-
 #### [`StartAndEndRangeEqualNotice`](/RULES.md#StartAndEndRangeEqualNotice)
 ##### Fields description
 
@@ -722,6 +709,7 @@
 | `route_short_and_long_name_equal`          	| [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	|
 | `route_short_name_too_long`                	| [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	|
 | `same_name_and_description_for_route`       | [`SameNameAndDescriptionForRouteNotice`](#SameNameAndDescriptionForRouteNotice)     |
+| `same_name_and_description_for_stop`       	| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)     	|
 | `same_route_and_agency_url`                	| [`SameRouteAndAgencyUrlNotice`](#SameRouteAndAgencyUrlNotice)                       |
 | `same_stop_and_agency_url`                 	| [`SameStopAndAgencyUrlNotice`](#SameStopAndAgencyUrlNotice)                         |
 | `same_stop_and_route_url`                  	| [`SameStopAndRouteUrlNotice`](#SameStopAndRouteUrlNotice)                           |
@@ -910,6 +898,18 @@
 
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
+
+#### [SameNameAndDescriptionForStopNotice](/RULES.md#SameNameAndDescriptionForStopNotice)
+##### Fields description
+
+| Field name     	| Description                             	| Type   	|
+|----------------	|-----------------------------------------	|--------	|
+| `csvRowNumber`  | The row number of the faulty record.      | Long 	  |
+| `stopId`        | The id of the faulty record.              | String  |
+| `routeDesc`    	| The faulty record's `stop_desc`.         	| String 	|
+
+##### Affected files
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
 #### [SameRouteAndAgencyUrlNotice](/RULES.md#SameRouteAndAgencyUrlNotice)
 ##### Fields description

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -75,7 +75,7 @@ public class LevelPresenceValidator extends FileValidator {
     private final long csvRowNumber;
     private final String pathwayId;
 
-    MissingLevelNotice(long csvRowNumber, String pathwayId) {
+    MissingLevelFileNotice(long csvRowNumber, String pathwayId) {
       super(SeverityLevel.ERROR);
       this.csvRowNumber = csvRowNumber;
       this.pathwayId = pathwayId;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LevelPresenceValidator.java
@@ -68,7 +68,7 @@ public class LevelPresenceValidator extends FileValidator {
    * A row from pathways.txt has {@code pathways.pathway_mode=5} but levels.txt is empty or not
    * provided.
    *
-   * <p>Severity: {@code SeverityLevel.WARNING}. To be upgraded to {@code SeverityLevel.ERROR}.
+   * <p>Severity: {@code SeverityLevel.ERROR}.
    */
   static class MissingLevelNotice extends ValidationNotice {
 
@@ -76,7 +76,7 @@ public class LevelPresenceValidator extends FileValidator {
     private final String pathwayId;
 
     MissingLevelNotice(long csvRowNumber, String pathwayId) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.csvRowNumber = csvRowNumber;
       this.pathwayId = pathwayId;
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationHasStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationHasStopTimesValidator.java
@@ -80,6 +80,8 @@ public class LocationHasStopTimesValidator extends FileValidator {
 
   /**
    * Describes a location in {@code stops.txt} that is not a stop but has a stop time associated.
+   *
+   * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class LocationWithUnexpectedStopTimeNotice extends ValidationNotice {
     private final long csvRowNumber;
@@ -88,7 +90,7 @@ public class LocationHasStopTimesValidator extends FileValidator {
     private final long stopTimeCsvRowNumber;
 
     LocationWithUnexpectedStopTimeNotice(GtfsStop location, GtfsStopTime stopTime) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.csvRowNumber = location.csvRowNumber();
       this.stopId = location.stopId();
       this.stopName = location.stopName();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayStopsConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayStopsConsistencyValidator.java
@@ -82,7 +82,7 @@ public class PathwayStopsConsistencyValidator extends FileValidator {
   /**
    * A stop referenced by a row from {@code pathways.txt} has {@code location_type = 1} (station).
    *
-   * <p>Severity: {@code SeverityLevel.WARNING} to be upgraded to {@code SeverityLevel.ERROR}.
+   * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class LocationTypeStationForStopOnPathwayNotice extends ValidationNotice {
 
@@ -98,7 +98,7 @@ public class PathwayStopsConsistencyValidator extends FileValidator {
         String stopId,
         long stopCsvRowNumber,
         String fieldName) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.pathwayId = pathwayId;
       this.pathwayCsvRowNumber = pathwayCsvRowNumber;
       this.stopId = stopId;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -57,7 +57,7 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
    * <p>"Do not simply duplicate the name of the location."
    * (http://gtfs.org/reference/static#stopstxt)
    *
-   * <p>Severity: {@code SeverityLevel.ERROR}
+   * <p>Severity: {@code SeverityLevel.WARNING}
    */
   static class SameNameAndDescriptionForStopNotice extends ValidationNotice {
 
@@ -66,7 +66,7 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
     private final String routeDesc;
 
     SameNameAndDescriptionForStopNotice(long csvRowNumber, String stopId, String routeDesc) {
-      super(SeverityLevel.ERROR);
+      super(SeverityLevel.WARNING);
       this.stopId = stopId;
       this.csvRowNumber = csvRowNumber;
       this.routeDesc = routeDesc;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -57,7 +57,7 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
    * <p>"Do not simply duplicate the name of the location."
    * (http://gtfs.org/reference/static#stopstxt)
    *
-   * <p>Severity: {@code SeverityLevel.WARNING} - To be upgraded to {@code SeverityLevel.ERROR}
+   * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class SameNameAndDescriptionForStopNotice extends ValidationNotice {
 
@@ -66,7 +66,7 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
     private final String routeDesc;
 
     SameNameAndDescriptionForStopNotice(long csvRowNumber, String stopId, String routeDesc) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.stopId = stopId;
       this.csvRowNumber = csvRowNumber;
       this.routeDesc = routeDesc;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -71,14 +71,14 @@ public class StopZoneIdValidator extends FileValidator {
    * A {@code GtfsShape} should be referred to at least once in {@code GtfsTripTableContainer}
    * station).
    *
-   * <p>Severity: {@code SeverityLevel.WARNING} - Will be upgraded to {@code SeverityLevel.ERROR}
+   * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class StopWithoutZoneIdNotice extends ValidationNotice {
     private final String stopId;
     private final long csvRowNumber;
 
     StopWithoutZoneIdNotice(String stopId, long csvRowNumber) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.stopId = stopId;
       this.csvRowNumber = csvRowNumber;
     }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
@@ -67,7 +67,7 @@ public class TimepointTimeValidator extends SingleEntityValidator<GtfsStopTime> 
   /**
    * Timepoint without time
    *
-   * <p>Severity: {@code SeverityLevel.WARNING}
+   * <p>Severity: {@code SeverityLevel.ERROR}
    */
   static class StopTimeTimepointWithoutTimesNotice extends ValidationNotice {
     private final long csvRowNumber;
@@ -77,7 +77,7 @@ public class TimepointTimeValidator extends SingleEntityValidator<GtfsStopTime> 
 
     StopTimeTimepointWithoutTimesNotice(
         long csvRowNumber, String tripId, long stopSequence, String specifiedField) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.csvRowNumber = csvRowNumber;
       this.tripId = tripId;
       this.stopSequence = stopSequence;


### PR DESCRIPTION
**Summary:**

This PR provides support to make the validation rules closer to the GTFS specification

The following notices are upgraded from `WARNING` to `ERROR`: 
- `StopTimeTimepointWithoutTimeNotice`: 


> |  Field Name | Type | Presence | Description |
> |  ------ | ------ | ------ | ------ |
> |  `trip_id` | ID referencing `trips.trip_id` | **Required** | Identifies a trip.  |
> |  `arrival_time` | Time | **Conditionally Required** | Arrival time at the stop (defined by `stop_times.stop_id`) for a specific trip (defined by `stop_times.trip_id`). <br><br>If there are not separate times for arrival and departure at a stop, `arrival_time` and `departure_time` should be the same. <br><br>For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins.<br><br> If exact arrival and departure times (`timepoint=1` or empty) are not available, estimated or interpolated arrival and departure times (`timepoint=0`) should be provided.<br><br>Conditionally Required:<br>- **Required** for the first and last stop in a trip (defined by `stop_times.stop_sequence`). <br>- **Required** for `timepoint=1`.<br>- Optional otherwise.|
> |  `departure_time` | Time | **Conditionally Required** | Departure time from the stop (defined by `stop_times.stop_id`) for a specific trip (defined by `stop_times.trip_id`).<br><br>If there are not separate times for arrival and departure at a stop, `arrival_time` and `departure_time` should be the same. <br><br>For times occurring after midnight on the service day, enter the time as a value greater than 24:00:00 in HH:MM:SS local time for the day on which the trip schedule begins.<br><br> If exact arrival and departure times (`timepoint=1` or empty) are not available, estimated or interpolated arrival and departure times (`timepoint=0`) should be or
> 

_https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt_

- `EmptyColumnNameNotice`:  
> The first line of each file must contain field names. 

_https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#file-requirements_

- `LocationWithUnexpectedStopTimeNotice`: 
> Referenced locations must be stops/platforms, i.e. their stops.location_type value must be 0 or empty.
_https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stop_timestxt_

- `StopWithoutZoneIdNotice`: 
> Conditionally Required:
> - Required if providing fare information using fare_rules.txt
_https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt_

- `MissingLevelFileNotice`: 
> Describes levels in a station. Useful in conjunction with pathways.txt, and is required for navigating pathways with elevators (pathway_mode=5).

https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#levelstxt

- `SameNameAndDescriptionForStopNotice`:
~> Do not simply duplicate the name of the location.~

This stays as a warning. After RFC cleanup:
> Should not be a duplicate of `stop_name`.
_https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#stopstxt_

- `LocationTypeStationForStopOnPathwayNotice`: 
> Values for stop_id that identify stations (location_type=1) are forbidden.
_https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#pathwaystxt_


<br class="Apple-interchange-newline">
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
