### PR TITLE
fix: remove duplicate notice RouteShortAndLongNameEqualNotice

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -134,7 +134,6 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	| Non ascii or non printable char in  `id`.                                                                                                                   	|
 | [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	| A platform has no `parent_station` field set.                                                                                                               	|
 | [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	| Insufficient route color contrast.                                                                                                                          	|
-| [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	| Short and long name are equal for a route.                                                                                                                  	|
 | [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	| Short name of a route is too long (more than 12 characters).                                                                                                	|
 | [`SameNameAndDescriptionForRouteNotice`](#SameNameAndDescriptionForRouteNotice)     | Same name and description for route.                                                                                                                        	|
 | [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)       | Same name and description for stop.                                                                                                                      	    |
@@ -748,15 +747,6 @@ A route's color and `route_text_color` should be contrasting.
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 * [Original Python validator implementation](https://github.com/google/transitfeed)
-
-<a name="RouteShortAndLongNameEqualNotice"/>
-
-#### RouteShortAndLongNameEqualNotice
-
-Short and long name are equal for a route.
-
-##### References:
-* [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 
 <a name="RouteShortNameTooLongNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -616,7 +616,6 @@
 | `non_ascii_or_non_printable_char`          	| [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	|
 | `platform_without_parent_station`          	| [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	|
 | `route_color_contrast`                     	| [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	|
-| `route_short_and_long_name_equal`          	| [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	|
 | `route_short_name_too_long`                	| [`RouteShortNameTooLongNotice`](#RouteShortNameTooLongNotice)                     	|
 | `same_name_and_description_for_route`       | [`SameNameAndDescriptionForRouteNotice`](#SameNameAndDescriptionForRouteNotice)     |
 | `same_name_and_description_for_stop`       	| [`SameNameAndDescriptionForStopNotice`](#SameNameAndDescriptionForStopNotice)     	|
@@ -817,19 +816,6 @@
 | `csvRowNumber`   	| The row number of the faulty record.       	| Long 	  |
 | `routeColor`     	| The faulty record's HTML route color.      	| String 	|
 | `routeTextColor` 	| The faulty record's HTML route text color. 	| String 	|
-
-##### Affected files
-* [`routes.txt`](http://gtfs.org/reference/static#routestxt)
-
-#### [RouteShortAndLongNameEqualNotice](/RULES.md#RouteShortAndLongNameEqualNotice)
-##### Fields description
-
-| Field name     	| Description                             	  | Type   	|
-|----------------	|-------------------------------------------	|--------	|
-| `routeId`        	| The id of the faulty record.            	| String  |
-| `csvRowNumber`   	| The row number of the faulty record.    	| Long 	  |
-| `routeShortName` 	| The faulty record's `route_short_name`. 	| String 	|
-| `routeLongName`  	| The faulty record's `route_long_name`.  	| String 	|
 
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -29,7 +29,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
  *
  * <ul>
  *   <li>{@link RouteBothShortAndLongNameMissingNotice}
- *   <li>{@link RouteShortAndLongNameEqualNotice}
  *   <li>{@link RouteShortNameTooLongNotice}
  *   <li>{@link SameNameAndDescriptionForRouteNotice}
  * </ul>
@@ -46,15 +45,6 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
     if (!hasLongName && !hasShortName) {
       noticeContainer.addValidationNotice(
           new RouteBothShortAndLongNameMissingNotice(entity.routeId(), entity.csvRowNumber()));
-    }
-
-    if (hasShortName
-        && hasLongName
-        && entity.routeShortName().equalsIgnoreCase(entity.routeLongName())) {
-      noticeContainer.addValidationNotice(
-          new RouteShortAndLongNameEqualNotice(
-              entity.routeId(), entity.csvRowNumber(),
-              entity.routeShortName(), entity.routeLongName()));
     }
 
     if (hasShortName && entity.routeShortName().length() > MAX_SHORT_NAME_LENGTH) {
@@ -97,27 +87,6 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
       super(SeverityLevel.ERROR);
       this.routeId = routeId;
       this.csvRowNumber = csvRowNumber;
-    }
-  }
-
-  /**
-   * Short and long name are equal for a route.
-   *
-   * <p>Severity: {@code SeverityLevel.WARNING}
-   */
-  static class RouteShortAndLongNameEqualNotice extends ValidationNotice {
-    private final String routeId;
-    private final long csvRowNumber;
-    private final String routeShortName;
-    private final String routeLongName;
-
-    RouteShortAndLongNameEqualNotice(
-        String routeId, long csvRowNumber, String routeShortName, String routeLongName) {
-      super(SeverityLevel.WARNING);
-      this.routeId = routeId;
-      this.csvRowNumber = csvRowNumber;
-      this.routeShortName = routeShortName;
-      this.routeLongName = routeLongName;
     }
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidatorTest.java
@@ -26,7 +26,6 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.validator.RouteNameValidator.RouteBothShortAndLongNameMissingNotice;
-import org.mobilitydata.gtfsvalidator.validator.RouteNameValidator.RouteShortAndLongNameEqualNotice;
 import org.mobilitydata.gtfsvalidator.validator.RouteNameValidator.RouteShortNameTooLongNotice;
 import org.mobilitydata.gtfsvalidator.validator.RouteNameValidator.SameNameAndDescriptionForRouteNotice;
 
@@ -55,17 +54,6 @@ public class RouteNameValidatorTest {
         .containsExactly(new RouteBothShortAndLongNameMissingNotice("r1", 1));
     assertThat(validateRoute(createRoute("S", null, null))).isEmpty();
     assertThat(validateRoute(createRoute(null, "Long", null))).isEmpty();
-    assertThat(validateRoute(createRoute("S", "Long", null))).isEmpty();
-  }
-
-  @Test
-  public void routeShortAndLongNameEqual() {
-    assertThat(validateRoute(createRoute("S", "S", null)))
-        .containsExactly(new RouteShortAndLongNameEqualNotice("r1", 1, "S", "S"));
-    // Compare case-insensitive.
-    assertThat(validateRoute(createRoute("SA", "Sa", null)))
-        .containsExactly(new RouteShortAndLongNameEqualNotice("r1", 1, "SA", "Sa"));
-
     assertThat(validateRoute(createRoute("S", "Long", null))).isEmpty();
   }
 
@@ -110,14 +98,7 @@ public class RouteNameValidatorTest {
   }
 
   @Test
-  public void allNamesProvidedAndDifferentFromRouteDescShouldNotGenerateNotice() {
-    assertThat(validateRoute(createRoute("short name", "long name", "desc"))).isEmpty();
-  }
-
-  @Test
   public void equalRouteShortNameRouteLongNameAndRouteDescShouldGenerateTwoNotices() {
-    assertThat(validateRoute(createRoute("duplicate", "duplicate", "duplicate")))
-        .contains(new RouteShortAndLongNameEqualNotice("r1", 1, "duplicate", "duplicate"));
     assertThat(validateRoute(createRoute("duplicate", "duplicate", "duplicate")))
         .contains(
             new SameNameAndDescriptionForRouteNotice(1, "r1", "duplicate", "route_short_name"));


### PR DESCRIPTION
**Summary:**

This PR provides support to remove duplicate notice `RouteShortAndLongNameEqualNotice`. We only keep `DuplicateRouteNameNotice`. 

**Expected behavior:** 

`RouteShortAndLongNameEqualNotice` shouldn't longer be generated in `RouteNameValidator`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
