### PR TITLE
fix: StopZoneIdValidator

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -848,7 +848,7 @@ Such stops normally do not provide user value. This notice may indicate a typo i
 
 #### StopWithoutZoneIdNotice
 
-Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a station or an entrance (i.e. `stops.location_type = 1 or 2`).
+Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a station, an entrance or an generic node (i.e. `stops.location_type = 1, 2 or 3`).
 
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)

--- a/RULES.md
+++ b/RULES.md
@@ -848,7 +848,7 @@ Such stops normally do not provide user value. This notice may indicate a typo i
 
 #### StopWithoutZoneIdNotice
 
-Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a station, an entrance or an generic node (i.e. `stops.location_type = 1, 2 or 3`).
+If `fare_rules.txt` is provided, then all stops and platforms (location_type = 0) must have `stops.zone_id` assigned.
 
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)

--- a/RULES.md
+++ b/RULES.md
@@ -848,7 +848,7 @@ Such stops normally do not provide user value. This notice may indicate a typo i
 
 #### StopWithoutZoneIdNotice
 
-Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a station or en entrance (i.e. `stops.location_type = 1 or 2`).
+Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a station or an entrance (i.e. `stops.location_type = 1 or 2`).
 
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)

--- a/RULES.md
+++ b/RULES.md
@@ -848,7 +848,7 @@ Such stops normally do not provide user value. This notice may indicate a typo i
 
 #### StopWithoutZoneIdNotice
 
-Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a stop or en entrance (i.e. `stops.location_type = 1 or 2`).
+Per GTFS specification, `stops.zone_id` should be provided if fare information is provided using `fare_rules.txt`. This rule does not apply to records from `stops.txt` that represent a station or en entrance (i.e. `stops.location_type = 1 or 2`).
 
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -950,7 +950,8 @@
 | Field name               	| Description                                	| Type   	|
 |--------------------------	|--------------------------------------------	|--------	|
 | `stopId`                 	| The faulty record's id.                    	| String 	|
-| `csvRowNumber`        	  | The row number of the faulty record.       	| Long   	|
+| `stopName`                | The faulty record's `stops.stop_name`.       	| String 	|
+| `csvRowNumber`        	| The row number of the faulty record.       	| Long   	|
 
 ##### Affected files
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -27,9 +27,8 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 
 /**
- * Validates that all stops in "stops.txt" have a value for {@code stops.zone_id} if fare
- * information is provided using "fare_rules.txt". This rule does not apply if a record from
- * "stops.txt" represents a station or station entrance i.e {@code stops.location_type = 1 or 2}.
+ * Check that if {@code fare_rules.txt} is provided, then all stops and platforms (location_type =
+ * 0) have {@code stops.zone_id} assigned.
  *
  * <p>Generated notice: {@link StopWithoutZoneIdNotice}.
  */
@@ -57,8 +56,7 @@ public class StopZoneIdValidator extends FileValidator {
       if (stop.hasZoneId()) {
         return;
       }
-      noticeContainer.addValidationNotice(
-          new StopWithoutZoneIdNotice(stop, stop.csvRowNumber()));
+      noticeContainer.addValidationNotice(new StopWithoutZoneIdNotice(stop, stop.csvRowNumber()));
     }
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -51,7 +51,7 @@ public class StopZoneIdValidator extends FileValidator {
     }
     for (GtfsStop stop : stopTable.getEntities()) {
       if (stop.locationType().equals(GtfsLocationType.STOP) && !stop.hasZoneId()) {
-        noticeContainer.addValidationNotice(new StopWithoutZoneIdNotice(stop, stop.csvRowNumber()));
+        noticeContainer.addValidationNotice(new StopWithoutZoneIdNotice(stop));
       }
     }
   }
