### PR TITLE
fix: validate route, stops and agency consistency urls

### DIFF
--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -911,10 +911,11 @@
 
 | Field name     	| Description                                	| Type   	|
 |----------------	|--------------------------------------------	|--------	|
-| `csvRowNumber`  | The row number of the faulty record.       	| Long   	|
-| `routeId`       | The faulty record's id.                    	| String 	|
+| `routeCsvRowNumber`    | The row number of the faulty record from `routes.txt`.       	| Long   	|
+| `routeId`         | The faulty record's id.                    	| String 	|
 | `agencyId`    	| The faulty record's `routes.agency_id`.    	| String 	|
 | `routeUrl`     	| The duplicate URL value                    	| String 	|
+| `agencyCsvRowNumber`    | The row number of the faulty record from `agency.txt`.       	| Long   	|
 
 ##### Affected files
 * [`agency.txt`](http://gtfs.org/reference/static#agencytxt)
@@ -925,11 +926,11 @@
 
 | Field name     	| Description                                            	| Type   	|
 |----------------	|--------------------------------------------------------	|--------	|
-| `csvRowNumber` 	| The row number of the faulty record.                   	| Long   	|
+| `stopCsvRowNumber`| The row number of the faulty record from `stops.txt`.     | Long   	|
 | `stopId`       	| The faulty record's id.                                	| String 	|
 | `agencyName`   	| The faulty record's `agency.agency_name`.              	| String 	|
-| `stopUrl`      	| The duplicate URL value.                                | String 	|
-| `csvRowNumber` 	| The row number of the faulty record from `agency.txt`. 	| Long   	|
+| `stopUrl`      	| The duplicate URL value.                                  | String 	|
+| `agencyCsvRowNumber` 	| The row number of the faulty record from `agency.txt`.|  Long   	|
 
 ##### Affected files
 * [`agency.txt`](http://gtfs.org/reference/static#agencytxt)
@@ -940,7 +941,7 @@
 
 | Field name          	| Description                                            	| Type   	|
 |---------------------	|--------------------------------------------------------	|--------	|
-| `csvRowNumber`      	| The row number of the faulty record.                   	| Long   	|
+| `stopsvRowNumber`     | The row number of the faulty record from `stops.txt`.    	| Long   	|
 | `stopId`            	| The faulty record's id.                                	| String 	|
 | `stopUrl`           	| The duplicate URL value.                                | String 	|
 | `routeId`           	| The faulty record's id from `routes.txt.               	| String 	|

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
@@ -110,14 +110,11 @@ public class UrlConsistencyValidator extends FileValidator {
    */
   private ListMultimap<String, GtfsAgency> agenciesByUrlMap(GtfsAgencyTableContainer agencyTable) {
     ListMultimap<String, GtfsAgency> agenciesByUrl = ArrayListMultimap.create();
-    agencyTable
-        .getEntities()
-        .forEach(
-            agency -> {
-              if (agency.hasAgencyUrl()) {
-                agenciesByUrl.put(Ascii.toLowerCase(agency.agencyUrl()), agency);
-              }
-            });
+    for (GtfsAgency agency : agencyTable.getEntities()) {
+      if (agency.hasAgencyUrl()) {
+        agenciesByUrl.put(Ascii.toLowerCase(agency.agencyUrl()), agency);
+      }
+    }
     return agenciesByUrl;
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
@@ -19,7 +19,6 @@ package org.mobilitydata.gtfsvalidator.validator;
 import com.google.common.base.Ascii;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
-import java.util.List;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -77,8 +76,7 @@ public class UrlConsistencyValidator extends FileValidator {
       for (GtfsAgency agency : agencyByUrlMap.get(Ascii.toLowerCase(stop.stopUrl()))) {
         noticeContainer.addValidationNotice(new SameStopAndAgencyUrlNotice(stop, agency));
       }
-      List<GtfsRoute> routes = routesByUrlMap.get(Ascii.toLowerCase(stop.stopUrl()));
-      for (GtfsRoute route : routes) {
+      for (GtfsRoute route : routesByUrlMap.get(Ascii.toLowerCase(stop.stopUrl()))) {
         noticeContainer.addValidationNotice(new SameStopAndRouteUrlNotice(stop, route));
       }
     }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidatorTest.java
@@ -134,11 +134,15 @@ public class UrlConsistencyValidatorTest {
             createAgency(8, "some agency name value", null));
 
     ImmutableList<GtfsStop> stops =
-        ImmutableList.of(createStop(456, "www.mobilitydata.org"), createStop(55, null));
+        ImmutableList.of(
+            createStop(456, "www.mobilitydata.org"),
+            createStop(55, null),
+            createStop(77, "www.anotherurl.com"));
     assertThat(generateNotices(agencies, ImmutableList.of(), stops))
         .containsExactly(
             new SameStopAndAgencyUrlNotice(stops.get(0), agencies.get(0)),
-            new SameStopAndAgencyUrlNotice(stops.get(0), agencies.get(2)));
+            new SameStopAndAgencyUrlNotice(stops.get(0), agencies.get(2)),
+            new SameStopAndAgencyUrlNotice(stops.get(2), agencies.get(1)));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidatorTest.java
@@ -62,11 +62,11 @@ public class UrlConsistencyValidatorTest {
         .build();
   }
 
-  private static GtfsRoute createRoute(String agencyId, String routeUrl) {
+  private static GtfsRoute createRoute(long csvRowNumber, String agencyId, String routeUrl) {
     return new GtfsRoute.Builder()
-        .setCsvRowNumber(3)
+        .setCsvRowNumber(csvRowNumber)
         .setRouteUrl(routeUrl)
-        .setRouteId("route id value")
+        .setRouteId(String.format("route id %s", csvRowNumber))
         .setAgencyId(agencyId)
         .setRouteShortName("route short name value")
         .setRouteLongName("route long name value")
@@ -74,10 +74,10 @@ public class UrlConsistencyValidatorTest {
         .build();
   }
 
-  private static GtfsStop createStop(long csvRowNumber, String stopId, String stopUrl) {
+  private static GtfsStop createStop(long csvRowNumber, String stopUrl) {
     return new GtfsStop.Builder()
         .setCsvRowNumber(csvRowNumber)
-        .setStopId(stopId)
+        .setStopId(String.format("stop id %s", csvRowNumber))
         .setStopUrl(stopUrl)
         .build();
   }
@@ -90,23 +90,26 @@ public class UrlConsistencyValidatorTest {
                     createAgency(0, "first agency id value", "www.mobilitydata.org"),
                     createAgency(2, "other agency id value", "www.someotherurl")),
                 ImmutableList.of(
-                    createRoute("first agency id value", "www.atotallydifferenturl.com")),
+                    createRoute(4, "first agency id value", "www.atotallydifferenturl.com")),
                 ImmutableList.of()))
         .isEmpty();
   }
 
   @Test
   public void sameRouteAndAgencyUrl_generatesNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(
-                    createAgency(0, "first agency name value", "www.mobilitydata.org"),
-                    createAgency(2, "other agency name value", "www.anotherurl.com")),
-                ImmutableList.of(createRoute("route id value", "www.mobilitydata.org")),
-                ImmutableList.of()))
+    ImmutableList<GtfsAgency> agencies =
+        ImmutableList.of(
+            createAgency(0, "first agency name value", "www.mobilitydata.org"),
+            createAgency(2, "other agency name value", "www.anotherurl.com"),
+            createAgency(6, "another agency name value", "www.MobilityData.org"));
+    ImmutableList<GtfsRoute> routes =
+        ImmutableList.of(
+            createRoute(3, "route id value", "www.mobilitydata.org"),
+            createRoute(4, "other route id value", null));
+    assertThat(generateNotices(agencies, routes, ImmutableList.of()))
         .containsExactly(
-            new SameRouteAndAgencyUrlNotice(
-                3, "route id value", "first agency name value", "www.mobilitydata.org", 0));
+            new SameRouteAndAgencyUrlNotice(routes.get(0), agencies.get(0)),
+            new SameRouteAndAgencyUrlNotice(routes.get(0), agencies.get(2)));
   }
 
   @Test
