### PR TITLE
feat: Return Optional from byXyz methods

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/StopUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/StopUtil.java
@@ -35,12 +35,16 @@ public class StopUtil {
   public static S2LatLng getStopOrParentLatLng(GtfsStopTableContainer stopTable, String stopId) {
     // Do not do an infinite loop since there may be a data bug and an infinite cycle of parents.
     for (int i = 0; i < 3; ++i) {
-      GtfsStop stop = stopTable.byStopId(stopId);
-      if (stop.hasStopLatLon()) {
-        return stop.stopLatLon();
+      Optional<GtfsStop> optionalLocation = stopTable.byStopId(stopId);
+      if (!optionalLocation.isPresent()) {
+        break;
       }
-      if (stop.hasParentStation()) {
-        stopId = stop.parentStation();
+      GtfsStop location = optionalLocation.get();
+      if (location.hasStopLatLon()) {
+        return location.stopLatLon();
+      }
+      if (location.hasParentStation()) {
+        stopId = location.parentStation();
       } else {
         break;
       }
@@ -66,10 +70,11 @@ public class StopUtil {
       GtfsStopTableContainer stopTable, String stopId) {
     // Do not do an infinite loop since there may be a data bug and an infinite cycle of parents.
     for (int i = 0; i < 3; ++i) {
-      GtfsStop location = stopTable.byStopId(stopId);
-      if (location == null) {
+      Optional<GtfsStop> optionalLocation = stopTable.byStopId(stopId);
+      if (!optionalLocation.isPresent()) {
         break;
       }
+      GtfsStop location = optionalLocation.get();
       if (location.locationType().equals(GtfsLocationType.STATION)) {
         return Optional.of(location);
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsTripServiceIdForeignKeyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsTripServiceIdForeignKeyValidator.java
@@ -71,7 +71,7 @@ public class GtfsTripServiceIdForeignKeyValidator extends FileValidator {
       String childKey,
       GtfsCalendarTableContainer calendarContainer,
       GtfsCalendarDateTableContainer calendarDateContainer) {
-    return calendarContainer.byServiceId(childKey) != null
+    return calendarContainer.byServiceId(childKey).isPresent()
         || !calendarDateContainer.byServiceId(childKey).isEmpty();
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingLevelIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingLevelIdValidator.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
@@ -59,9 +60,9 @@ public class MissingLevelIdValidator extends FileValidator {
       }
     }
     for (String stopId : elevatorEndpoints) {
-      GtfsStop location = stops.byStopId(stopId);
-      if (location != null && !location.hasLevelId()) {
-        noticeContainer.addValidationNotice(new MissingLevelIdNotice(location));
+      Optional<GtfsStop> location = stops.byStopId(stopId);
+      if (location.isPresent() && !location.get().hasLevelId()) {
+        noticeContainer.addValidationNotice(new MissingLevelIdNotice(location.get()));
       }
     }
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
+import java.util.Optional;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -58,7 +59,12 @@ public class ParentLocationTypeValidator extends FileValidator {
       if (!location.hasParentStation()) {
         continue;
       }
-      GtfsStop parentLocation = stopTable.byStopId(location.parentStation());
+      Optional<GtfsStop> optionalParentLocation = stopTable.byStopId(location.parentStation());
+      if (!optionalParentLocation.isPresent()) {
+        // Broken reference is reported in another rule.
+        continue;
+      }
+      GtfsStop parentLocation = optionalParentLocation.get();
       GtfsLocationType expected = expectedParentLocationType(location.locationType());
       if (expected != GtfsLocationType.UNRECOGNIZED && parentLocation.locationType() != expected) {
         noticeContainer.addValidationNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
+import java.util.Optional;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -67,8 +68,12 @@ public class PathwayEndpointTypeValidator extends FileValidator {
 
   private void checkEndpoint(
       GtfsPathway pathway, String fieldName, String stopId, NoticeContainer noticeContainer) {
-    GtfsStop stop = stopTable.byStopId(stopId);
-    switch (stop.locationType()) {
+    Optional<GtfsStop> stop = stopTable.byStopId(stopId);
+    if (!stop.isPresent()) {
+      // Broken reference is reported in another rule.
+      return;
+    }
+    switch (stop.get().locationType()) {
       case STOP:
         if (!stopTable.byParentStation(stopId).isEmpty()) {
           noticeContainer.addValidationNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
@@ -23,12 +23,14 @@ import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsShape;
 import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
@@ -120,19 +122,21 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       final ShapePoints shapePoints = ShapePoints.fromGtfsShape(gtfsShapePoints);
       // Report each stop that is too far from shape only once, even if there are multiple trips
       // that visit it.
-      Set<Long> processedtripHashes = new HashSet<>();
+      Set<Long> processedTripHashes = new HashSet<>();
       Set<String> reportedStopIds = new HashSet<>();
       for (GtfsTrip trip : trips) {
         List<GtfsStopTime> stopTimes = stopTimeTable.byTripId(trip.tripId());
-        if (!processedtripHashes.add(tripHash(stopTimes))) {
+        if (!processedTripHashes.add(tripHash(stopTimes))) {
+          continue;
+        }
+        Optional<GtfsRoute> route = routeTable.byRouteId(trip.routeId());
+        if (!route.isPresent()) {
+          // Broken reference is reported in another rule.
           continue;
         }
         final StopPoints stopPoints =
             StopPoints.fromStopTimes(
-                stopTimes,
-                stopTable,
-                StopPoints.routeTypeToStationSize(
-                    routeTable.byRouteId(trip.routeId()).routeType()));
+                stopTimes, stopTable, StopPoints.routeTypeToStationSize(route.get().routeType()));
 
         reportProblems(
             trip,
@@ -177,36 +181,37 @@ public class ShapeToStopMatchingValidator extends FileValidator {
             ? new StopTooFarFromShapeNotice(
                 trip,
                 problem.getStopTime(),
-                stopForStopTime(problem.getStopTime()),
+                stopNameForStopTime(problem.getStopTime()),
                 problem.getMatch().getLocationLatLng(),
                 problem.getMatch().getGeoDistanceToShape())
             : new StopTooFarFromShapeUsingUserDistanceNotice(
                 trip,
                 problem.getStopTime(),
-                stopForStopTime(problem.getStopTime()),
+                stopNameForStopTime(problem.getStopTime()),
                 problem.getMatch().getLocationLatLng(),
                 problem.getMatch().getGeoDistanceToShape());
       case STOPS_MATCH_OUT_OF_ORDER:
         return new StopsMatchShapeOutOfOrderNotice(
             trip,
             problem.getStopTime(),
-            stopForStopTime(problem.getStopTime()),
+            stopNameForStopTime(problem.getStopTime()),
             problem.getMatch().getLocationLatLng(),
             problem.getPrevStopTime(),
-            stopForStopTime(problem.getPrevStopTime()),
+            stopNameForStopTime(problem.getPrevStopTime()),
             problem.getPrevMatch().getLocationLatLng());
       default: // STOP_HAS_TOO_MANY_MATCHES
         return new StopHasTooManyMatchesForShapeNotice(
             trip,
             problem.getStopTime(),
-            stopForStopTime(problem.getStopTime()),
+            stopNameForStopTime(problem.getStopTime()),
             problem.getMatch().getLocationLatLng(),
             problem.getMatchCount());
     }
   }
 
-  private GtfsStop stopForStopTime(GtfsStopTime stopTime) {
-    return stopTable.byStopId(stopTime.stopId());
+  private String stopNameForStopTime(GtfsStopTime stopTime) {
+    Optional<GtfsStop> stop = stopTable.byStopId(stopTime.stopId());
+    return stop.isPresent() ? stop.get().stopName() : "";
   }
 
   private enum MatchingDistance {
@@ -241,14 +246,14 @@ public class ShapeToStopMatchingValidator extends FileValidator {
     private final int matchCount;
 
     StopHasTooManyMatchesForShapeNotice(
-        GtfsTrip trip, GtfsStopTime stopTime, GtfsStop stop, S2LatLng location, int matchCount) {
+        GtfsTrip trip, GtfsStopTime stopTime, String stopName, S2LatLng location, int matchCount) {
       super(SeverityLevel.WARNING);
       this.tripCsvRowNumber = trip.csvRowNumber();
       this.shapeId = trip.shapeId();
       this.tripId = trip.tripId();
       this.stopTimeCsvRowNumber = stopTime.csvRowNumber();
       this.stopId = stopTime.stopId();
-      this.stopName = stop.stopName();
+      this.stopName = stopName;
       this.match = location;
       this.matchCount = matchCount;
     }
@@ -275,7 +280,7 @@ public class ShapeToStopMatchingValidator extends FileValidator {
     StopTooFarFromShapeUsingUserDistanceNotice(
         GtfsTrip trip,
         GtfsStopTime stopTime,
-        GtfsStop stop,
+        String stopName,
         S2LatLng location,
         double geoDistanceToShape) {
       super(SeverityLevel.WARNING);
@@ -284,7 +289,7 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       this.tripId = trip.tripId();
       this.stopTimeCsvRowNumber = stopTime.csvRowNumber();
       this.stopId = stopTime.stopId();
-      this.stopName = stop.stopName();
+      this.stopName = stopName;
       this.match = location;
       this.geoDistanceToShape = geoDistanceToShape;
     }
@@ -309,7 +314,7 @@ public class ShapeToStopMatchingValidator extends FileValidator {
     StopTooFarFromShapeNotice(
         GtfsTrip trip,
         GtfsStopTime stopTime,
-        GtfsStop stop,
+        String stopName,
         S2LatLng location,
         double geoDistanceToShape) {
       super(SeverityLevel.WARNING);
@@ -318,7 +323,7 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       this.tripId = trip.tripId();
       this.stopTimeCsvRowNumber = stopTime.csvRowNumber();
       this.stopId = stopTime.stopId();
-      this.stopName = stop.stopName();
+      this.stopName = stopName;
       this.match = location;
       this.geoDistanceToShape = geoDistanceToShape;
     }
@@ -348,10 +353,10 @@ public class ShapeToStopMatchingValidator extends FileValidator {
     public StopsMatchShapeOutOfOrderNotice(
         GtfsTrip trip,
         GtfsStopTime stopTime1,
-        GtfsStop stop1,
+        String stopName1,
         S2LatLng location1,
         GtfsStopTime stopTime2,
-        GtfsStop stop2,
+        String stopName2,
         S2LatLng location2) {
       super(SeverityLevel.WARNING);
       this.tripCsvRowNumber = trip.csvRowNumber();
@@ -359,11 +364,11 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       this.tripId = trip.tripId();
       this.stopTimeCsvRowNumber1 = stopTime1.csvRowNumber();
       this.stopId1 = stopTime1.stopId();
-      this.stopName1 = stop1.stopName();
+      this.stopName1 = stopName1;
       this.match1 = location1;
       this.stopTimeCsvRowNumber2 = stopTime2.csvRowNumber();
       this.stopId2 = stopTime2.stopId();
-      this.stopName2 = stop2.stopName();
+      this.stopName2 = stopName2;
       this.match2 = location2;
     }
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsLevelTableLoaderTest.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.table;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth8.assertThat;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -24,6 +25,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -72,8 +74,9 @@ public class GtfsLevelTableLoaderTest {
 
     assertThat(noticeContainer.getValidationNotices()).isEmpty();
     assertThat(tableContainer.entityCount()).isEqualTo(1);
-    GtfsLevel level = tableContainer.byLevelId("level1");
-    assertThat(level).isNotNull();
+    Optional<GtfsLevel> optionalLevel = tableContainer.byLevelId("level1");
+    assertThat(optionalLevel).isPresent();
+    GtfsLevel level = optionalLevel.get();
     assertThat(level.levelId()).isEqualTo("level1");
     assertThat(level.levelName()).isEqualTo("Ground");
     assertThat(level.levelIndex()).isEqualTo(1);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidatorTest.java
@@ -152,4 +152,23 @@ public class ParentLocationTypeValidatorTest {
     assertThat(validateNoParent(GtfsLocationType.GENERIC_NODE)).isEmpty();
     assertThat(validateNoParent(GtfsLocationType.BOARDING_AREA)).isEmpty();
   }
+
+  @Test
+  public void foreignKeyViolation_handledGracefully() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new ParentLocationTypeValidator(
+            GtfsStopTableContainer.forEntities(
+                ImmutableList.of(
+                    new GtfsStop.Builder()
+                        .setCsvRowNumber(1)
+                        .setStopId("child")
+                        .setStopName("Child location")
+                        .setLocationType(GtfsLocationType.STOP)
+                        .setParentStation("parent")
+                        .build()),
+                noticeContainer))
+        .validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidatorTest.java
@@ -234,7 +234,7 @@ public class ShapeToStopMatchingValidatorTest {
             new StopTooFarFromShapeNotice(
                 trip,
                 stopTimes.get(1),
-                stops.get(1),
+                stops.get(1).stopName(),
                 S2LatLng.fromDegrees(47.366073, 8.525384),
                 150.578313));
   }
@@ -262,7 +262,7 @@ public class ShapeToStopMatchingValidatorTest {
             new StopHasTooManyMatchesForShapeNotice(
                 trip,
                 stopTimes.get(0),
-                stops.get(0),
+                stops.get(0).stopName(),
                 S2LatLng.fromDegrees(47.365034, 8.525651),
                 3));
   }
@@ -293,10 +293,10 @@ public class ShapeToStopMatchingValidatorTest {
             new StopsMatchShapeOutOfOrderNotice(
                 trip,
                 stopTimes.get(1),
-                stops.get(1),
+                stops.get(1).stopName(),
                 S2LatLng.fromDegrees(47.366044, 8.525183),
                 stopTimes.get(0),
-                stops.get(0),
+                stops.get(0).stopName(),
                 S2LatLng.fromDegrees(47.364081, 8.525713)));
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/ForeignKeyValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/ForeignKeyValidatorGenerator.java
@@ -144,7 +144,7 @@ public class ForeignKeyValidatorGenerator {
             .addParameter(parentClasses.tableContainerTypeName(), "parentContainer");
     if (parentField.primaryKey()) {
       hasReferencedKeyMethod.addStatement(
-          "return parentContainer.$L(key) != null",
+          "return parentContainer.$L(key).isPresent()",
           FieldNameConverter.byKeyMethodName(parentField.name()));
     } else if (parentField.firstKey() || parentField.index()) {
       hasReferencedKeyMethod.addStatement(

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -122,9 +122,10 @@ public class TableContainerGenerator {
     typeSpec.addMethod(
         MethodSpec.methodBuilder(methodName)
             .addModifiers(Modifier.PUBLIC)
+            .addAnnotation(Nullable.class)
             .addParameter(TypeName.get(indexField.javaType()), "key")
-            .returns(entityTypeName)
-            .addStatement("return $L.get(key)", fieldName)
+            .returns(ParameterizedTypeName.get(ClassName.get(Optional.class), entityTypeName))
+            .addStatement("return Optional.ofNullable($L.getOrDefault(key, null))", fieldName)
             .build());
   }
 


### PR DESCRIPTION
Fix issue #1010

Any foreign key reference may be potentially broken. Authors of the
validator rules must bear that in mind and implement appropriate
behaviour.

A considered alternative is to run all foreign key checks separately -
but this is not preventing all bugs. E.g., trips.service_id is
referencing either calendar.txt or calendar_dates.txt.

```
  // This may raise NPE even if all foreign key checks succeded.
  calendarContainer.byServiceId(trip.serviceId())
```