### PR TITLE
fix: False positive for StopZoneIdValidator

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -607,7 +607,7 @@ Missing `stop_time.arrival_time` or `stop_time.departure_time`
 
 #### StopWithoutZoneIdNotice
 
-If `fare_rules.txt` is provided, then all stops and platforms (location_type = 0) must have `stops.zone_id` assigned.
+If `fare_rules.txt` is provided, and `fare_rules.txt` uses at least one column among `origin_id`, `destination_id`, and `contains_id`, then all stops and platforms (location_type = 0) must have `stops.zone_id` assigned. 
 
 ##### References:
 * [GTFS stops.txt specification](https://gtfs.org/reference/static#stopstxt)

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -28,8 +28,15 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 
 /**
- * Check that if {@code fare_rules.txt} is provided, then all stops and platforms (location_type =
- * 0) have {@code stops.zone_id} assigned.
+ * Checks that all stops and platforms (location_type = 0) have {@code stops.zone_id} assigned.
+ * assigned if {@code fare_rules.txt} is provided and at least one of the following fields is
+ * provided:
+ *
+ * <ul>
+ *   <li>{@code fare_rules.origin_id}
+ *   <li>{@code fare_rules.contains_id}
+ *   <li>{@code fare_rules.destination_id}
+ * </ul>
  *
  * <p>Generated notice: {@link StopWithoutZoneIdNotice}.
  */

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -21,6 +21,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareRule;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareRuleTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
@@ -49,11 +50,34 @@ public class StopZoneIdValidator extends FileValidator {
     if (fareRuleTable.getEntities().isEmpty()) {
       return;
     }
+    if (!hasFareZoneStructure(fareRuleTable)) {
+      return;
+    }
     for (GtfsStop stop : stopTable.getEntities()) {
-      if (stop.locationType().equals(GtfsLocationType.STOP) && !stop.hasZoneId()) {
+      if (!stop.locationType().equals(GtfsLocationType.STOP)) {
+        continue;
+      }
+      if (!stop.hasZoneId()) {
         noticeContainer.addValidationNotice(new StopWithoutZoneIdNotice(stop));
       }
     }
+  }
+
+  /**
+   * Checks if the {@code GtfsFareRuleTableContainer} provided as parameter has a fare structure
+   * that uses zones.
+   *
+   * @param fareRuleTable the {@code GtfsFareRuleTableContainer} to be checked
+   * @return true if the {@code GtfsFareRuleTableContainer} provided as parameter has a fare
+   *     structure that uses zones; false otherwise.
+   */
+  private static boolean hasFareZoneStructure(GtfsFareRuleTableContainer fareRuleTable) {
+    for (GtfsFareRule fareRule : fareRuleTable.getEntities()) {
+      if (fareRule.hasContainsId() || fareRule.hasDestinationId() || fareRule.hasOriginId()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -57,7 +57,6 @@ public class StopZoneIdValidatorTest {
     return new GtfsFareRule.Builder()
         .setCsvRowNumber(csvRowNumber)
         .setFareId(toFareRuleId(csvRowNumber))
-        .setFareId(toFareRuleId(csvRowNumber))
         .setRouteId("route id value")
         .build();
   }
@@ -81,14 +80,14 @@ public class StopZoneIdValidatorTest {
   }
 
   @Test
-  public void stop_zoneIdNotProvided_zoneStruncture_yieldsNotice() {
+  public void stop_zoneIdNotProvided_zoneStructure_yieldsNotice() {
     ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(3, GtfsLocationType.STOP, null));
     assertThat(generateNotices(stops, ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .containsExactly(new StopWithoutZoneIdNotice(stops.get(0)));
   }
 
   @Test
-  public void stop_zoneIdNotProvided_nozZneStruncture_yieldsNotice() {
+  public void stop_zoneIdNotProvided_noZoneStructure_yieldsNotice() {
     ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(3, GtfsLocationType.STOP, null));
     assertThat(generateNotices(stops, ImmutableList.of(createFareRuleWithoutZoneStructure(5))))
         .isEmpty();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidatorTest.java
@@ -45,10 +45,20 @@ public class StopZoneIdValidatorTest {
         .build();
   }
 
-  private static GtfsFareRule createFareRule(long csvRowNumber) {
+  private static GtfsFareRule createFareRuleWithZoneStructure(long csvRowNumber) {
     return new GtfsFareRule.Builder()
         .setCsvRowNumber(csvRowNumber)
         .setFareId(toFareRuleId(csvRowNumber))
+        .setOriginId("origin id")
+        .build();
+  }
+
+  private static GtfsFareRule createFareRuleWithoutZoneStructure(long csvRowNumber) {
+    return new GtfsFareRule.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setFareId(toFareRuleId(csvRowNumber))
+        .setFareId(toFareRuleId(csvRowNumber))
+        .setRouteId("route id value")
         .build();
   }
 
@@ -71,10 +81,17 @@ public class StopZoneIdValidatorTest {
   }
 
   @Test
-  public void stop_zoneIdNotProvided_yieldsNotice() {
+  public void stop_zoneIdNotProvided_zoneStruncture_yieldsNotice() {
     ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(3, GtfsLocationType.STOP, null));
-    assertThat(generateNotices(stops, ImmutableList.of(createFareRule(5))))
+    assertThat(generateNotices(stops, ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .containsExactly(new StopWithoutZoneIdNotice(stops.get(0)));
+  }
+
+  @Test
+  public void stop_zoneIdNotProvided_nozZneStruncture_yieldsNotice() {
+    ImmutableList<GtfsStop> stops = ImmutableList.of(createStop(3, GtfsLocationType.STOP, null));
+    assertThat(generateNotices(stops, ImmutableList.of(createFareRuleWithoutZoneStructure(5))))
+        .isEmpty();
   }
 
   @Test
@@ -82,7 +99,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.STOP, "zone id value")),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -91,7 +108,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.STATION, null)),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -100,7 +117,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.STATION, "zone id value")),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -109,7 +126,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.ENTRANCE, null)),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -118,7 +135,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.ENTRANCE, "zone id value")),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -127,7 +144,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.GENERIC_NODE, null)),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -136,7 +153,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.GENERIC_NODE, "zone id value")),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -145,7 +162,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, null)),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 
@@ -154,7 +171,7 @@ public class StopZoneIdValidatorTest {
     assertThat(
             generateNotices(
                 ImmutableList.of(createStop(3, GtfsLocationType.BOARDING_AREA, "zone id value")),
-                ImmutableList.of(createFareRule(5))))
+                ImmutableList.of(createFareRuleWithZoneStructure(5))))
         .isEmpty();
   }
 


