### PR TITLE
docs: fix typos in README.md and USAGE.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ This is a command-line tool written in Java that performs the following steps:
 ### Run it
 To validate a GTFS dataset on your computer:
 
-`java -jar gtfs-validator-v-snapshot_cli.jar -i /myDirectory/gtfs.zip -o output -c ca` 
+`java -jar gtfs-validator-v3.0.0-beta_cli.jar -i /myDirectory/gtfs.zip -o output -c ca` 
 
 To download and validate a GTFS dataset from a URL:
 
-`java -jar gtfs-validator-v-snapshot_cli.jar -u https://www.abc.com/gtfs.zip -o output -c ca`
+`java -jar gtfs-validator-v3.0.0-beta_cli.jar -u https://www.abc.com/gtfs.zip -o output -c ca`
 
 where:
 * `--input` or `-i`: the path to the GTFS file (e.g., `/myDirectory/gtfs.zip`)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -18,7 +18,7 @@ The below instructions are for the [`v3.0.0-beta`](https://github.com/MobilityDa
 | `-u`       	| `--url`                       	| Optional  	| Fully qualified URL to download GTFS archive.                                                                             	|
 | `-v`       	| `--validation_report_name`    	| Optional  	| Name of the validation report (including `.json` extension).                                                              	|
 | `-e`       	| `--system_errors_report_name` 	| Optional  	| Name of the system errors report (including `.json` extension).                                                             	|
-| `-n`       	| `--export_notice_schema`       	| Optional  	| Export notice schema as a json file.                                                                                           |
+| `-n`       	| `--export_notices_schema`       	| Optional  	| Export notice schema as a json file.                                                                                           |
 
 ⚠️ Note that exactly one of the following options must be provided: `--url` or `--input`.
 


### PR DESCRIPTION
- Fix to README.md: feedback gathered after testing the beta release documentation
- Fix USAGE.md for the typo in the `export_notices_schema` parameter