### PR TITLE
feat: Support Hierarchical Vehicle Types in StopTimeTravelSpeedValidator

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/HierarchicalVehicleType.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/HierarchicalVehicleType.java
@@ -1,0 +1,145 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
+
+/**
+ * Hierarchical Vehicle Type (HVT) codes from European TPEG standard provide a support a more rich
+ * set of vehicle types than the standard GTFS.
+ *
+ * <p>HVT are not a part of the GTFS standard (and probably won't be) but they are widely used. The
+ * standard GTFS validator emits a warning for a hierarchical vehicle type but nevertheless keeps
+ * its constant that can be retrieved via {@code GtfsRoute.routeTypeValue()}.
+ *
+ * <p>This class provides methods for validators that want to support HVT.
+ *
+ * @see <a href="https://developers.google.com/transit/gtfs/reference/extended-route-types">Extended
+ *     GTFS Route Types</a>
+ */
+public class HierarchicalVehicleType {
+
+  /**
+   * Converts hierarchical vehicle type (HVT) to basic GTFS route types.
+   *
+   * <p>If a basic GTFS route type is passed (e.g., 0-7), then it is returned as-is.
+   *
+   * <p>Returns {@link GtfsRouteType#UNRECOGNIZED} for HVT that can't be represented by a basic GTFS
+   * route type.
+   */
+  public static GtfsRouteType toBasicGtfsRouteType(int hierarchicalVehicleType) {
+    if (hierarchicalVehicleType >= 0 && hierarchicalVehicleType <= 7
+        || hierarchicalVehicleType == 11
+        || hierarchicalVehicleType == 12) {
+      return GtfsRouteType.forNumber(hierarchicalVehicleType);
+    }
+
+    switch (hierarchicalVehicleType) {
+      case COMMUNAL_TAXI:
+        return GtfsRouteType.BUS;
+      case MONORAIL:
+        return GtfsRouteType.MONORAIL;
+      default:
+        break;
+    }
+
+    switch ((hierarchicalVehicleType / 100) * 100) {
+      case RAILWAY_SERVICE:
+        return GtfsRouteType.RAIL;
+      case BUS_SERVICE:
+      case COACH_SERVICE:
+        return GtfsRouteType.BUS;
+      case URBAN_RAILWAY_SERVICE:
+        return GtfsRouteType.SUBWAY;
+      case TROLLEYBUS_SERVICE:
+        return GtfsRouteType.TROLLEYBUS;
+      case TRAM_SERVICE:
+        return GtfsRouteType.LIGHT_RAIL;
+      case FERRY_SERVICE:
+      case WATER_TRANSPORT_SERVICE:
+        return GtfsRouteType.FERRY;
+      case AERIAL_LIFT_SERVICE:
+        return GtfsRouteType.AERIAL_LIFT;
+      case FUNICULAR_SERVICE:
+        return GtfsRouteType.FUNICULAR;
+      default:
+        return GtfsRouteType.UNRECOGNIZED;
+    }
+  }
+
+  public static final int RAILWAY_SERVICE = 100;
+  public static final int HIGH_SPEED_RAIL = 101;
+  public static final int LONG_DISTANCE_TRAINS = 102;
+  public static final int INTER_REGIONAL_RAIL = 103;
+  public static final int CAR_TRANSPORT_RAIL = 104;
+  public static final int SLEEPER_RAIL = 105;
+  public static final int REGIONAL_RAIL = 106;
+  public static final int TOURIST_RAILWAY = 107;
+  public static final int RAIL_SHUTTLE = 108;
+  public static final int SUBURBAN_RAILWAY = 109;
+  public static final int REPLACEMENT_RAIL = 110;
+  public static final int SPECIAL_RAIL = 111;
+  public static final int LORRY_TRANSPORT_RAIL = 112;
+  public static final int ALL_RAIL_SERVICES = 113;
+  public static final int CROSS_COUNTRY_RAIL = 114;
+  public static final int VEHICLE_TRANSPORT_RAIL = 115;
+  public static final int RACK_AND_PINION_RAILWAY = 116;
+  public static final int ADDITIONAL_RAIL = 117;
+  public static final int COACH_SERVICE = 200;
+  public static final int INTERNATIONAL_COACH = 201;
+  public static final int NATIONAL_COACH = 202;
+  public static final int SHUTTLE_COACH = 203;
+  public static final int REGIONAL_COACH = 204;
+  public static final int SPECIAL_COACH = 205;
+  public static final int SIGHTSEEING_COACH = 206;
+  public static final int TOURIST_COACH = 207;
+  public static final int COMMUTER_COACH = 208;
+  public static final int ALL_COACH_SERVICES = 209;
+  public static final int URBAN_RAILWAY_SERVICE = 400;
+  public static final int METRO = 401;
+  public static final int UNDERGROUND = 402;
+  public static final int URBAN_RAILWAY = 403;
+  public static final int ALL_URBAN_RAILWAY_SERVICES = 404;
+  public static final int MONORAIL = 405;
+  public static final int BUS_SERVICE = 700;
+  public static final int REGIONAL_BUS = 701;
+  public static final int EXPRESS_BUS = 702;
+  public static final int STOPPING_BUS = 703;
+  public static final int LOCAL_BUS = 704;
+  public static final int NIGHT_BUS = 705;
+  public static final int POST_BUS = 706;
+  public static final int SPECIAL_NEEDS_BUS = 707;
+  public static final int MOBILITY_BUS = 708;
+  public static final int MOBILITY_BUS_FOR_REGISTERED_DISABLED = 709;
+  public static final int SIGHTSEEING_BUS = 710;
+  public static final int SHUTTLE_BUS = 711;
+  public static final int SCHOOL_BUS = 712;
+  public static final int SCHOOL_AND_PUBLIC_SERVICE_BUS = 713;
+  public static final int RAIL_REPLACEMENT_BUS = 714;
+  public static final int DEMAND_AND_RESPONSE_BUS = 715;
+  public static final int ALL_BUS_SERVICES = 716;
+  public static final int TROLLEYBUS_SERVICE = 800;
+  public static final int TRAM_SERVICE = 900;
+  public static final int CITY_TRAM = 901;
+  public static final int LOCAL_TRAM = 902;
+  public static final int REGIONAL_TRAM = 903;
+  public static final int SIGHTSEEING_TRAM = 904;
+  public static final int SHUTTLE_TRAM = 905;
+  public static final int ALL_TRAM_SERVICES = 906;
+  public static final int WATER_TRANSPORT_SERVICE = 1000;
+  public static final int AIR_SERVICE = 1100;
+  public static final int FERRY_SERVICE = 1200;
+  public static final int AERIAL_LIFT_SERVICE = 1300;
+  public static final int FUNICULAR_SERVICE = 1400;
+  public static final int TAXI_SERVICE = 1500;
+  public static final int COMMUNAL_TAXI = 1501;
+  public static final int WATER_TAXI = 1502;
+  public static final int RAIL_TAXI = 1503;
+  public static final int BIKE_TAXI = 1504;
+  public static final int LICENSED_TAXI = 1505;
+  public static final int PRIVATE_HIRE_SERVICE_VEHICLE = 1506;
+  public static final int ALL_TAXI_SERVICES = 1507;
+  public static final int MISCELLANEOUS_SERVICE = 1700;
+  public static final int HORSE_DRAWN_CARRIAGE = 1702;
+
+  /* Private constructor to disable instantiation. */
+  private HierarchicalVehicleType() {}
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -298,7 +298,8 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
   private static final int NUM_SECONDS_PER_HOUR = 3600;
 
   /** Returns a speed threshold (km/h) for a given vehicle type. */
-  private static double getMaxVehicleSpeedKph(GtfsRoute route) {
+  @VisibleForTesting
+  static double getMaxVehicleSpeedKph(GtfsRoute route) {
     // Pass int routeTypeValue to support potential non-standard route types (HVT).
     switch (HierarchicalVehicleType.toBasicGtfsRouteType(route.routeTypeValue())) {
       case LIGHT_RAIL:

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -35,7 +35,6 @@ import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
@@ -43,6 +42,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+import org.mobilitydata.gtfsvalidator.util.HierarchicalVehicleType;
 import org.mobilitydata.gtfsvalidator.util.S2Earth;
 
 /**
@@ -90,7 +90,7 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
         // Broken reference is reported in another rule.
         continue;
       }
-      final double maxSpeedKph = getMaxVehicleSpeedKph(route.get().routeType());
+      final double maxSpeedKph = getMaxVehicleSpeedKph(route.get());
       final double[] distancesKm = findDistancesKmBetweenStops(tripAndStopTimes.getStopTimes());
 
       validateConsecutiveStops(trips, distancesKm, maxSpeedKph, noticeContainer);
@@ -298,8 +298,9 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
   private static final int NUM_SECONDS_PER_HOUR = 3600;
 
   /** Returns a speed threshold (km/h) for a given vehicle type. */
-  private static double getMaxVehicleSpeedKph(GtfsRouteType routeType) {
-    switch (routeType) {
+  private static double getMaxVehicleSpeedKph(GtfsRoute route) {
+    // Pass int routeTypeValue to support potential non-standard route types (HVT).
+    switch (HierarchicalVehicleType.toBasicGtfsRouteType(route.routeTypeValue())) {
       case LIGHT_RAIL:
         // The Houston METRORail can reach speeds of 100 km/h.
         return 100;

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/HierarchicalVehicleTypeTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/HierarchicalVehicleTypeTest.java
@@ -1,0 +1,115 @@
+package org.mobilitydata.gtfsvalidator.util;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.util.HierarchicalVehicleType.toBasicGtfsRouteType;
+
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteType;
+
+public class HierarchicalVehicleTypeTest {
+
+  @Test
+  public void toBasicGtfsRouteType_basicGtfs() {
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.LIGHT_RAIL.getNumber()))
+        .isEqualTo(GtfsRouteType.LIGHT_RAIL);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.SUBWAY.getNumber()))
+        .isEqualTo(GtfsRouteType.SUBWAY);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.RAIL.getNumber())).isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.BUS.getNumber())).isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.FERRY.getNumber()))
+        .isEqualTo(GtfsRouteType.FERRY);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.CABLE_TRAM.getNumber()))
+        .isEqualTo(GtfsRouteType.CABLE_TRAM);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.AERIAL_LIFT.getNumber()))
+        .isEqualTo(GtfsRouteType.AERIAL_LIFT);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.FUNICULAR.getNumber()))
+        .isEqualTo(GtfsRouteType.FUNICULAR);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.TROLLEYBUS.getNumber()))
+        .isEqualTo(GtfsRouteType.TROLLEYBUS);
+    assertThat(toBasicGtfsRouteType(GtfsRouteType.MONORAIL.getNumber()))
+        .isEqualTo(GtfsRouteType.MONORAIL);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_rail() {
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.RAILWAY_SERVICE))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.HIGH_SPEED_RAIL))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.LONG_DISTANCE_TRAINS))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.INTER_REGIONAL_RAIL))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.SLEEPER_RAIL))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.REGIONAL_RAIL))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TOURIST_RAILWAY))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.RAIL_SHUTTLE))
+        .isEqualTo(GtfsRouteType.RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.SUBURBAN_RAILWAY))
+        .isEqualTo(GtfsRouteType.RAIL);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_coach() {
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.COACH_SERVICE))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.INTERNATIONAL_COACH))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.NATIONAL_COACH))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.REGIONAL_COACH))
+        .isEqualTo(GtfsRouteType.BUS);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_urbanRailway() {
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.URBAN_RAILWAY_SERVICE))
+        .isEqualTo(GtfsRouteType.SUBWAY);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.METRO)).isEqualTo(GtfsRouteType.SUBWAY);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.UNDERGROUND))
+        .isEqualTo(GtfsRouteType.SUBWAY);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.URBAN_RAILWAY))
+        .isEqualTo(GtfsRouteType.SUBWAY);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.MONORAIL))
+        .isEqualTo(GtfsRouteType.MONORAIL);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_bus() {
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.BUS_SERVICE))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.REGIONAL_BUS))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.EXPRESS_BUS))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.LOCAL_BUS))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.DEMAND_AND_RESPONSE_BUS))
+        .isEqualTo(GtfsRouteType.BUS);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_others() {
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TROLLEYBUS_SERVICE))
+        .isEqualTo(GtfsRouteType.TROLLEYBUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TRAM_SERVICE))
+        .isEqualTo(GtfsRouteType.LIGHT_RAIL);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.WATER_TRANSPORT_SERVICE))
+        .isEqualTo(GtfsRouteType.FERRY);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.FERRY_SERVICE))
+        .isEqualTo(GtfsRouteType.FERRY);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.AERIAL_LIFT_SERVICE))
+        .isEqualTo(GtfsRouteType.AERIAL_LIFT);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.FUNICULAR_SERVICE))
+        .isEqualTo(GtfsRouteType.FUNICULAR);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.COMMUNAL_TAXI))
+        .isEqualTo(GtfsRouteType.BUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.MISCELLANEOUS_SERVICE))
+        .isEqualTo(GtfsRouteType.UNRECOGNIZED);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.HORSE_DRAWN_CARRIAGE))
+        .isEqualTo(GtfsRouteType.UNRECOGNIZED);
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/util/HierarchicalVehicleTypeTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/util/HierarchicalVehicleTypeTest.java
@@ -1,6 +1,7 @@
 package org.mobilitydata.gtfsvalidator.util;
 
 import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assertWithMessage;
 import static org.mobilitydata.gtfsvalidator.util.HierarchicalVehicleType.toBasicGtfsRouteType;
 
 import org.junit.Test;
