### PR TITLE
chore: upgrade TranslationForeignKeyViolationNotice to ERROR

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -111,6 +111,7 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) | Backwards time travel between stops in `stop_times.txt`                                                                                                |
 | [`StopTimeWithOnlyArrivalOrDepartureTimeNotice`](#StopTimeWithOnlyArrivalOrDepartureTimeNotice)                 | Missing `stop_times.arrival_time` or `stop_times.departure_time`.                                                                                      |
 | [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                                                           | Stop without value for `stops.zone_id`.                                                                                                                |
+| [`TranslationForeignKeyViolationNotice`](#TranslationForeignKeyViolationNotice)                                 | An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.                                                      |
 | [`TranslationUnexpectedValueNotice`](#TranslationUnexpectedValueNotice)                                         | A field in a translations row has value but must be empty.                                                                                             |
 | [`WrongParentLocationTypeNotice`](#WrongParentLocationTypeNotice)                                               | Incorrect type of the parent location.                                                                                                                 |
 
@@ -147,7 +148,6 @@ Additional details regarding the notices' context is provided in [`NOTICES.md`](
 | [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	| `arrival_time` or `departure_time` not specified for timepoint.                                                                                             	|
 | [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	| Stop too far from trip shape.                                                                                                                               	|
 | [`StopWithoutStopTimeNotice`](#StopWithoutStopTimeNotice)                             | A stop in `stops.txt` is not referenced by any `stop_times.stop_id`.                                                                                          |
-| [`TranslationForeignKeyViolationNotice`](#TranslationForeignKeyViolationNotice)       | An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.                                                             |
 | [`TranslationUnknownTableNameNotice`](#TranslationUnknownTableNameNotice)             | A translation references an unknown or missing GTFS table.                                                                                                    |
 | [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	| An enum has an unexpected value.                                                                                                                            	|
 | [`UnusableTripNotice`](#UnusableTripNotice)                                       	| Trips must have more than one stop to be usable.                                                                                                            	|
@@ -571,6 +571,15 @@ If `fare_rules.txt` is provided, then all stops and platforms (location_type = 0
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)
 
+<a name="TranslationForeignKeyViolationNotice"/>
+
+#### TranslationForeignKeyViolationNotice
+
+An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.
+
+##### References:
+* [translations.txt specification](http://gtfs.org/reference/static/#translationstxt)
+
 <a name="TranslationUnexpectedValueNotice"/>
 
 #### TranslationUnexpectedValueNotice
@@ -883,15 +892,6 @@ Per GTFS Best Practices, route alignments (in `shapes.txt`) should be within 100
 
 A stop in `stops.txt` is not referenced by any `stop_times.stop_id`, so it is not used by any trip.
 Such stops normally do not provide user value. This notice may indicate a typo in `stop_times.txt`.
-
-<a name="TranslationForeignKeyViolationNotice"/>
-
-#### TranslationForeignKeyViolationNotice
-
-An entity with the given `record_id` and `record_sub_id` cannot be found in the referenced table.
-
-##### References:
-* [translations.txt specification](http://gtfs.org/reference/static/#translationstxt)
 
 <a name="TranslationUnknownTableNameNotice"/>
 

--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -47,6 +47,7 @@
 | `stop_without_zone_id`                     	            | [`StopWithoutZoneIdNotice`](#StopWithoutZoneIdNotice)                 	                                        |
 | `stop_time_wit_arrival_before_previous_departure_time` 	| [`StopTimeWithArrivalBeforePreviousDepartureTimeNotice`](#StopTimeWithArrivalBeforePreviousDepartureTimeNotice) 	|
 | `stop_time_with_only_arrival_or_departure_time`        	| [`StopTimeWithOnlyArrivalOrDepartureTimeNotice`](#StopTimeWithOnlyArrivalOrDepartureTimeNotice)                 	|
+| `translation_foreign_key_violation`                       | [`TranslationForeignKeyViolationNotice`](#TranslationForeignKeyViolationNotice)	                                |
 | `translation_unexpected_value`                           	| [`TranslationUnexpectedValueNotice`](#TranslationUnexpectedValueNotice)                                               	|
 | `wrong_parent_location_type`                           	| [`WrongParentLocationTypeNotice`](#WrongParentLocationTypeNotice)                                               	|
 
@@ -617,6 +618,19 @@
 ##### Affected files
 * [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
 
+#### [`TranslationForeignKeyViolationNotice`](/RULES.md#TranslationForeignKeyViolationNotice)
+##### Fields description
+
+| Field name       | Description                            | Type    	|
+|------------------|----------------------------------------|-------	|
+| `csvRowNumber`   | The row number of the faulty record.   | Long    	|
+| `tableName`      | `table_name` of the faulty record.     | String  	|
+| `recordId`       | `record_id` of the faulty record.      | String  	|
+| `recordSubId`    | `record_sub_id` of the faulty record.  | String  	|
+
+##### Affected files
+* [`translations.txt`](http://gtfs.org/reference/static#translationstxt)
+
 #### [`TranslationUnexpectedValueNotice`](/RULES.md#TranslationUnexpectedValueNotice)
 ##### Fields description
 
@@ -680,7 +694,6 @@
 | `stop_time_timepoint_without_times`        	| [`StopTimeTimepointWithoutTimesNotice`](#StopTimeTimepointWithoutTimesNotice)     	|
 | `stop_too_far_from_trip_shape`            	| [`StopTooFarFromTripShapeNotice`](#StopTooFarFromTripShapeNotice)                 	|
 | `too_fast_travel`                          	| [`TooFastTravelNotice`](#TooFastTravelNotice)                                     	|
-| `translation_foreign_key_violation`           | [`TranslationForeignKeyViolationNotice`](#TranslationForeignKeyViolationNotice)	    |
 | `translation_unknown_table_name`              | [`TranslationUnknownTableNameNotice`](#TranslationUnknownTableNameNotice)	            |
 | `unexpected_enum_value`                    	| [`UnexpectedEnumValueNotice`](#UnexpectedEnumValueNotice)                         	|
 | `unusable_trip`                            	| [`UnusableTripNotice`](#UnusableTripNotice)                                       	|
@@ -1060,19 +1073,6 @@
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
 * [`stop_times.txt`](http://gtfs.org/reference/static#stop_timestxt)
 * [`trips.txt`](http://gtfs.org/reference/static#tripstxt)
-
-#### [`TranslationForeignKeyViolationNotice`](/RULES.md#TranslationForeignKeyViolationNotice)
-##### Fields description
-
-| Field name       | Description                            | Type    	|
-|------------------|----------------------------------------|-------	|
-| `csvRowNumber`   | The row number of the faulty record.   | Long    	|
-| `tableName`      | `table_name` of the faulty record.     | String  	|
-| `recordId`       | `record_id` of the faulty record.      | String  	|
-| `recordSubId`    | `record_sub_id` of the faulty record.  | String  	|
-
-##### Affected files
-* [`translations.txt`](http://gtfs.org/reference/static#translationstxt)
 
 #### [`TranslationUnknownTableNameNotice`](/RULES.md#TranslationUnknownTableNameNotice)
 ##### Fields description

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -227,7 +227,7 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
     private final String recordSubId;
 
     TranslationForeignKeyViolationNotice(GtfsTranslation translation) {
-      super(SeverityLevel.WARNING);
+      super(SeverityLevel.ERROR);
       this.csvRowNumber = translation.csvRowNumber();
       this.tableName = translation.tableName();
       this.recordId = translation.recordId();


### PR DESCRIPTION
closes #1026 
 
 **Summary:**

This PR provides support to update `TranslationForeignKeyViolationNotice `: from `WARNING` to `ERROR`.

**Expected behavior:** 

According to the [specification](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md#translationstxt):

> The value in record_id must be a main ID of the table

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
