### PR TITLE
feat: Validate that a generic node is not dangling

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -131,6 +131,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`MissingLevelFileNotice`](#MissingLevelFileNotice)       	                                | `levels.txt` is conditionally required.                                                                                                                	    |
 | [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	| More than one row in CSV.                                                                                                                                   	|
 | [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	| Non ascii or non printable char in  `id`.                                                                                                                   	|
+| [`PathwayDanglingGenericNodeNotice`](#PathwayDanglingGenericNodeNotice)           	| A generic node has only one incident location in a pathway graph.                                                                                             |
 | [`PathwayUnreachableLocationNotice`](#PathwayUnreachableLocationNotice)               | A location is not reachable at least in one direction: from the entrances or to the exits.                                                                    |
 | [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	| A platform has no `parent_station` field set.                                                                                                               	|
 | [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	| Insufficient route color contrast.                                                                                                                          	|
@@ -720,6 +721,16 @@ A value of a field with type `id` contains non ASCII or non printable characters
 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)
+
+<a name="PathwayDanglingGenericNodeNotice"/>
+
+#### PathwayDanglingGenericNodeNotice
+
+A generic node has only one incident location in a pathway graph. Such generic node is useless
+because there is no benefit in visiting it.
+
+##### References:
+* [pathways.txt specification](http://gtfs.org/reference/static/#pathwaystxt)
 
 <a name="PathwayUnreachableLocationNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -613,6 +613,7 @@
 | `missing_level_file`                         	| [`MissingLevelFileNotice`](#MissingLevelFileNotice)                                       	|
 | `more_than_one_entity`                     	| [`MoreThanOneEntityNotice`](#MoreThanOneEntityNotice)                             	|
 | `non_ascii_or_non_printable_char`          	| [`NonAsciiOrNonPrintableCharNotice`](#NonAsciiOrNonPrintableCharNotice)           	|
+| `pathway_dangling_generic_node`               | [`PathwayDanglingGenericNodeNotice`](#PathwayDanglingGenericNodeNotice)	            |
 | `pathway_unreachable_location`                | [`PathwayUnreachableLocationNotice`](#PathwayUnreachableLocationNotice)	            |
 | `platform_without_parent_station`          	| [`PlatformWithoutParentStationNotice`](#PlatformWithoutParentStationNotice)       	|
 | `route_color_contrast`                     	| [`RouteColorContrastNotice`](#RouteColorContrastNotice)                           	|
@@ -781,6 +782,20 @@
 
 ##### Affected files
 [All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
+
+#### [PathwayDanglingGenericNodeNotice](/RULES.md#PathwayDanglingGenericNodeNotice)
+##### Fields description
+
+| Field name     | Description                                         | Type    	|
+|----------------|-----------------------------------------------------|---------	|
+| `csvRowNumber` | Row number of the dangling generic node.            | Long    	|
+| `stopId`       | The id of the dangling generic node.                | String  	|
+| `stopName`     | The stop name of the dangling generic node.         | String  	|
+| `parentStation`| The parent station of the dangling generic node.    | String 	|
+
+##### Affected files
+* [`pathways.txt`](http://gtfs.org/reference/static#pathwaystxt)
+* [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 
 #### [PathwayUnreachableLocationNotice](/RULES.md#PathwayUnreachableLocationNotice)
 ##### Fields description

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayDanglingGenericNodeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayDanglingGenericNodeValidator.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.GENERIC_NODE;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+
+/**
+ * Validates that generic node is not dangling, i.e. does not have just one incident location in the
+ * pathway graph.
+ *
+ * <p>Such generic node is useless because there is no benefit in visiting it.
+ *
+ * <p>Pathway directions are ignored during that validation.
+ */
+@GtfsValidator
+public class PathwayDanglingGenericNodeValidator extends FileValidator {
+
+  private final GtfsPathwayTableContainer pathwayTable;
+  private final GtfsStopTableContainer stopTable;
+
+  @Inject
+  PathwayDanglingGenericNodeValidator(
+      GtfsPathwayTableContainer pathwayTable, GtfsStopTableContainer stopTable) {
+    this.pathwayTable = pathwayTable;
+    this.stopTable = stopTable;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    for (GtfsStop location : stopTable.getEntities()) {
+      if (!location.locationType().equals(GENERIC_NODE)) {
+        continue;
+      }
+      Set<String> incidentIds = new HashSet<>();
+      for (GtfsPathway pathway : pathwayTable.byFromStopId(location.stopId())) {
+        incidentIds.add(pathway.toStopId());
+      }
+      for (GtfsPathway pathway : pathwayTable.byToStopId(location.stopId())) {
+        incidentIds.add(pathway.fromStopId());
+      }
+      if (incidentIds.size() == 1) {
+        // The generic node is incident to a single location.
+        noticeContainer.addValidationNotice(new PathwayDanglingGenericNodeNotice(location));
+      }
+    }
+  }
+
+  /**
+   * Describes a dangling generic node, i.e. that has only one incident location in a pathway graph.
+   */
+  static class PathwayDanglingGenericNodeNotice extends ValidationNotice {
+    private final long csvRowNumber;
+    private final String stopId;
+    private final String stopName;
+    private final String parentStation;
+
+    PathwayDanglingGenericNodeNotice(GtfsStop genericNode) {
+      super(SeverityLevel.WARNING);
+      this.csvRowNumber = genericNode.csvRowNumber();
+      this.stopId = genericNode.stopId();
+      this.stopName = genericNode.stopName();
+      this.parentStation = genericNode.parentStation();
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PathwayDanglingGenericNodeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PathwayDanglingGenericNodeValidatorTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.ENTRANCE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.GENERIC_NODE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STATION;
+import static org.mobilitydata.gtfsvalidator.table.GtfsLocationType.STOP;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
+import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.validator.PathwayDanglingGenericNodeValidator.PathwayDanglingGenericNodeNotice;
+
+@RunWith(JUnit4.class)
+public final class PathwayDanglingGenericNodeValidatorTest {
+
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsPathway> pathways, List<GtfsStop> stops) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new PathwayDanglingGenericNodeValidator(
+            GtfsPathwayTableContainer.forEntities(pathways, noticeContainer),
+            GtfsStopTableContainer.forEntities(stops, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  static String rowToStopId(long csvRowNumber) {
+    return "stop" + csvRowNumber;
+  }
+
+  static String rowToPathwayId(long csvRowNumber) {
+    return "pathway" + csvRowNumber;
+  }
+
+  static GtfsPathway createPathway(long fromStopRow, long toStopRow) {
+    long row = fromStopRow * 1000 + toStopRow;
+    return new GtfsPathway.Builder()
+        .setCsvRowNumber(row)
+        .setPathwayId(rowToPathwayId(row))
+        .setFromStopId(rowToStopId(fromStopRow))
+        .setToStopId(rowToStopId(toStopRow))
+        .build();
+  }
+
+  static GtfsStop createLocation(long csvRowNumber, GtfsLocationType locationType) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(rowToStopId(csvRowNumber))
+        .setLocationType(locationType.getNumber())
+        .build();
+  }
+
+  static GtfsStop createChildLocation(
+      long csvRowNumber, GtfsLocationType locationType, long parentRow) {
+    return new GtfsStop.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setStopId(rowToStopId(csvRowNumber))
+        .setLocationType(locationType.getNumber())
+        .setParentStation(rowToStopId(parentRow))
+        .build();
+  }
+
+  @Test
+  public void danglingGenericNode_yieldsNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, GENERIC_NODE, 10),
+            createChildLocation(13, ENTRANCE, 10));
+    assertThat(
+            generateNotices(ImmutableList.of(createPathway(11, 13), createPathway(11, 12)), stops))
+        .containsExactly(new PathwayDanglingGenericNodeNotice(stops.get(2)));
+  }
+
+  @Test
+  public void danglingGenericNodeWithTwoPathways_yieldsNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, GENERIC_NODE, 10),
+            createChildLocation(13, ENTRANCE, 10));
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createPathway(11, 13), createPathway(11, 12), createPathway(12, 11)),
+                stops))
+        .containsExactly(new PathwayDanglingGenericNodeNotice(stops.get(2)));
+  }
+
+  @Test
+  public void isolatedGenericNode_yieldsNoNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, GENERIC_NODE, 10),
+            createChildLocation(13, ENTRANCE, 10));
+    assertThat(generateNotices(ImmutableList.of(createPathway(11, 13)), stops)).isEmpty();
+  }
+
+  @Test
+  public void passThroughGenericNode_yieldsNoNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, GENERIC_NODE, 10),
+            createChildLocation(13, ENTRANCE, 10));
+    assertThat(
+            generateNotices(ImmutableList.of(createPathway(11, 12), createPathway(12, 13)), stops))
+        .isEmpty();
+  }
+
+  @Test
+  public void danglingPlatformAndEntrance_yieldsNoNotice() {
+    List<GtfsStop> stops =
+        ImmutableList.of(
+            createLocation(10, STATION),
+            createChildLocation(11, STOP, 10),
+            createChildLocation(12, ENTRANCE, 10));
+    assertThat(generateNotices(ImmutableList.of(createPathway(11, 12)), stops)).isEmpty();
+  }
+}


### PR DESCRIPTION
A dangling node has just one incident location in the pathway graph.
Such generic node is useless because there is no benefit in visiting it.
