### PR TITLE
feat: Validate that locations are reachable if a station has pathways

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -131,6 +131,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`MissingLevelFileNotice`](#MissingLevelFileNotice)       	                                | `levels.txt` is conditionally required.                                                                                                                	    |
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	| More than one row in CSV.                                                                                                                                   	|
 | [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	| Non ascii or non printable char in  `id`.                                                                                                                   	|
+| [`PathwayUnreachableLocationNotice`](#PathwayUnreachableLocationNotice)               | A location is not reachable at least in one direction: from the entrances or to the exits.                                                                    |
 | [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	| A platform has no `parent_station` field set.                                                                                                               	|
 | [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	| Insufficient route color contrast.                                                                                                                          	|
 | [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	| Short and long name are equal for a route.                                                                                                                  	|
@@ -719,6 +720,22 @@ A value of a field with type `id` contains non ASCII or non printable characters
 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)
+
+<a name="PathwayUnreachableLocationNotice"/>
+
+#### PathwayUnreachableLocationNotice
+
+A location belongs to a station that has pathways and is not reachable at least in one direction:
+from the entrances or to the exits.
+
+Notices are reported for platforms, boarding areas and generic nodes but not for entrances or
+stations.
+
+Notices are not reported for platforms that have boarding areas since such platforms may not
+have incident pathways. Instead, notices are reported for the boarding areas.
+
+##### References:
+* [pathways.txt specification](http://gtfs.org/reference/static/#pathwaystxt)
 
 <a name="PlatformWithoutParentStationNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -613,6 +613,7 @@
 | `missing_level_file`                         	| [`MissingLevelFileNotice`](#MissingLevelFileNotice)                                       	|
 | `more_than_one_entity`                     	| [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	|
 | `non_ascii_or_non_printable_char`          	| [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	|
+| `pathway_unreachable_location`                | [`PathwayUnreachableLocationNotice`](#PathwayUnreachableLocationNotice)	            |
 | `platform_without_parent_station`          	| [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	|
 | `route_color_contrast`                     	| [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	|
 | `route_short_and_long_name_equal`          	| [`RouteShortAndLongNameEqualNotice`](#RouteShortAndLongNameEqualNotice)           	|
@@ -780,6 +781,23 @@
 
 ##### Affected files
 [All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
+
+#### [PathwayUnreachableLocationNotice](/RULES.md#PathwayUnreachableLocationNotice)
+##### Fields description
+
+| Field name   	 | Description                                         | Type    	|
+|----------------|--------------------------------------------------|---------	|
+| `csvRowNumber` | Row number of the unreachable location.             | Long    	|
+| `stopId`     	 | The id of the unreachable location.                 | String  	|
+| `stopName`   	 | The stop name of the unreachable location.     	   | String  	|
+| `locationType` | The type of the unreachable location. 	           | Integer 	|
+| `parentStation`| The parent of the unreachable location. 	           | String 	|
+| `hasEntrance`  | Whether the location is reachable from entrances.   | String 	|
+| `hasExit`      | Whether some exit can be reached from the location. | String 	|
+
+##### Affected files
+* [`pathways.txt`](http://gtfs.org/reference/static#pathwaystxt)
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
 #### [PlatformWithoutParentStationNotice](/RULES.md#PlatformWithoutParentStationNotice)
 ##### Fields description

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -73,7 +73,8 @@ dependencies {
     implementation 'com.univocity:univocity-parsers:2.9.0'
     implementation 'com.google.geometry:s2-geometry:2.0.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
-    testImplementation "com.google.truth:truth:1.0.1"
+    testImplementation 'com.google.truth:truth:1.0.1'
+    testImplementation 'com.google.truth.extensions:truth-java8-extension:1.0.1'
 }
 
 test {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsPathwayIsBidirectionalEnum.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsPathwayIsBidirectionalEnum.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.table;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
+
+@GtfsEnumValue(name = "UNIDIRECTIONAL", value = 0)
+@GtfsEnumValue(name = "BIDIRECTIONAL", value = 1)
+public interface GtfsPathwayIsBidirectionalEnum {}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsPathwaySchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsPathwaySchema.java
@@ -20,6 +20,7 @@ import org.mobilitydata.gtfsvalidator.annotation.FieldType;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
 import org.mobilitydata.gtfsvalidator.annotation.ForeignKey;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.Index;
 import org.mobilitydata.gtfsvalidator.annotation.NonNegative;
 import org.mobilitydata.gtfsvalidator.annotation.NonZero;
 import org.mobilitydata.gtfsvalidator.annotation.Positive;
@@ -34,11 +35,13 @@ public interface GtfsPathwaySchema extends GtfsEntity {
   String pathwayId();
 
   @FieldType(FieldTypeEnum.ID)
+  @Index
   @Required
   @ForeignKey(table = "stops.txt", field = "stop_id")
   String fromStopId();
 
   @FieldType(FieldTypeEnum.ID)
+  @Index
   @Required
   @ForeignKey(table = "stops.txt", field = "stop_id")
   String toStopId();
@@ -47,7 +50,7 @@ public interface GtfsPathwaySchema extends GtfsEntity {
   GtfsPathwayMode pathwayMode();
 
   @Required
-  int isBidirectional();
+  GtfsPathwayIsBidirectional isBidirectional();
 
   @NonNegative
   double length();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidator.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.BOARDING_AREA;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.ENTRANCE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.GENERIC_NODE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STOP;
+import static org.mobilitydata.gtfsvalidator.table.GtfsPathwayIsBidirectional.BIDIRECTIONAL;
+import static org.mobilitydata.gtfsvalidator.validator.PathwayReachableLocationValidator.Traversal.FROM_ENTRANCES;
+import static org.mobilitydata.gtfsvalidator.validator.PathwayReachableLocationValidator.Traversal.TO_EXITS;
+
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.util.StopUtil;
+
+/**
+ * Validates that if a station has pathways, then each location is reachable in both directions:
+ * there is a way to get to that location from some entrance and a way to get from that location to
+ * some entrance.
+ *
+ * <p>Notices are reported for platforms, boarding areas and generic nodes but not for entrances or
+ * stations.
+ *
+ * <p>Notices are not reported for platforms that have boarding areas since such platforms may not
+ * have incident pathways. Instead, notices are reported for the boarding areas.
+ */
+@GtfsValidator
+public class PathwayReachableLocationValidator extends FileValidator {
+
+  private final GtfsPathwayTableContainer pathwayTable;
+  private final GtfsStopTableContainer stopTable;
+
+  @Inject
+  PathwayReachableLocationValidator(
+      GtfsPathwayTableContainer pathwayTable, GtfsStopTableContainer stopTable) {
+    this.pathwayTable = pathwayTable;
+    this.stopTable = stopTable;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    final Set<String> pathwayEndpoints = new HashSet<>(pathwayTable.byFromStopIdMap().keySet());
+    pathwayEndpoints.addAll(pathwayTable.byToStopIdMap().keySet());
+    final Set<String> stationsWithPathways = findStationsWithPathways(pathwayEndpoints);
+    final Set<String> withEntrances = traversePathways(FROM_ENTRANCES);
+    final Set<String> withExits = traversePathways(TO_EXITS);
+    for (GtfsStop location : stopTable.getEntities()) {
+      // Skip locations that do not belong to stations with pathways.
+      Optional<GtfsStop> includingStation =
+          StopUtil.getIncludingStation(stopTable, location.stopId());
+      if (!(includingStation.isPresent()
+          && stationsWithPathways.contains(includingStation.get().stopId()))) {
+        continue;
+      }
+      // Emit notices only for generic nodes, boarding areas and platforms that do not have boarding
+      // areas.
+      if (!(location.locationType().equals(GENERIC_NODE)
+          || location.locationType().equals(BOARDING_AREA)
+          || (location.locationType().equals(STOP)
+              && stopTable.byParentStation(location.stopId()).isEmpty()))) {
+        continue;
+      }
+      boolean hasEntrance = withEntrances.contains(location.stopId());
+      boolean hasExit = withExits.contains(location.stopId());
+      if (!(hasEntrance && hasExit)) {
+        noticeContainer.addValidationNotice(
+            new PathwayUnreachableLocationNotice(location, hasEntrance, hasExit));
+      }
+    }
+  }
+
+  /**
+   * Returns stop_ids of stations that have child platforms/entrances/etc. that have incident
+   * pathways.
+   */
+  private Set<String> findStationsWithPathways(Set<String> pathwayEndpoints) {
+    Set<String> stationsWithPathways = new HashSet<>();
+    for (String stopId : pathwayEndpoints) {
+      StopUtil.getIncludingStation(stopTable, stopId)
+          .ifPresent(station -> stationsWithPathways.add(station.stopId()));
+    }
+    return stationsWithPathways;
+  }
+
+  /**
+   * Traverses pathway graph using BFS either from entrances (in the direction of pathways) or to
+   * entrances (opposite to the direction of pathways).
+   *
+   * <p>Returns a set of {@code stop_id} of all visited locations, including the entrances.
+   *
+   * <p>Bidirectional pathways are handled naturally: they are traversable in both directions.
+   */
+  private Set<String> traversePathways(Traversal traversal) {
+    Set<String> visitedStopIds = new HashSet<>();
+    Queue<String> queue = new ArrayDeque<>();
+    for (GtfsStop stop : stopTable.getEntities()) {
+      if (stop.locationType().equals(ENTRANCE)) {
+        queue.add(stop.stopId());
+        visitedStopIds.add(stop.stopId());
+      }
+    }
+    while (!queue.isEmpty()) {
+      String currStopId = queue.remove();
+      for (GtfsPathway pathway : pathwayTable.byFromStopId(currStopId)) {
+        if (traversal.equals(FROM_ENTRANCES) || pathway.isBidirectional().equals(BIDIRECTIONAL)) {
+          maybeDiscoverAndEnqueue(pathway.toStopId(), visitedStopIds, queue);
+        }
+      }
+      for (GtfsPathway pathway : pathwayTable.byToStopId(currStopId)) {
+        if (traversal.equals(TO_EXITS) || pathway.isBidirectional().equals(BIDIRECTIONAL)) {
+          maybeDiscoverAndEnqueue(pathway.fromStopId(), visitedStopIds, queue);
+        }
+      }
+    }
+    return visitedStopIds;
+  }
+
+  private static boolean maybeDiscoverAndEnqueue(
+      String stopId, Set<String> visitedStopIds, Queue<String> queue) {
+    if (visitedStopIds.contains(stopId)) {
+      return false;
+    }
+    queue.add(stopId);
+    visitedStopIds.add(stopId);
+    return true;
+  }
+
+  enum Traversal {
+    FROM_ENTRANCES,
+    TO_EXITS
+  }
+
+  /**
+   * Describes a location that is not reachable at least in one direction: from the entrances or to
+   * the exits.
+   */
+  static class PathwayUnreachableLocationNotice extends ValidationNotice {
+
+    private final long csvRowNumber;
+    private final String stopId;
+    private final String stopName;
+    private final int locationType;
+    private final String parentStation;
+    private final boolean hasEntrance;
+    private final boolean hasExit;
+
+    PathwayUnreachableLocationNotice(GtfsStop location, boolean hasEntrance, boolean hasExit) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = location.csvRowNumber();
+      this.stopId = location.stopId();
+      this.stopName = location.stopName();
+      this.locationType = location.locationTypeValue();
+      this.parentStation = location.parentStation();
+      this.hasEntrance = hasEntrance;
+      this.hasExit = hasExit;
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/StopUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/StopUtilTest.java
@@ -16,6 +16,13 @@
 
 package org.mobilitydata.gtfsvalidator.util;
 
+import static com.google.common.truth.Truth8.assertThat;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.BOARDING_AREA;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.ENTRANCE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STATION;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STOP;
+import static org.mobilitydata.gtfsvalidator.util.StopUtil.getIncludingStation;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.geometry.S2LatLng;
 import com.google.common.truth.Expect;
@@ -25,6 +32,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 
@@ -95,5 +103,52 @@ public class StopUtilTest {
     expect
         .that(StopUtil.getStopOrParentLatLng(stopTable, numberToStopId(0)))
         .isEqualTo(S2LatLng.CENTER);
+  }
+
+  private static GtfsStop createStop(
+      int id, GtfsLocationType locationType, @Nullable String parentStation) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(id)
+        .setStopId(numberToStopId(id))
+        .setLocationType(locationType)
+        .setParentStation(parentStation)
+        .build();
+  }
+
+  @Test
+  public void getIncludingStation_valid() {
+    ImmutableList<GtfsStop> stops =
+        ImmutableList.of(
+            createStop(0, STATION, null),
+            createStop(1, STOP, numberToStopId(0)),
+            createStop(2, BOARDING_AREA, numberToStopId(1)),
+            createStop(3, ENTRANCE, numberToStopId(0)));
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
+
+    assertThat(getIncludingStation(stopTable, numberToStopId(0))).hasValue(stops.get(0));
+    assertThat(getIncludingStation(stopTable, numberToStopId(1))).hasValue(stops.get(0));
+    assertThat(getIncludingStation(stopTable, numberToStopId(2))).hasValue(stops.get(0));
+    assertThat(getIncludingStation(stopTable, numberToStopId(3))).hasValue(stops.get(0));
+  }
+
+  @Test
+  public void getIncludingStation_infiniteLoop() {
+    ImmutableList<GtfsStop> stops =
+        ImmutableList.of(
+            createStop(0, STOP, numberToStopId(1)), createStop(1, STOP, numberToStopId(0)));
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
+
+    assertThat(getIncludingStation(stopTable, numberToStopId(0))).isEmpty();
+  }
+
+  @Test
+  public void getIncludingStation_noParent() {
+    ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(0, STOP, null));
+    GtfsStopTableContainer stopTable =
+        GtfsStopTableContainer.forEntities(stops, new NoticeContainer());
+
+    assertThat(getIncludingStation(stopTable, numberToStopId(0))).isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidatorTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.BOARDING_AREA;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.ENTRANCE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.GENERIC_NODE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STATION;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STOP;
+import static org.mobilitydata.gtfsvalidator.table.GtfsPathwayIsBidirectional.BIDIRECTIONAL;
+import static org.mobilitydata.gtfsvalidator.table.GtfsPathwayIsBidirectional.UNIDIRECTIONAL;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayIsBidirectional;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.validator.PathwayReachableLocationValidator.PathwayUnreachableLocationNotice;
+
+@RunWith(JUnit4.class)
+public final class PathwayReachableLocationValidatorTest {
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsPathway> pathways, List<GtfsStop> stops) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new PathwayReachableLocationValidator(
+            GtfsPathwayTableContainer.forEntities(pathways, noticeContainer),
+            GtfsStopTableContainer.forEntities(stops, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  static String rowToStopId(long csvRowNumber) {
+    return "stop" + csvRowNumber;
+  }
+
+  static String rowToPathwayId(long csvRowNumber) {
+    return "pathway" + csvRowNumber;
+  }
+
+  static GtfsPathway createPathway(
+      long fromStopRow, long toStopRow, GtfsPathwayIsBidirectional isBidirectional) {
+    long row = fromStopRow * 1000 + toStopRow;
+    return new GtfsPathway.Builder()
+        .setCsvRowNumber(row)
+        .setPathwayId(rowToPathwayId(row))
+        .setFromStopId(rowToStopId(fromStopRow))
+        .setToStopId(rowToStopId(toStopRow))
+        .setIsBidirectional(isBidirectional)
+        .build();
+  }
+
+  static GtfsStop createLocation(long csvRowNumber, GtfsLocationType locationType) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(rowToStopId(csvRowNumber))
+        .setLocationType(locationType)
+        .setStopName(locationType.name() + csvRowNumber)
+        .build();
+  }
+
+  static GtfsStop createChildLocation(
+      long csvRowNumber, GtfsLocationType locationType, long parentRow) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(rowToStopId(csvRowNumber))
+        .setLocationType(locationType)
+        .setParentStation(rowToStopId(parentRow))
+        .setStopName(locationType.name() + csvRowNumber)
+        .build();
+  }
+
+  @Test
+  public void unreachablePlatforms_yieldsNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, STOP, 10),
+            createChildLocation(13, STOP, 10),
+            createChildLocation(14, ENTRANCE, 10));
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createPathway(11, 14, UNIDIRECTIONAL), createPathway(14, 12, UNIDIRECTIONAL)),
+                stops))
+        .containsExactly(
+            new PathwayUnreachableLocationNotice(stops.get(1), false, true),
+            new PathwayUnreachableLocationNotice(stops.get(2), true, false),
+            new PathwayUnreachableLocationNotice(stops.get(3), false, false));
+  }
+
+  @Test
+  public void unreachableGenericNodes_yieldsNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, GENERIC_NODE, 10),
+            createChildLocation(12, GENERIC_NODE, 10),
+            createChildLocation(13, GENERIC_NODE, 10),
+            createChildLocation(14, ENTRANCE, 10));
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createPathway(11, 14, UNIDIRECTIONAL), createPathway(14, 12, UNIDIRECTIONAL)),
+                stops))
+        .containsExactly(
+            new PathwayUnreachableLocationNotice(stops.get(1), false, true),
+            new PathwayUnreachableLocationNotice(stops.get(2), true, false),
+            new PathwayUnreachableLocationNotice(stops.get(3), false, false));
+  }
+
+  @Test
+  public void reachablePlatform_yieldsNoNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, ENTRANCE, 10));
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createPathway(11, 12, UNIDIRECTIONAL), createPathway(12, 11, UNIDIRECTIONAL)),
+                stops))
+        .isEmpty();
+  }
+
+  @Test
+  public void bidirectionalPathway_yieldsNoNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, ENTRANCE, 10));
+    assertThat(generateNotices(ImmutableList.of(createPathway(11, 12, BIDIRECTIONAL)), stops))
+        .isEmpty();
+  }
+
+  @Test
+  public void unidirectionalPathway_yieldsNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, ENTRANCE, 10));
+    assertThat(generateNotices(ImmutableList.of(createPathway(11, 12, UNIDIRECTIONAL)), stops))
+        .containsExactly(new PathwayUnreachableLocationNotice(stops.get(1), false, true));
+  }
+
+  @Test
+  public void reachableBoardingAreas_yieldsNoNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, BOARDING_AREA, 11),
+            createChildLocation(13, BOARDING_AREA, 11),
+            createChildLocation(14, ENTRANCE, 10));
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createPathway(12, 14, BIDIRECTIONAL), createPathway(13, 14, BIDIRECTIONAL)),
+                stops))
+        .isEmpty();
+  }
+
+  @Test
+  public void unreachableBoardingArea_yieldsNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, BOARDING_AREA, 11),
+            createChildLocation(13, BOARDING_AREA, 11),
+            createChildLocation(14, ENTRANCE, 10));
+    assertThat(generateNotices(ImmutableList.of(createPathway(12, 14, BIDIRECTIONAL)), stops))
+        .containsExactly(new PathwayUnreachableLocationNotice(stops.get(3), false, false));
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidatorTest.java
@@ -62,10 +62,10 @@ public final class PathwayReachableLocationValidatorTest {
 
   static GtfsPathway createPathway(
       long fromStopRow, long toStopRow, GtfsPathwayIsBidirectional isBidirectional) {
-    long row = fromStopRow * 1000 + toStopRow;
+    long pathwayRow = fromStopRow * 1000 + toStopRow;
     return new GtfsPathway.Builder()
-        .setCsvRowNumber(row)
-        .setPathwayId(rowToPathwayId(row))
+        .setCsvRowNumber(pathwayRow)
+        .setPathwayId(rowToPathwayId(pathwayRow))
         .setFromStopId(rowToStopId(fromStopRow))
         .setToStopId(rowToStopId(toStopRow))
         .setIsBidirectional(isBidirectional)


### PR DESCRIPTION
Fix issue #974, issue #975

Validate that if a station has pathways, then each location is
reachable in both directions: there is a way to get to that location
from some entrance and a way to get from that location to some
entrance.

Notices are reported for platforms, boarding areas and generic nodes
but not for entrances or stations.

Notices are not reported for platforms that have boarding areas since
such platforms may not have incident pathways. Instead, notices are
reported for the boarding areas.
