### PR TITLE
feat: Support injection of the whole GtfsFeedContainer

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'commons-validator:commons-validator:1.6'
     implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.13'
     implementation 'com.google.flogger:flogger:0.5.1'
+    testImplementation 'com.google.flogger:flogger-system-backend:0.5.1'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"
     testImplementation 'com.google.truth.extensions:truth-java8-extension:1.0.1'

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainerTest.java
@@ -19,10 +19,10 @@ package org.mobilitydata.gtfsvalidator.table;
 import static com.google.common.truth.Truth8.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsStopTableContainer;
 
 public class GtfsFeedContainerTest {
 
@@ -35,42 +35,5 @@ public class GtfsFeedContainerTest {
     assertThat(feedContainer.getTableForFilename("stops.txt")).hasValue(stopTable);
     assertThat(feedContainer.getTableForFilename("STOPS.TXT")).hasValue(stopTable);
     assertThat(feedContainer.getTableForFilename("STOPS")).isEmpty();
-  }
-
-  /** Test class to avoid dependency on the real GtfsStop and annotation processor. */
-  static class GtfsStop implements GtfsEntity {
-
-    @Override
-    public long csvRowNumber() {
-      return 0;
-    }
-  }
-
-  /** Test class to avoid dependency on the real GtfsStopTableContainer and annotation processor. */
-  static class GtfsStopTableContainer extends GtfsTableContainer<GtfsStop> {
-
-    public GtfsStopTableContainer(TableStatus tableStatus, CsvHeader header) {
-      super(tableStatus, header);
-    }
-
-    @Override
-    public Class<GtfsStop> getEntityClass() {
-      return GtfsStop.class;
-    }
-
-    @Override
-    public List<GtfsStop> getEntities() {
-      return ImmutableList.of();
-    }
-
-    @Override
-    public String gtfsFilename() {
-      return "stops.txt";
-    }
-
-    @Override
-    public boolean isRequired() {
-      return true;
-    }
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsStop.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsStop.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
+
+/** Test class to avoid dependency on the real GtfsStop and annotation processor. */
+public class GtfsStop implements GtfsEntity {
+
+  @Override
+  public long csvRowNumber() {
+    return 0;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsStopTableContainer.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsStopTableContainer.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+
+/** Test class to avoid dependency on the real GtfsStopTableContainer and annotation processor. */
+public class GtfsStopTableContainer extends GtfsTableContainer<GtfsStop> {
+
+  public GtfsStopTableContainer(TableStatus tableStatus, CsvHeader header) {
+    super(tableStatus, header);
+  }
+
+  @Override
+  public Class<GtfsStop> getEntityClass() {
+    return GtfsStop.class;
+  }
+
+  @Override
+  public List<GtfsStop> getEntities() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public String gtfsFilename() {
+    return "stops.txt";
+  }
+
+  @Override
+  public boolean isRequired() {
+    return true;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/StopEntityValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/StopEntityValidator.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.validator.SingleEntityValidator;
+
+public class StopEntityValidator extends SingleEntityValidator<GtfsStop> {
+  private final CountryCode countryCode;
+  private final CurrentDateTime currentDateTime;
+
+  @Inject
+  public StopEntityValidator(CountryCode countryCode, CurrentDateTime currentDateTime) {
+    this.countryCode = countryCode;
+    this.currentDateTime = currentDateTime;
+  }
+
+  @Override
+  public void validate(GtfsStop entity, NoticeContainer noticeContainer) {}
+
+  public CountryCode getCountryCode() {
+    return countryCode;
+  }
+
+  public CurrentDateTime getCurrentDateTime() {
+    return currentDateTime;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/StopFileValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/StopFileValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.validator.FileValidator;
+
+public class StopFileValidator extends FileValidator {
+
+  private final GtfsStopTableContainer stopTable;
+  private final CountryCode countryCode;
+  private final CurrentDateTime currentDateTime;
+
+  @Inject
+  public StopFileValidator(
+      GtfsStopTableContainer stopTable, CountryCode countryCode, CurrentDateTime currentDateTime) {
+    this.stopTable = stopTable;
+    this.countryCode = countryCode;
+    this.currentDateTime = currentDateTime;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {}
+
+  public GtfsStopTableContainer getStopTable() {
+    return stopTable;
+  }
+
+  public CountryCode getCountryCode() {
+    return countryCode;
+  }
+
+  public CurrentDateTime getCurrentDateTime() {
+    return currentDateTime;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/WholeFeedValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/WholeFeedValidator.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.validator.FileValidator;
+
+public class WholeFeedValidator extends FileValidator {
+  private final GtfsFeedContainer feedContainer;
+  private final CountryCode countryCode;
+
+  private final CurrentDateTime currentDateTime;
+
+  @Inject
+  public WholeFeedValidator(
+      GtfsFeedContainer feedContainer, CountryCode countryCode, CurrentDateTime currentDateTime) {
+    this.feedContainer = feedContainer;
+    this.countryCode = countryCode;
+    this.currentDateTime = currentDateTime;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {}
+
+  public GtfsFeedContainer getFeedContainer() {
+    return feedContainer;
+  }
+
+  public CountryCode getCountryCode() {
+    return countryCode;
+  }
+
+  public CurrentDateTime getCurrentDateTime() {
+    return currentDateTime;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.testgtfs.StopEntityValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.StopFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.WholeFeedValidator;
+
+public class ValidatorLoaderTest {
+  private static final CountryCode COUNTRY_CODE = CountryCode.forStringOrUnknown("AU");
+  private static final CurrentDateTime CURRENT_DATE_TIME =
+      new CurrentDateTime(ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC));
+  private static final ValidationContext VALIDATION_CONTEXT =
+      ValidationContext.builder()
+          .setCountryCode(COUNTRY_CODE)
+          .setCurrentDateTime(CURRENT_DATE_TIME)
+          .build();
+
+  @Test
+  public void createValidatorWithContext_injectsContext() throws ReflectiveOperationException {
+    GtfsStopTableContainer stopTable =
+        new GtfsStopTableContainer(TableStatus.EMPTY_FILE, CsvHeader.EMPTY);
+    StopEntityValidator validator =
+        ValidatorLoader.createValidatorWithContext(StopEntityValidator.class, VALIDATION_CONTEXT);
+
+    assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
+    assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
+  }
+
+  @Test
+  public void createSingleFileValidator_injectsTableContainerAndContext()
+      throws ReflectiveOperationException {
+    GtfsStopTableContainer stopTable =
+        new GtfsStopTableContainer(TableStatus.EMPTY_FILE, CsvHeader.EMPTY);
+    StopFileValidator validator =
+        (StopFileValidator)
+            ValidatorLoader.createSingleFileValidator(
+                StopFileValidator.class, stopTable, VALIDATION_CONTEXT);
+
+    assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
+    assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
+    assertThat(validator.getStopTable()).isEqualTo(stopTable);
+  }
+
+  @Test
+  public void createMultiFileValidator_injectsFeedContainerAndContext()
+      throws ReflectiveOperationException {
+    GtfsStopTableContainer stopTable =
+        new GtfsStopTableContainer(TableStatus.EMPTY_FILE, CsvHeader.EMPTY);
+    GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(stopTable));
+    WholeFeedValidator validator =
+        (WholeFeedValidator)
+            ValidatorLoader.createMultiFileValidator(
+                WholeFeedValidator.class, feedContainer, VALIDATION_CONTEXT);
+
+    assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
+    assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
+    assertThat(validator.getFeedContainer()).isEqualTo(feedContainer);
+  }
+}


### PR DESCRIPTION
This will be used by GTFS translations validator that needs to work with
arbitrary tables.

flogger-system-backend was added to test dependencies. It is required
for testing ValidatorLoader class that initializes a static
FluentLogger.