@@ -30,83 +31,63 @@ public class HierarchicalVehicleTypeTest {
         .isEqualTo(GtfsRouteType.MONORAIL);
   }
 
-  @Test
-  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_rail() {
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.RAILWAY_SERVICE))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.HIGH_SPEED_RAIL))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.LONG_DISTANCE_TRAINS))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.INTER_REGIONAL_RAIL))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.SLEEPER_RAIL))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.REGIONAL_RAIL))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TOURIST_RAILWAY))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.RAIL_SHUTTLE))
-        .isEqualTo(GtfsRouteType.RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.SUBURBAN_RAILWAY))
-        .isEqualTo(GtfsRouteType.RAIL);
+  private static void assertAllSubtypes(int baseHvt, GtfsRouteType expectedRouteType) {
+    for (int i = 0; i < 99; ++i) {
+      assertWithMessage(String.format("HVT %d", baseHvt + i))
+          .that(toBasicGtfsRouteType(baseHvt + i))
+          .isEqualTo(expectedRouteType);
+    }
   }
 
   @Test
-  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_coach() {
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.COACH_SERVICE))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.INTERNATIONAL_COACH))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.NATIONAL_COACH))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.REGIONAL_COACH))
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_rail() {
+    assertAllSubtypes(HierarchicalVehicleType.RAILWAY_SERVICE, GtfsRouteType.RAIL);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_bus() {
+    assertAllSubtypes(HierarchicalVehicleType.COACH_SERVICE, GtfsRouteType.BUS);
+    assertAllSubtypes(HierarchicalVehicleType.BUS_SERVICE, GtfsRouteType.BUS);
+    assertAllSubtypes(HierarchicalVehicleType.TROLLEYBUS_SERVICE, GtfsRouteType.TROLLEYBUS);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.COMMUNAL_TAXI))
         .isEqualTo(GtfsRouteType.BUS);
   }
 
   @Test
   public void toBasicGtfsRouteType_hierarchicalVehicleTypes_urbanRailway() {
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.URBAN_RAILWAY_SERVICE))
-        .isEqualTo(GtfsRouteType.SUBWAY);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.METRO)).isEqualTo(GtfsRouteType.SUBWAY);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.UNDERGROUND))
-        .isEqualTo(GtfsRouteType.SUBWAY);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.URBAN_RAILWAY))
-        .isEqualTo(GtfsRouteType.SUBWAY);
+    for (int i = 0; i < 99; ++i) {
+      if (HierarchicalVehicleType.URBAN_RAILWAY_SERVICE + i != HierarchicalVehicleType.MONORAIL) {
+        assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.URBAN_RAILWAY_SERVICE + i))
+            .isEqualTo(GtfsRouteType.SUBWAY);
+      }
+    }
     assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.MONORAIL))
         .isEqualTo(GtfsRouteType.MONORAIL);
   }
 
   @Test
