### PR TITLE
chore: upgrade EmptyColumnNameNotice to ERROR

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -76,6 +76,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)                                                             | Duplicated column in CSV.                                                                                                                              |
 | [`DuplicateFareRuleZoneIdFieldsNotice`](#DuplicateFareRuleZoneIdFieldsNotice)                                   | Duplicate rows from `fare_rules.txt` based on `fare_rules.route_id`, `fare_rules.origin_id`, `fare_rules.contains_id` and `fare_rules.destination_id`. |
 | [`DuplicateKeyNotice`](#DuplicateKeyNotice)                                                                     | Duplicated entity.                                                                                                                                     |
+| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                                            	  | A column name is empty.                                                                                                                                |
 | [`EmptyFileNotice`](#EmptyFileNotice)                                                                           | A CSV file is empty.                                                                                                                                   |
 | [`ForeignKeyViolationNotice`](#ForeignKeyViolationNotice)                                                       | Wrong foreign key.                                                                                                                                     |
 | [`InconsistentAgencyTimezoneNotice`](#InconsistentAgencyTimezoneNotice)                                         | Inconsistent Timezone among agencies.                                                                                                                  |
@@ -119,7 +120,6 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 |-----------------------------------------------------------------------------------	|-------------------------------------------------------------------------------------------------------------------------------------------------------------	|
 | [`AttributionWithoutRoleNotice`](#AttributionWithoutRoleNotice)                   	| Attribution with no role.                                                                                                                                   	|
 | [`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)                           	| Duplicate  `routes.route_long_name`. Duplicate `routes.route_short_name`. Duplicate combination of fields `route_long_name`  and `routes.route_short_name`. 	|
-| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                 	| A column name is empty.                                                                                                                                     	|
 | [`EmptyRowNotice`](#EmptyRowNotice)                                               	| A row in the input file has only spaces.                                                                                                                      |
 | [`FastTravelBetweenConsecutiveStopsNotice`](#FastTravelBetweenConsecutiveStopsNotice) | A transit vehicle moves too fast between two consecutive stops.                                                                            	                |
 | [`FastTravelBetweenFarStopsNotice`](#FastTravelBetweenFarStopsNotice)                 | A transit vehicle moves too fast between two far stops.                                                                            	                        |
@@ -236,6 +236,15 @@ The values of the given key and rows are duplicates.
 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)
+
+<a name="EmptyColumnNameNotice"/>
+
+#### EmptyColumnNameNotice
+
+A column name has not been provided. Such columns are skipped by the validator.
+
+##### References:
+* [GTFS file requirements](http://gtfs.org/reference/static/#file-requirements)
 
 <a name="EmptyFileNotice"/>
 
@@ -592,14 +601,6 @@ Note that there may be valid cases where routes have the same short and long nam
 ##### References:
 * [routes.txt specification](http://gtfs.org/reference/static/#routestxt)
 * [routes.txt best practices](http://gtfs.org/best-practices/#routestxt)
-<a name="EmptyColumnNameNotice"/>
-
-#### EmptyColumnNameNotice
-
-A column name has not been provided. Such columns are skipped by the validator.
-
-##### References:
-* [GTFS file requirements](http://gtfs.org/reference/static/#file-requirements)
 
 <a name="EmptyRowNotice"/>
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
@@ -19,14 +19,14 @@ package org.mobilitydata.gtfsvalidator.notice;
 /**
  * A column name is empty. Such columns are skipped by the validator.
  *
- * <p>Severity: {@code SeverityLevel.WARNING}
+ * <p>Severity: {@code SeverityLevel.ERROR}
  */
 public class EmptyColumnNameNotice extends ValidationNotice {
   private final String filename;
   private final int index;
 
   public EmptyColumnNameNotice(String filename, int index) {
-    super(SeverityLevel.WARNING);
+    super(SeverityLevel.ERROR);
     this.filename = filename;
     this.index = index;
   }

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -14,6 +14,7 @@
 | `duplicated_column`                                    	| [`DuplicatedColumnNotice`](#DuplicatedColumnNotice)                                                             	|
 | `duplicate_fare_rule_zone_id_fields`                   	| [`DuplicateFareRuleZoneIdFieldsNotice`](#DuplicateFareRuleZoneIdFieldsNotice)                                   	|
 | `duplicate_key`                                        	| [`DuplicateKeyNotice`](#DuplicateKeyNotice)                                                                     	|
+| `empty_column_name`                                   	| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                         	                    |
 | `empty_file`                                           	| [`EmptyFileNotice`](#EmptyFileNotice)                                                                           	|
 | `foreign_key_violation`                                	| [`ForeignKeyViolationNotice`](#ForeignKeyViolationNotice)                                                       	|
 | `inconsistent_agency_timezone`                         	| [`InconsistentAgencyTimezoneNotice`](#InconsistentAgencyTimezoneNotice)                                         	|
@@ -150,6 +151,17 @@
 | `fieldValue1`    	| Composite key's first value.       	| Object 	|
 | `fieldName2`     	| Composite key's second field name. 	| String 	|
 | `fieldValue2`    	| Composite key's second value.      	| Object 	|
+
+##### Affected files
+[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
+
+#### [EmptyColumnNameNotice](/RULES.md#EmptyColumnNameNotice)
+##### Fields description
+
+| Field name 	| Description                    	  | Type    	|
+|------------	|---------------------------------	|---------	|
+| `filename`   	| The name of the faulty file.   	| String   	|
+| `index`      	| The index of the empty column. 	| Integer 	|
 
 ##### Affected files
 [All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
@@ -614,7 +626,6 @@
 |--------------------------------------------	|-----------------------------------------------------------------------------------	|
 | `attribution_without_role`           	      | [`AttributionWithoutRoleNotice`](#AttributionWithoutRoleNotice)                   	|
 | `duplicate_route_name`                      | [`DuplicateRouteNameNotice`](#DuplicateRouteNameNotice)                           	|
-| `empty_column_name`                        	| [`EmptyColumnNameNotice`](#EmptyColumnNameNotice)                                 	|
 | `empty_row`                                	| [`EmptyRowNotice`](#EmptyRowNotice)                                               	|
 | `fast_travel_between_consecutive_stops`      	| [`FastTravelBetweenConsecutiveStopsNotice`](#FastTravelBetweenConsecutiveStopsNotice) |
 | `fast_travel_between_far_stops`               | [`FastTravelBetweenFarStopsNotice`](#FastTravelBetweenFarStopsNotice)                 |
@@ -676,17 +687,6 @@
 
 ##### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
-
-#### [EmptyColumnNameNotice](/RULES.md#EmptyColumnNameNotice)
-##### Fields description
-
-| Field name 	| Description                    	  | Type    	|
-|------------	|---------------------------------	|---------	|
-| `filename`   	| The name of the faulty file.   	| String   	|
-| `index`      	| The index of the empty column. 	| Integer 	|
-
-##### Affected files
-[All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
 
 #### [EmptyRowNotice](/RULES.md#EmptyRowNotice)
 ##### Fields description


### PR DESCRIPTION
closes #1017 
 **Summary:**

This PR provides support to upgrade `EmptyColumnNameNotice` to ERROR.

**Expected behavior:** 

`EmptyColumnNameNotice`:
> The first line of each file must contain field names.

https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#file-requirements

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