@@ -67,11 +67,11 @@ public class StopZoneIdValidator extends FileValidator {
     private final String stopName;
     private final long csvRowNumber;
 
-    StopWithoutZoneIdNotice(GtfsStop stop, long csvRowNumber) {
+    StopWithoutZoneIdNotice(GtfsStop stop) {
       super(SeverityLevel.WARNING);
       this.stopId = stop.stopId();
       this.stopName = stop.stopName();
-      this.csvRowNumber = csvRowNumber;
+      this.csvRowNumber = stop.csvRowNumber();
     }
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -64,7 +64,8 @@ public class StopZoneIdValidator extends FileValidator {
 
   private boolean isStationOrEntrance(GtfsStop stop) {
     return stop.locationType().equals(GtfsLocationType.STATION)
-        || stop.locationType().equals(GtfsLocationType.ENTRANCE);
+        || stop.locationType().equals(GtfsLocationType.ENTRANCE)
+        || stop.locationType().equals(GtfsLocationType.GENERIC_NODE) ;
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -50,20 +50,10 @@ public class StopZoneIdValidator extends FileValidator {
       return;
     }
     for (GtfsStop stop : stopTable.getEntities()) {
-      if (isStationOrEntrance(stop)) {
-        return;
+      if (stop.locationType().equals(GtfsLocationType.STOP) && !stop.hasZoneId()) {
+        noticeContainer.addValidationNotice(new StopWithoutZoneIdNotice(stop, stop.csvRowNumber()));
       }
-      if (stop.hasZoneId()) {
-        return;
-      }
-      noticeContainer.addValidationNotice(new StopWithoutZoneIdNotice(stop, stop.csvRowNumber()));
     }
-  }
-
-  private boolean isStationOrEntrance(GtfsStop stop) {
-    return stop.locationType().equals(GtfsLocationType.STATION)
-        || stop.locationType().equals(GtfsLocationType.ENTRANCE)
-        || stop.locationType().equals(GtfsLocationType.GENERIC_NODE);
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -64,7 +64,7 @@ public class StopZoneIdValidator extends FileValidator {
 
   private boolean isStationOrEntrance(GtfsStop stop) {
     return stop.locationType().equals(GtfsLocationType.STATION)
-        || stop.locationType().equals(GtfsLocationType.STOP);
+        || stop.locationType().equals(GtfsLocationType.ENTRANCE);
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -65,7 +65,7 @@ public class StopZoneIdValidator extends FileValidator {
   private boolean isStationOrEntrance(GtfsStop stop) {
     return stop.locationType().equals(GtfsLocationType.STATION)
         || stop.locationType().equals(GtfsLocationType.ENTRANCE)
-        || stop.locationType().equals(GtfsLocationType.GENERIC_NODE) ;
+        || stop.locationType().equals(GtfsLocationType.GENERIC_NODE);
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -58,7 +58,7 @@ public class StopZoneIdValidator extends FileValidator {
         return;
       }
       noticeContainer.addValidationNotice(
-          new StopWithoutZoneIdNotice(stop.stopId(), stop.csvRowNumber()));
+          new StopWithoutZoneIdNotice(stop, stop.csvRowNumber()));
     }
   }
 
@@ -76,11 +76,13 @@ public class StopZoneIdValidator extends FileValidator {
    */
   static class StopWithoutZoneIdNotice extends ValidationNotice {
     private final String stopId;
+    private final String stopName;
     private final long csvRowNumber;
 
-    StopWithoutZoneIdNotice(String stopId, long csvRowNumber) {
+    StopWithoutZoneIdNotice(GtfsStop stop, long csvRowNumber) {
       super(SeverityLevel.WARNING);
-      this.stopId = stopId;
+      this.stopId = stop.stopId();
+      this.stopName = stop.stopName();
       this.csvRowNumber = csvRowNumber;
     }
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -46,7 +46,10 @@ public class StopZoneIdValidatorTest {
   }
 
   private static GtfsFareRule createFareRule(long csvRowNumber) {
-    return new GtfsFareRule.Builder().setCsvRowNumber(csvRowNumber).setFareId(toFareRuleId(csvRowNumber)).build();
+    return new GtfsFareRule.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setFareId(toFareRuleId(csvRowNumber))
+        .build();
   }
 
   private static String toLocationId(GtfsLocationType locationType, long csvRowNumber) {
@@ -70,94 +73,92 @@ public class StopZoneIdValidatorTest {
   @Test
   public void stop_zoneIdNotProvided_yieldsNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.STOP, null)),
-            ImmutableList.of(createFareRule(5))))
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.STOP, null)),
+                ImmutableList.of(createFareRule(5))))
         .containsExactly(new StopWithoutZoneIdNotice(toLocationId(GtfsLocationType.STOP, 3), 3));
   }
 
   @Test
   public void stop_zoneIdProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.STOP, "zone id value")),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.STOP, "zone id value")),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void station_zoneIdNotProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.STATION, null)),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.STATION, null)),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void station_zoneIdProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.STATION, "zone id value")),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.STATION, "zone id value")),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void entrance_zoneIdNotProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.ENTRANCE, null)),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.ENTRANCE, null)),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void entrance_zoneIdProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.ENTRANCE, "zone id value")),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.ENTRANCE, "zone id value")),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void genericNode_zoneIdNotProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.GENERIC_NODE, null)),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.GENERIC_NODE, null)),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void genericNode_zoneIdProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.GENERIC_NODE, "zone id value")),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.GENERIC_NODE, "zone id value")),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test
   public void boardingArea_zoneIdNotProvided_yieldsNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.BOARDING_AREA, null)),
-            ImmutableList.of(createFareRule(5))))
-        .containsExactly(new StopWithoutZoneIdNotice(toLocationId(GtfsLocationType.BOARDING_AREA, 3), 3));
-
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, null)),
+                ImmutableList.of(createFareRule(5))))
+        .containsExactly(
+            new StopWithoutZoneIdNotice(toLocationId(GtfsLocationType.BOARDING_AREA, 3), 3));
   }
 
   @Test
   public void boardingArea_zoneIdProvided_noNotice() {
     assertThat(
-        generateNotices(
-            ImmutableList.of(
-                createStop(3, GtfsLocationType.BOARDING_AREA, "zone id value")),
-            ImmutableList.of(createFareRule(5)))).isEmpty();
+            generateNotices(
+                ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, "zone id value")),
+                ImmutableList.of(createFareRule(5))))
+        .isEmpty();
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -144,13 +144,12 @@ public class StopZoneIdValidatorTest {
   }
 
   @Test
