### PR TITLE
fix: Catch any runtime exception when parsing a GTFS field

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -18,7 +18,6 @@ package org.mobilitydata.gtfsvalidator.parsing;
 
 import java.math.BigDecimal;
 import java.time.ZoneId;
-import java.time.zone.ZoneRulesException;
 import java.util.Currency;
 import java.util.Locale;
 import java.util.function.Function;
@@ -360,9 +359,9 @@ public class RowParser {
     }
     try {
       return parsingFunction.apply(s);
-    } catch (IllegalArgumentException | ZoneRulesException e) {
+    } catch (RuntimeException e) {
       // Most parsing functions throw an IllegalArgumentException but ZoneId.of() throws
-      // a ZoneRulesException.
+      // a ZoneRulesException or DateTimeException. Be sure to catch all of them.
       noticeContainer.addValidationNotice(
           noticingFunction.apply(
               fileName, row.getRowNumber(), header.getColumnName(columnIndex), s));

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -237,11 +237,18 @@ public class RowParserTest {
   }
 
   @Test
-  public void asTimezone() {
+  public void asTimezone_valid() {
     assertThat(createParser("America/Toronto").asTimezone(0, true))
         .isEqualTo(ZoneId.of("America/Toronto"));
+  }
 
+  @Test
+  public void asTimezone_invalid() {
+    // ZoneId.of("invalid") throws ZoneRulesException.
     assertThat(createParser("invalid").asTimezone(0, true)).isNull();
+
+    // ZoneId.of("Latinoamerica/ Argentina") throws DateTimeException.
+    assertThat(createParser("Latinoamerica/ Argentina").asTimezone(0, true)).isNull();
   }
 
   @Test


### PR DESCRIPTION
ZoneId.of can throw DateTimeException for certain arguments. To be
completely safe, we are catching any RuntimeException now.