### PR DESCRIPTION
**Summary:**

This PR provides support to avoid false positives in the context of `StopZoneIdValidator`.

**Expected behavior:** 

The validator doesn't trigger `StopWithoutZoneIdNotice` when the fares depend on the routes.

1. Run the fix proposal on [10-15 Transit's GTFS Schedule source](https://transitfeeds.com/p/10-15-transit/936/latest/download). This file has the following structure that is considered valid:

| fare_id | route_id | origin_id | destination_id | contains_id |
|---------|----------|-----------|----------------|-------------|
| 2331    | 7468     |           |                |             |
| 2331    | 7469     |           |                |             |
| 2331    | 7925     |           |                |             |

(from https://github.com/MobilityData/gtfs-validator/issues/1075#issue-1065995820).

2. Observe no more false positive for `StopWithoutZoneIdNotice` in the validation report:

```json
{
  "notices": [
    {
      "code": "stop_without_stop_time",
      "severity": "WARNING",
      "totalNotices": 3,
      "sampleNotices": [
        {
          "csvRowNumber": 85,
          "stopId": "2436381",
          "stopName": "11th Ave & F St"
        },
        {
          "csvRowNumber": 133,
          "stopId": "2729800",
          "stopName": "Vine and Davis"
        },
        {
          "csvRowNumber": 134,
          "stopId": "2729801",
          "stopName": "Vine and Weller"
        }
      ]
    },
    {
      "code": "unknown_column",
      "severity": "INFO",
      "totalNotices": 29,
      "sampleNotices": [
        {
          "filename": "calendar.txt",
          "fieldName": "service_name",
          "index": 2
        },
        {
          "filename": "calendar_dates.txt",
          "fieldName": "holiday_name",
          "index": 3
        },
        {
          "filename": "feed_info.txt",
          "fieldName": "feed_license",
          "index": 5
        },
        {
          "filename": "feed_info.txt",
          "fieldName": "feed_id",
          "index": 10
        },
        {
          "filename": "routes.txt",
          "fieldName": "min_headway_minutes",
          "index": 11
        },
        {
          "filename": "routes.txt",
          "fieldName": "eligibility_restricted",
          "index": 12
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "start_service_area_id",
          "index": 11
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "end_service_area_id",
          "index": 12
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "start_service_area_radius",
          "index": 13
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "end_service_area_radius",
          "index": 14
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "pickup_booking_rule_id",
          "index": 17
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "drop_off_booking_rule_id",
          "index": 18
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "min_arrival_time",
          "index": 19
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "max_departure_time",
          "index": 20
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "mean_duration_factor",
          "index": 21
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "mean_duration_offset",
          "index": 22
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "safe_duration_factor",
          "index": 23
        },
        {
          "filename": "stop_times.txt",
          "fieldName": "safe_duration_offset",
          "index": 24
        },
        {
          "filename": "stops.txt",
          "fieldName": "position",
          "index": 13
        },
        {
          "filename": "stops.txt",
          "fieldName": "direction",
          "index": 14
        },
        {
          "filename": "trips.txt",
          "fieldName": "trip_type",
          "index": 11
        },
        {
          "filename": "trips.txt",
          "fieldName": "drt_max_travel_time",
          "index": 12
        },
        {
          "filename": "trips.txt",
          "fieldName": "drt_avg_travel_time",
          "index": 13
        },
        {
          "filename": "trips.txt",
          "fieldName": "drt_advance_book_min",
          "index": 14
        },
        {
          "filename": "trips.txt",
          "fieldName": "drt_pickup_message",
          "index": 15
        },
        {
          "filename": "trips.txt",
          "fieldName": "drt_drop_off_message",
          "index": 16
        },
        {
          "filename": "trips.txt",
          "fieldName": "continuous_pickup_message",
          "index": 17
        },
        {
          "filename": "trips.txt",
          "fieldName": "continuous_drop_off_message",
          "index": 18
        },
        {
          "filename": "trips.txt",
          "fieldName": "booking_rule_id",
          "index": 19
        }
      ]
    },
    {
      "code": "unknown_file",
      "severity": "INFO",
      "totalNotices": 13,
      "sampleNotices": [
        {
          "filename": "areas.txt"
        },
        {
          "filename": "calendar_attributes.txt"
        },
        {
          "filename": "directions.txt"
        },
        {
          "filename": "fare_rider_categories.txt"
        },
        {
          "filename": "farezone_attributes.txt"
        },
        {
          "filename": "rider_categories.txt"
        },
        {
          "filename": "runcut.txt"
        },
        {
          "filename": "stop_attributes.txt"
        },
        {
          "filename": "timetable_stop_order.txt"
        },
        {
          "filename": "timetables.txt"
        },
        {
          "filename": "linked_datasets.txt"
        },
        {
          "filename": "location_groups.txt"
        },
        {
          "filename": "booking_rules.txt"
        }
      ]
    }
  ]
}
```


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