-  public void boardingArea_zoneIdNotProvided_yieldsNotice() {
+  public void boardingArea_zoneIdNotProvided_noNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, null)),
                 ImmutableList.of(createFareRule(5))))
-        .containsExactly(
-            new StopWithoutZoneIdNotice(createStop(3, GtfsLocationType.BOARDING_AREA, null), 3));
+        .isEmpty();
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -74,8 +74,19 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(
+                    createStop(4, GtfsLocationType.STOP, "zone id value", "stop id value"),
+                    createStop(6, GtfsLocationType.STATION, "zone id value", "station id value"),
+                    createStop(7, GtfsLocationType.ENTRANCE, "zone id value", "entrance id value"),
                     createStop(
-                        3, GtfsLocationType.BOARDING_AREA, "zone id value", "stop id value")),
+                        10,
+                        GtfsLocationType.GENERIC_NODE,
+                        "zone id value",
+                        "generic node id value"),
+                    createStop(
+                        3,
+                        GtfsLocationType.BOARDING_AREA,
+                        "zone id value",
+                        "boarding area id value")),
                 ImmutableList.of()))
         .isEmpty();
   }
@@ -111,23 +122,22 @@ public class StopZoneIdValidatorTest {
   }
 
   @Test
-  public void fareRuleProvided_stopLocationEqualsStop_noNotice() {
+  public void fareRuleProvided_stopLocationEqualsStationOrEntrance_zoneIdNotProvided_zeroNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(
-                    createStop(3, GtfsLocationType.STOP, "zone id value", "stop id value"),
-                    createStop(
-                        5, GtfsLocationType.STOP, "other zone id value", "other stop id value")),
+                    createStop(3, GtfsLocationType.STATION, null, "stop id value"),
+                    createStop(5, GtfsLocationType.ENTRANCE, null, "other stop id value")),
                 ImmutableList.of(createFareRule(5, "fare id value"))))
         .isEmpty();
   }
 
   @Test
-  public void fareRuleProvided_stopLocationEqualsEntrance_noNotice() {
+  public void fareRuleProvided_stopLocationEqualsStationOrEntrance_zoneIdProvided_noNotice() {
     assertThat(
             generateNotices(
                 ImmutableList.of(
-                    createStop(3, GtfsLocationType.ENTRANCE, "zone id value", "stop id value"),
+                    createStop(3, GtfsLocationType.STATION, "zone id value", "stop id value"),
                     createStop(
                         5,
                         GtfsLocationType.ENTRANCE,

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -76,7 +76,8 @@ public class StopZoneIdValidatorTest {
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.STOP, null)),
                 ImmutableList.of(createFareRule(5))))
-        .containsExactly(new StopWithoutZoneIdNotice(createStop(3, GtfsLocationType.STOP, null), 3));
+        .containsExactly(
+            new StopWithoutZoneIdNotice(createStop(3, GtfsLocationType.STOP, null), 3));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -72,12 +72,9 @@ public class StopZoneIdValidatorTest {
 
   @Test
   public void stop_zoneIdNotProvided_yieldsNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(createStop(3, GtfsLocationType.STOP, null)),
-                ImmutableList.of(createFareRule(5))))
-        .containsExactly(
-            new StopWithoutZoneIdNotice(createStop(3, GtfsLocationType.STOP, null), 3));
+    ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(3, GtfsLocationType.STOP, null));
+    assertThat(generateNotices(stops, ImmutableList.of(createFareRule(5))))
+        .containsExactly(new StopWithoutZoneIdNotice(stops.get(0)));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -76,7 +76,7 @@ public class StopZoneIdValidatorTest {
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.STOP, null)),
                 ImmutableList.of(createFareRule(5))))
-        .containsExactly(new StopWithoutZoneIdNotice(toLocationId(GtfsLocationType.STOP, 3), 3));
+        .containsExactly(new StopWithoutZoneIdNotice(createStop(3, GtfsLocationType.STOP, null), 3));
   }
 
   @Test
@@ -149,7 +149,7 @@ public class StopZoneIdValidatorTest {
                 ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, null)),
                 ImmutableList.of(createFareRule(5))))
         .containsExactly(
-            new StopWithoutZoneIdNotice(toLocationId(GtfsLocationType.BOARDING_AREA, 3), 3));
+            new StopWithoutZoneIdNotice(createStop(3, GtfsLocationType.BOARDING_AREA, null), 3));
   }
 
   @Test


### PR DESCRIPTION
closes #950

**Summary:**

This PR provides support to check `STATION` or `ENTRANCE` in `StopZoneIdValidator`.

**Expected behavior:** 

No notice should be generated for a record from `stops.txt` if `stop.zone_id` is empty AND `stops.location_type=1` or `stops.location_type=2`


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
