### PR TITLE
ci: Remove upload of validation reports to Google Cloud

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -186,16 +186,6 @@ jobs:
         with:
           name: reports_all
           path: ${{ github.sha }}/output
-      - name: Set up and authorize Cloud
-        uses: google-github-actions/auth@v0
-        with:
-          credentials_json: ${{ secrets.VALIDATOR_SA_KEY }}
-      - name: Upload reports to Google Cloud Storage
-        id: upload-files
-        uses: google-github-actions/upload-cloud-storage@main
-        with:
-          path: ${{ github.sha }}/output
-          destination: gtfs-validator-reports
   compare-outputs:
     needs: [ get-reports ]
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,8 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ -n "${{ secrets.VALIDATOR_SA_KEY }}" ]
-          then
+          if [ "${{ secrets.VALIDATOR_SA_KEY }}" == "" ]; then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"
           else

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ -n "${{ secrets.VALIDATOR_SA_KEY }}" ]
+          if [ ! -z "${{ secrets.VALIDATOR_SA_KEY }}" ]
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -160,24 +160,8 @@ jobs:
           path: scripts/mobility-database-harvester/datasets_metadata
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
-  secrets-gate:
-    runs-on: ubuntu-latest
-    outputs:
-      ok: ${{ steps.check-secrets.outputs.ok }}
-    steps:
-      - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
-        id: check-secrets
-        run: |
-          # FIXME: The below IF statement always returns false and therefore skips uploads even on branches from this repo. See https://github.com/MobilityData/gtfs-validator/issues/1128
-          if [ "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]; then
-            echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
-            echo "::set-output name=ok::true"
-          else
-            echo "Secrets are NOT configured to upload validation reports to Google Cloud - skipping upload. This is expected for pull requests from forks."
-            echo "::set-output name=ok::false"
-          fi
   get-reports:
-    needs: [ fetch-urls, pack-master, pack-snapshot, secrets-gate ]
+    needs: [ fetch-urls, pack-master, pack-snapshot ]
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
@@ -202,18 +186,6 @@ jobs:
         with:
           name: reports_all
           path: ${{ github.sha }}/output
-      - name: Set up and authorize Cloud
-        uses: google-github-actions/auth@v0
-        if: needs.secrets-gate.outputs.ok == 'true'
-        with:
-          credentials_json: ${{ secrets.VALIDATOR_SA_KEY }}
-      - name: Upload reports to Google Cloud Storage
-        id: upload-files
-        uses: google-github-actions/upload-cloud-storage@main
-        if: needs.secrets-gate.outputs.ok == 'true'
-        with:
-          path: ${{ github.sha }}/output
-          destination: gtfs-validator-reports
   compare-outputs:
     needs: [ get-reports ]
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [[ ! -z "${{ secrets.VALIDATOR_SA_KEY }}" ]]
+          if [ -n "${{ secrets.VALIDATOR_SA_KEY }}" ]
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ "${{ secrets.VALIDATOR_SA_KEY }}" == "***" ]
+          if [ -n "${{ secrets.VALIDATOR_SA_KEY }}" ]
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ "${{ secrets.VALIDATOR_SA_KEY }}" = "***" ];
+          if [ "${{ secrets.VALIDATOR_SA_KEY }}" == "***" ];
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -160,8 +160,19 @@ jobs:
           path: scripts/mobility-database-harvester/datasets_metadata
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+  secrets-gate:
+    runs-on: ubuntu-latest
+    outputs:
+      ok: ${{ steps.check-secrets.outputs.ok }}
+    steps:
+      - name: check for secrets needed to upload on GCP Cloud Storage
+        id: check-secrets
+        run: |
+          if [ ! -z "${{ secrets.VALIDATOR_SA_KEY }}" ]; then
+            echo "::set-output name=ok::true"
+          fi
   get-reports:
-    needs: [ fetch-urls, pack-master, pack-snapshot ]
+    needs: [ fetch-urls, pack-master, pack-snapshot, secrets-gate ]
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
@@ -186,6 +197,18 @@ jobs:
         with:
           name: reports_all
           path: ${{ github.sha }}/output
