### PR TITLE
docs: remove documentation related to StopTimeWithDepartureBeforeArrivalTim…

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -594,15 +594,6 @@ For a given `trip_id`, the `arrival_time` of (n+1)-th stoptime in sequence must 
 ##### References:
 * [Original Python validator implementation](https://github.com/google/transitfeed)
 
-<a name="StopTimeWithDepartureBeforeArrivalTimeNotice"/>
-
-#### StopTimeWithDepartureBeforeArrivalTimeNotice
-
-The `departure_time` must not precede the `arrival_time` in `stop_times.txt` if both are given. 
-
-##### References:
-* [Original Python validator implementation](https://github.com/google/transitfeed)
-
 <a name="StopTimeWithOnlyArrivalOrDepartureTimeNotice"/>
 
 #### StopTimeWithOnlyArrivalOrDepartureTimeNotice


### PR DESCRIPTION
closes #1048 

**Summary:**

This PR removes documentation related to deprecated notice 
 `StopTimeWithDepartureBeforeArrivalTimeNotice`

**Expected behavior:** 

This notice should no longer appear in `RULES.md`.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~
