### PR TITLE
fix: change limit on notice count during validation to 100_000

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -139,6 +139,7 @@ public class NoticeContainer {
       noticesOfTypeJson.add("notices", noticesArrayJson);
       int i = 0;
       for (T notice : noticesOfType) {
+        ++i;
         if (i > MAX_PER_NOTICE_TYPE_AND_SEVERITY) {
           // Do not export too many notices for this type.
           break;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -72,6 +72,7 @@ public class NoticeContainer {
     if (noticesForType.size() < maxValidationNoticePerType) {
       validationNotices.add(notice);
     }
+
   }
 
   /** Adds a new system error to the container (if there is capacity). */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -153,5 +153,4 @@ public class NoticeContainer {
     }
     return noticesByType;
   }
-
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -153,4 +153,5 @@ public class NoticeContainer {
     }
     return noticesByType;
   }
+
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 public class NoticeContainer {
   /** Limit on the amount of exported notices of the same type and severity. */
-  private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100000;
+  private static final int MAX_EXPORTS_PER_NOTICE_TYPE = 100_000;
 
   /**
    * Limit on the total amount of stored validation notices.
@@ -44,7 +44,7 @@ public class NoticeContainer {
    *
    * <p>Note that system errors are not limited since we don't expect to have a lot of them.
    */
-  private static final int MAX_VALIDATION_NOTICES = 10000000;
+  private static final int MAX_VALIDATION_NOTICES = 100_000;
 
   private final List<ValidationNotice> validationNotices = new ArrayList<>();
   private final List<SystemError> systemErrors = new ArrayList<>();

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -137,7 +137,12 @@ public class NoticeContainer {
       noticesOfTypeJson.addProperty("totalNotices", noticesOfType.size());
       JsonArray noticesArrayJson = new JsonArray();
       noticesOfTypeJson.add("notices", noticesArrayJson);
+      int i = 0;
       for (T notice : noticesOfType) {
+        if (i > MAX_PER_NOTICE_TYPE_AND_SEVERITY) {
+          // Do not export too many notices for this type.
+          break;
+        }
         noticesArrayJson.add(notice.getContext());
       }
     }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -62,7 +62,7 @@ public class NoticeContainer {
     if (notice.isError()) {
       hasValidationErrors = true;
     }
-    if (validationNotices.size() > maxTotalValidationNotices) {
+    if (validationNotices.size() >= maxTotalValidationNotices) {
       return;
     }
     ListMultimap<String, ValidationNotice> noticesOfType =

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -72,7 +72,6 @@ public class NoticeContainer {
     if (noticesForType.size() < maxValidationNoticePerType) {
       validationNotices.add(notice);
     }
-
   }
 
   /** Adds a new system error to the container (if there is capacity). */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -69,7 +69,7 @@ public class NoticeContainer {
         groupNoticesByTypeAndSeverity(validationNotices);
     List<ValidationNotice> noticesForType =
         noticesOfType.get(notice.getCode() + notice.getSeverityLevel().ordinal());
-    if (noticesForType == null || noticesForType.size() < maxValidationNoticePerType) {
+    if (noticesForType.size() < maxValidationNoticePerType) {
       validationNotices.add(notice);
     }
   }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -97,4 +97,31 @@ public class NoticeContainerTest {
     assertThat(c1.getValidationNotices()).containsExactly(n1, n2);
     assertThat(c1.getSystemErrors()).containsExactly(e1, e2);
   }
+
+  @Test
+  public void addValidationNotice_setMax_perNoticeType() {
+    ValidationNotice n1 = new MissingRequiredFileNotice("stops.txt");
+    ValidationNotice n2 = new UnknownFileNotice("unknown.txt");
+    NoticeContainer noticeContainer = new NoticeContainer();
+    int MAX_TOTAL_VALIDATION_NOTICES = 50;
+    int MAX_VALIDATION_NOTICES_PER_TYPE = 15;
+    for (int i = 0; i < MAX_TOTAL_VALIDATION_NOTICES + 5; i++) {
+      noticeContainer.addValidationNotice(
+          n1, MAX_TOTAL_VALIDATION_NOTICES, MAX_VALIDATION_NOTICES_PER_TYPE);
+      noticeContainer.addValidationNotice(
+          n2, MAX_TOTAL_VALIDATION_NOTICES, MAX_VALIDATION_NOTICES_PER_TYPE);
+    }
+    assertThat(noticeContainer.getValidationNotices().size())
+        .isEqualTo(2 * MAX_VALIDATION_NOTICES_PER_TYPE);
+    assertThat(
+            NoticeContainer.groupNoticesByTypeAndSeverity(noticeContainer.getValidationNotices())
+                .get(n1.getCode() + n1.getSeverityLevel().ordinal())
+                .size())
+        .isEqualTo(15);
+    assertThat(
+            NoticeContainer.groupNoticesByTypeAndSeverity(noticeContainer.getValidationNotices())
+                .get(n2.getCode() + n2.getSeverityLevel().ordinal())
+                .size())
+        .isEqualTo(15);
+  }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -99,7 +99,7 @@ public class NoticeContainerTest {
   }
 
   @Test
-  public void addValidationNotice_setMax_perNoticeType() {
+  public void addValidationNotice_setMax_perNoticeTypeAndSeverity() {
     ValidationNotice n1 = new MissingRequiredFileNotice("stops.txt");
     ValidationNotice n2 = new UnknownFileNotice("unknown.txt");
     NoticeContainer noticeContainer = new NoticeContainer();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -124,4 +124,21 @@ public class NoticeContainerTest {
                 .size())
         .isEqualTo(15);
   }
+
+  @Test
+  public void addValidationNotice_setMaxTotalValidationNotices() {
+    ValidationNotice n1 = new MissingRequiredFileNotice("stops.txt");
+    ValidationNotice n2 = new UnknownFileNotice("unknown.txt");
+    NoticeContainer noticeContainer = new NoticeContainer();
+    int MAX_TOTAL_VALIDATION_NOTICES = 30;
+    int MAX_VALIDATION_NOTICES_PER_TYPE = 16;
+    for (int i = 0; i < MAX_TOTAL_VALIDATION_NOTICES + 5; i++) {
+      noticeContainer.addValidationNotice(
+          n1, MAX_TOTAL_VALIDATION_NOTICES, MAX_VALIDATION_NOTICES_PER_TYPE);
+      noticeContainer.addValidationNotice(
+          n2, MAX_TOTAL_VALIDATION_NOTICES, MAX_VALIDATION_NOTICES_PER_TYPE);
+    }
+    assertThat(noticeContainer.getValidationNotices().size())
+        .isEqualTo(MAX_TOTAL_VALIDATION_NOTICES);
+  }
 }


### PR DESCRIPTION
closes #959 

**Summary:**

This PR provides support to change the limits on the number of `ValidationNotice`s  during validation.

**Expected behavior:** 

NoticeContainer will impose these types of limitations:

1. Limit total number of added notices to 10M (during validation)
2. Limit total number of notices with same type and severity to 100k (during validation)

The post-validation limit number of JSON-exported notices per notice type to 100k becomes implicit since no more than 100k notices of the same type (and severity) can be added to the `NoticeContainer`


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