+      - name: Set up and authorize Cloud
+        uses: google-github-actions/auth@v0
+        if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
+        with:
+          credentials_json: ${{ secrets.VALIDATOR_SA_KEY }}
+      - name: Upload reports to Google Cloud Storage
+        id: upload-files
+        uses: google-github-actions/upload-cloud-storage@main
+        if:
+        with:
+          path: ${{ github.sha }}/output
+          destination: gtfs-validator-reports
   compare-outputs:
     needs: [ get-reports ]
     runs-on: ubuntu-latest

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ "${{ secrets.VALIDATOR_SA_KEY }}" == "" ]; then
+          if [ "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]; then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"
           else

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ "${{ secrets.VALIDATOR_SA_KEY }}" == "***" ];
+          if [ "${{ secrets.VALIDATOR_SA_KEY }}" == "***" ]
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [[ -z "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]];
+          if [ "${{ secrets.VALIDATOR_SA_KEY }}" = "***" ];
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -165,11 +165,16 @@ jobs:
     outputs:
       ok: ${{ steps.check-secrets.outputs.ok }}
     steps:
-      - name: check for secrets needed to upload on GCP Cloud Storage
+      - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ ! -z "${{ secrets.VALIDATOR_SA_KEY }}" ]; then
+          if [[ "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]];
+          then
+            echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"
+          else
+            echo "Secrets are NOT configured to upload validation reports to Google Cloud - skipping upload. This is expected for pull requests from forks."
+            echo "::set-output name=ok::false"
           fi
   get-reports:
     needs: [ fetch-urls, pack-master, pack-snapshot, secrets-gate ]
@@ -199,13 +204,13 @@ jobs:
           path: ${{ github.sha }}/output
       - name: Set up and authorize Cloud
         uses: google-github-actions/auth@v0
-        if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
+        if: needs.secrets-gate.outputs.ok == 'true'
         with:
           credentials_json: ${{ secrets.VALIDATOR_SA_KEY }}
       - name: Upload reports to Google Cloud Storage
         id: upload-files
         uses: google-github-actions/upload-cloud-storage@main
-        if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
+        if: needs.secrets-gate.outputs.ok == 'true'
         with:
           path: ${{ github.sha }}/output
           destination: gtfs-validator-reports

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [ ! -z "${{ secrets.VALIDATOR_SA_KEY }}" ]
+          if [[ ! -z "${{ secrets.VALIDATOR_SA_KEY }}" ]]
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
+          # FIXME: The below IF statement always returns false and therefore skips uploads even on branches from this repo. See https://github.com/MobilityData/gtfs-validator/issues/1128
           if [ "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]; then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Upload reports to Google Cloud Storage
         id: upload-files
         uses: google-github-actions/upload-cloud-storage@main
-        if:
+        if: ${{ needs.secrets-gate.outputs.ok == 'true' }}
         with:
           path: ${{ github.sha }}/output
           destination: gtfs-validator-reports

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [[ "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]];
+          if [[ "${{ secrets.VALIDATOR_SA_KEY }}" = "***" ]];
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Check for secrets needed to upload validation reports to GCP Cloud Storage
         id: check-secrets
         run: |
-          if [[ "${{ secrets.VALIDATOR_SA_KEY }}" = "***" ]];
+          if [[ -z "${{ secrets.VALIDATOR_SA_KEY }}" != "" ]];
           then
             echo "Secrets to upload validations reports to Google Cloud are configured in the repo."
             echo "::set-output name=ok::true"


### PR DESCRIPTION
closes https://github.com/MobilityData/gtfs-validator/issues/1094

**Summary:**

This PR removes the usage of GCP cloud storage. The content of this PR fixes the behavior described [here](https://github.com/MobilityData/gtfs-validator/issues/1094)

**Expected behavior:** 

On forks, acceptance tests should run and not fail because of missing credentials: upload to cloud storage is not used - on this GitHub repository, google cloud storage is used as a backup. 

Please make sure these boxes are checked before submitting your pull request - thanks!

- ~[ ] Run the unit tests with `gradle test` to make sure you didn't break anything~
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