-  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_bus() {
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.BUS_SERVICE))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.REGIONAL_BUS))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.EXPRESS_BUS))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.LOCAL_BUS))
-        .isEqualTo(GtfsRouteType.BUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.DEMAND_AND_RESPONSE_BUS))
-        .isEqualTo(GtfsRouteType.BUS);
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_tram() {
+    assertAllSubtypes(HierarchicalVehicleType.TRAM_SERVICE, GtfsRouteType.LIGHT_RAIL);
   }
 
   @Test
-  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_others() {
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TROLLEYBUS_SERVICE))
-        .isEqualTo(GtfsRouteType.TROLLEYBUS);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TRAM_SERVICE))
-        .isEqualTo(GtfsRouteType.LIGHT_RAIL);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.WATER_TRANSPORT_SERVICE))
-        .isEqualTo(GtfsRouteType.FERRY);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.FERRY_SERVICE))
-        .isEqualTo(GtfsRouteType.FERRY);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.AERIAL_LIFT_SERVICE))
-        .isEqualTo(GtfsRouteType.AERIAL_LIFT);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.FUNICULAR_SERVICE))
-        .isEqualTo(GtfsRouteType.FUNICULAR);
-    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.COMMUNAL_TAXI))
-        .isEqualTo(GtfsRouteType.BUS);
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_ferry() {
+    assertAllSubtypes(HierarchicalVehicleType.WATER_TRANSPORT_SERVICE, GtfsRouteType.FERRY);
+    assertAllSubtypes(HierarchicalVehicleType.FERRY_SERVICE, GtfsRouteType.FERRY);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_cable() {
+    assertAllSubtypes(HierarchicalVehicleType.AERIAL_LIFT_SERVICE, GtfsRouteType.AERIAL_LIFT);
+    assertAllSubtypes(HierarchicalVehicleType.FUNICULAR_SERVICE, GtfsRouteType.FUNICULAR);
+  }
+
+  @Test
+  public void toBasicGtfsRouteType_hierarchicalVehicleTypes_unrecognized() {
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.AIR_SERVICE))
+        .isEqualTo(GtfsRouteType.UNRECOGNIZED);
+    assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.TAXI_SERVICE))
+        .isEqualTo(GtfsRouteType.UNRECOGNIZED);
     assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.MISCELLANEOUS_SERVICE))
         .isEqualTo(GtfsRouteType.UNRECOGNIZED);
     assertThat(toBasicGtfsRouteType(HierarchicalVehicleType.HORSE_DRAWN_CARRIAGE))

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidatorTest.java
@@ -17,6 +17,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.getMaxVehicleSpeedKph;
 import static org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.getSpeedKphBetweenStops;
 
 import com.google.common.collect.ImmutableList;
