### PR TITLE
fix: Use `ImmutableMap.Builder.buildOrThrow()` instead of `build()`

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.univocity:univocity-parsers:2.9.0'
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.google.geometry:s2-geometry:2.0.0'
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'commons-validator:commons-validator:1.6'
     implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.13'
     implementation 'com.google.flogger:flogger:0.6'

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     implementation 'com.beust:jcommander:1.48'
     implementation 'javax.inject:javax.inject:1'
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'com.google.flogger:flogger:0.6'
     implementation 'com.google.flogger:flogger-system-backend:0.6'
     implementation 'com.univocity:univocity-parsers:2.9.0'

--- a/output-comparator/build.gradle
+++ b/output-comparator/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     implementation project(':core')
     implementation 'commons-io:commons-io:2.8.0'
     implementation 'com.google.api-client:google-api-client:1.31.2'
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'com.google.flogger:flogger:0.5.1'
     implementation 'com.google.flogger:flogger-system-backend:0.5.1'
     implementation 'com.beust:jcommander:1.48'

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     implementation 'javax.inject:javax.inject:1'
     implementation 'com.squareup:javapoet:1.13.0'
     implementation 'org.apache.commons:commons-lang3:3.6'
-    implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.google.guava:guava:31.0.1-jre'
     implementation 'com.google.flogger:flogger:0.6'
     implementation 'com.univocity:univocity-parsers:2.9.0'
     implementation 'com.google.geometry:s2-geometry:2.0.0'

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsFileDescriptor.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsFileDescriptor.java
@@ -105,7 +105,7 @@ public abstract class GtfsFileDescriptor {
           indicesBuilder.add(field);
         }
       }
-      ImmutableMap<String, GtfsFieldDescriptor> fieldsMap = fieldsMapBuilder.build();
+      ImmutableMap<String, GtfsFieldDescriptor> fieldsMap = fieldsMapBuilder.buildOrThrow();
       ImmutableList.Builder<LatLonDescriptor> latLonBuilder = ImmutableList.builder();
       for (GtfsFieldDescriptor field : fields()) {
         if (!field.type().equals(FieldTypeEnum.LATITUDE)) {


### PR DESCRIPTION
`ImmutableMap.Builder.build()` throws if the same key was added to the builder twice. There were thousands of bugs because many people are not aware of that. The `build()` method is deprecated in Guava 31 and replaced by `buildOrThrow()` with the same behaviour.

See also: https://github.com/google/guava/commit/4b9c269f5cba1431101ffde0290a871769120316
