### PR TITLE
chore: Use LocalDate.EPOCH available in Java 11

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/ServicePeriod.java
@@ -16,13 +16,6 @@ import java.util.TreeSet;
  * <p>This class is immutable.
  */
 public class ServicePeriod {
-  /**
-   * The epoch year LocalDate, '1970-01-01'.
-   *
-   * <p>{@code LocalDate.EPOCH} is not available in Java 8, so we have to define it here.
-   */
-  public static final LocalDate EPOCH = LocalDate.of(1970, 1, 1);
-
   private final LocalDate serviceStart;
   private final LocalDate serviceEnd;
   private final byte weeklyPattern;
@@ -57,13 +50,13 @@ public class ServicePeriod {
   /**
    * Creates a service period from the given dates.
    *
-   * <p>serviceStart and serviceEnd will be set to {@link #EPOCH}.
+   * <p>serviceStart and serviceEnd will be set to {@link LocalDate#EPOCH}.
    *
    * @param dates service dates
    */
   public ServicePeriod(Set<LocalDate> dates) {
-    this.serviceStart = EPOCH;
-    this.serviceEnd = EPOCH;
+    this.serviceStart = LocalDate.EPOCH;
+    this.serviceEnd = LocalDate.EPOCH;
     this.weeklyPattern = 0;
     this.addedDays = Preconditions.checkNotNull(dates);
     this.removedDays = ImmutableSet.of();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/util/ServicePeriodTest.java
@@ -92,8 +92,8 @@ public class ServicePeriodTest {
   public void addedAndRemovedDays() {
     assertThat(
             new ServicePeriod(
-                    ServicePeriod.EPOCH,
-                    ServicePeriod.EPOCH,
+                    LocalDate.EPOCH,
+                    LocalDate.EPOCH,
                     (byte) 0,
                     ImmutableSortedSet.of(
                         LocalDate.of(2021, 1, 3),

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/CalendarUtil.java
@@ -56,8 +56,8 @@ public final class CalendarUtil {
               calendar.saturdayValue(),
               calendar.sundayValue());
     } else {
-      serviceStart = ServicePeriod.EPOCH;
-      serviceEnd = ServicePeriod.EPOCH;
+      serviceStart = LocalDate.EPOCH;
+      serviceEnd = LocalDate.EPOCH;
       weeklyPattern = 0;
     }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/ServiceIdIntersectionCache.java
@@ -13,7 +13,7 @@ import java.util.SortedSet;
  * <p>This class is not thread-safe.
  */
 public class ServiceIdIntersectionCache {
-  private static final LocalDate NO_OVERLAP = ServicePeriod.EPOCH;
+  private static final LocalDate NO_OVERLAP = LocalDate.EPOCH;
   private final Map<String, SortedSet<LocalDate>> serviceDates;
   // The cache stores LocalDate instead of Optional<LocalDate> for size
   // efficiency. If services do not overlap, we store null.

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/CalendarUtilTest.java
@@ -94,8 +94,8 @@ public class CalendarUtilTest {
   @Test
   public void createServicePeriod_empty() {
     ServicePeriod servicePeriod = CalendarUtil.createServicePeriod(null, ImmutableList.of());
-    assertThat(servicePeriod.getServiceStart()).isEqualTo(ServicePeriod.EPOCH);
-    assertThat(servicePeriod.getServiceEnd()).isEqualTo(ServicePeriod.EPOCH);
+    assertThat(servicePeriod.getServiceStart()).isEqualTo(LocalDate.EPOCH);
+    assertThat(servicePeriod.getServiceEnd()).isEqualTo(LocalDate.EPOCH);
     assertThat(servicePeriod.getWeeklyPattern()).isEqualTo(0);
     assertThat(servicePeriod.getAddedDays()).isEmpty();
     assertThat(servicePeriod.getRemovedDays()).isEmpty();
@@ -165,8 +165,8 @@ public class CalendarUtilTest {
                 ImmutableSet.of()),
             "s3",
             new ServicePeriod(
-                ServicePeriod.EPOCH,
-                ServicePeriod.EPOCH,
+                LocalDate.EPOCH,
+                LocalDate.EPOCH,
                 (byte) 0,
                 ImmutableSet.of(LocalDate.of(2021, 3, 8)),
                 ImmutableSet.of(LocalDate.of(2021, 3, 9))));
@@ -193,8 +193,8 @@ public class CalendarUtilTest {
                         ImmutableSet.of()),
                     "s3",
                     new ServicePeriod(
-                        ServicePeriod.EPOCH,
-                        ServicePeriod.EPOCH,
+                        LocalDate.EPOCH,
+                        LocalDate.EPOCH,
                         (byte) 0,
                         ImmutableSet.of(LocalDate.of(2021, 3, 8)),
                         ImmutableSet.of(LocalDate.of(2021, 3, 9))))))


### PR DESCRIPTION
GTFS Validator has upgraded from Java 8 to 11.