@@ -39,6 +40,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+import org.mobilitydata.gtfsvalidator.util.HierarchicalVehicleType;
 import org.mobilitydata.gtfsvalidator.util.S2Earth;
 import org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.FastTravelBetweenConsecutiveStopsNotice;
 import org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.FastTravelBetweenFarStopsNotice;
@@ -325,5 +327,31 @@ public final class StopTimeTravelSpeedValidatorTest {
     List<GtfsStopTime> stopTimes =
         createStopTimesSameDepartureArrival(ImmutableList.of(GtfsTime.fromString("08:00:00")));
     assertThat(getSpeedKphBetweenStops(2, stopTimes.get(0), stopTimes.get(0))).isEqualTo(120);
+  }
+
+  @Test
+  public void getMaxVehicleSpeedKph_standardGtfs() {
+    assertThat(
+            getMaxVehicleSpeedKph(new GtfsRoute.Builder().setRouteType(GtfsRouteType.RAIL).build()))
+        .isEqualTo(500);
+    assertThat(
+            getMaxVehicleSpeedKph(new GtfsRoute.Builder().setRouteType(GtfsRouteType.BUS).build()))
+        .isEqualTo(150);
+  }
+
+  @Test
+  public void getMaxVehicleSpeedKph_hvt() {
+    assertThat(
+            getMaxVehicleSpeedKph(
+                new GtfsRoute.Builder()
+                    .setRouteType(HierarchicalVehicleType.HIGH_SPEED_RAIL)
+                    .build()))
+        .isEqualTo(500);
+    assertThat(
+            getMaxVehicleSpeedKph(
+                new GtfsRoute.Builder()
+                    .setRouteType(HierarchicalVehicleType.FUNICULAR_SERVICE)
+                    .build()))
+        .isEqualTo(50);
   }
 }


### PR DESCRIPTION
HVTs are non-standard but widely used. The standard GTFS validator emits
a warning for an HVT but the original value can be retrieved via
GtfsRouteType.routeTypeValue().

There are feeds that run high-speed railway services. The default 200
km/h limit is too low for them, so it is worth to apply the usual 500
km/h limit for railway.

See https://developers.google.com/transit/gtfs/reference/extended-route-types