### PR TITLE
feat: Return optional from getTableForFilename

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     implementation 'com.google.flogger:flogger:0.5.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation 'com.google.truth.extensions:truth-java8-extension:1.0.1'
 }
 
 test {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
@@ -16,11 +16,13 @@
 
 package org.mobilitydata.gtfsvalidator.table;
 
+import com.google.common.base.Ascii;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 
 /**
@@ -40,8 +42,20 @@ public class GtfsFeedContainer {
     }
   }
 
-  public GtfsTableContainer<?> getTable(String filename) {
-    return tables.get(filename);
+  /**
+   * Returns GTFS table for given file name, if any.
+   *
+   * <p>Returns empty if the table is not supported by schema. If table is supported but not
+   * provided in the feed, then returns an empty table container with {@link
+   * TableStatus#MISSING_FILE}.
+   *
+   * <p>File names are case-insensitive.
+   *
+   * @param filename file name, including ".txt" extension
+   * @return GTFS table or empty if the table is not supported by schema
+   */
+  public Optional<GtfsTableContainer<?>> getTableForFilename(String filename) {
+    return Optional.ofNullable(tables.getOrDefault(Ascii.toLowerCase(filename), null));
   }
 
   public <T extends GtfsTableContainer<?>> T getTable(Class<T> clazz) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainerTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.table;
+
+import static com.google.common.truth.Truth8.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
+
+public class GtfsFeedContainerTest {
+
+  @Test
+  public void getTableForFilename() {
+    GtfsStopTableContainer stopTable =
+        new GtfsStopTableContainer(TableStatus.EMPTY_FILE, CsvHeader.EMPTY);
+    GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(stopTable));
+
+    assertThat(feedContainer.getTableForFilename("stops.txt")).hasValue(stopTable);
+    assertThat(feedContainer.getTableForFilename("STOPS.TXT")).hasValue(stopTable);
+    assertThat(feedContainer.getTableForFilename("STOPS")).isEmpty();
+  }
+
+  /** Test class to avoid dependency on the real GtfsStop and annotation processor. */
+  static class GtfsStop implements GtfsEntity {
+
+    @Override
+    public long csvRowNumber() {
+      return 0;
+    }
+  }
+
+  /** Test class to avoid dependency on the real GtfsStopTableContainer and annotation processor. */
+  static class GtfsStopTableContainer extends GtfsTableContainer<GtfsStop> {
+
+    public GtfsStopTableContainer(TableStatus tableStatus, CsvHeader header) {
+      super(tableStatus, header);
+    }
+
+    @Override
+    public Class<GtfsStop> getEntityClass() {
+      return GtfsStop.class;
+    }
+
+    @Override
+    public List<GtfsStop> getEntities() {
+      return ImmutableList.of();
+    }
+
+    @Override
+    public String gtfsFilename() {
+      return "stops.txt";
+    }
+
+    @Override
+    public boolean isRequired() {
+      return true;
+    }
+  }
+}


### PR DESCRIPTION
Function name was changed to getTableForFilename to make clear that it
accepts file name including ".txt" extension.

This function will be used by translations validator that must be ready
to handle invalid table names, that is why the return type is changed to
an explicit Optional.