@@ -117,22 +120,25 @@ public class UrlConsistencyValidatorTest {
                     createAgency(0, "first agency id value", "www.mobilitydata.org"),
                     createAgency(2, "other agency id value", "www.someotherurl")),
                 ImmutableList.of(),
-                ImmutableList.of(createStop(44, "stop id value", "stop url value"))))
+                ImmutableList.of(createStop(44, "stop url value"))))
         .isEmpty();
   }
 
   @Test
   public void sameStopAndAgencyUrl_generatesNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(
-                    createAgency(0, "first agency name value", "www.mobilitydata.org"),
-                    createAgency(2, "other agency name value", "www.anotherurl.com")),
-                ImmutableList.of(),
-                ImmutableList.of(createStop(456, "stop id value", "www.mobilitydata.org"))))
+    ImmutableList<GtfsAgency> agencies =
+        ImmutableList.of(
+            createAgency(0, "first agency name value", "www.mobilitydata.org"),
+            createAgency(2, "other agency name value", "www.anotherurl.com"),
+            createAgency(4, "another agency name value", "www.mobilitydata.org"),
+            createAgency(8, "some agency name value", null));
+
+    ImmutableList<GtfsStop> stops =
+        ImmutableList.of(createStop(456, "www.mobilitydata.org"), createStop(55, null));
+    assertThat(generateNotices(agencies, ImmutableList.of(), stops))
         .containsExactly(
-            new SameStopAndAgencyUrlNotice(
-                456, "stop id value", "first agency name value", "www.mobilitydata.org", 0));
+            new SameStopAndAgencyUrlNotice(stops.get(0), agencies.get(0)),
+            new SameStopAndAgencyUrlNotice(stops.get(0), agencies.get(2)));
   }
 
   @Test
