### PR TITLE
fix: Raise IllegalArgumentException for invalid date

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsDate.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/type/GtfsDate.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.type;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 
 /** Represents GTFS date. */
@@ -34,6 +35,13 @@ public class GtfsDate implements Comparable<GtfsDate> {
     return new GtfsDate(LocalDate.ofEpochDay(epochDay));
   }
 
+  /**
+   * Parses date from string in {@code YYYYMMDD} format.
+   *
+   * @param yyyymmdd date in {@code YYYYMMDD} format, e.g. "20210102"
+   * @throws IllegalArgumentException for invalid date string
+   * @return a GtfsDate instance
+   */
   public static GtfsDate fromString(String yyyymmdd) {
     if (yyyymmdd.length() != 8) {
       throw new IllegalArgumentException("Date must have YYYYMMDD format: " + yyyymmdd);
@@ -46,7 +54,11 @@ public class GtfsDate implements Comparable<GtfsDate> {
     } catch (NumberFormatException ex) {
       throw new IllegalArgumentException("Date must have YYYYMMDD format: " + yyyymmdd);
     }
-    return new GtfsDate(LocalDate.of(year, month, day));
+    try {
+      return new GtfsDate(LocalDate.of(year, month, day));
+    } catch (DateTimeException e) {
+      throw new IllegalArgumentException("Invalid date " + yyyymmdd, e);
+    }
   }
 
   public int getYear() {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/type/GtfsDateTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/type/GtfsDateTest.java
@@ -27,13 +27,17 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class GtfsDateTest {
   @Test
-  public void fromString() {
+  public void fromString_valid() {
     assertThat(GtfsDate.fromString("20200901").getLocalDate()).isEqualTo(LocalDate.of(2020, 9, 1));
     assertThat(GtfsDate.fromString("19970103").getLocalDate()).isEqualTo(LocalDate.of(1997, 1, 3));
+  }
 
+  @Test
+  public void fromString_invalid() {
     assertThrows(IllegalArgumentException.class, () -> GtfsDate.fromString("0"));
     assertThrows(IllegalArgumentException.class, () -> GtfsDate.fromString("qwerty"));
     assertThrows(IllegalArgumentException.class, () -> GtfsDate.fromString("today"));
+    assertThrows(IllegalArgumentException.class, () -> GtfsDate.fromString("20219999"));
   }
 
   @Test


### PR DESCRIPTION
Fix issue #976

Previously, DateTimeException was raised for dates like 20219999. This
exception was not caught in RowParser:

```
  private <T> T parseAsType(
  ...
    try {
      return parsingFunction.apply(s);
    } catch (IllegalArgumentException | ZoneRulesException e) {

```

We prefer to change GtfsDate instead of RowParser for avoiding
complicating the generic RowParser code.