@@ -140,20 +146,21 @@ public class UrlConsistencyValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(),
-                ImmutableList.of(createRoute("first agency id value", "www.mobilitydata.org")),
-                ImmutableList.of(createStop(44, "stop id value", "stop url value"))))
+                ImmutableList.of(createRoute(8, "first agency id value", "www.mobilitydata.org")),
+                ImmutableList.of(createStop(44, "stop url value"))))
         .isEmpty();
   }
 
   @Test
   public void sameStopAndRouteUrl_generatesNotice() {
-    assertThat(
-            generateNotices(
-                ImmutableList.of(),
-                ImmutableList.of(createRoute("first agency id value", "www.mobilitydata.org")),
-                ImmutableList.of(createStop(456, "stop id value", "www.mobilitydata.org"))))
+    ImmutableList<GtfsRoute> routes =
+        ImmutableList.of(createRoute(5, "first agency id value", "www.mobilitydata.org"));
+    ImmutableList<GtfsStop> stops =
+        ImmutableList.of(
+            createStop(456, "www.mobilitydata.org"), createStop(88, "www.mobilitYData.org"));
+    assertThat(generateNotices(ImmutableList.of(), routes, stops))
         .containsExactly(
-            new SameStopAndRouteUrlNotice(
-                456, "stop id value", "www.mobilitydata.org", "route id value", 3));
+            new SameStopAndRouteUrlNotice(stops.get(0), routes.get(0)),
+            new SameStopAndRouteUrlNotice(stops.get(1), routes.get(0)));
   }
 }


### PR DESCRIPTION
relates to #907 and #909 

**Summary:**

This PR reworks the rule logic implemented in #932: 

**Expected behavior:** 

- a notice is generated for each stop/agency/route whose url is duplicate.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
