### PR TITLE
fix: Updates scripts to modify mobilitydatabase.org to old.mobilitydatabase.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Instructions to build the project from the command-line using [Gradle](https://g
 The architecture of the `gtfs-validator` is described on our [Architecture page](/docs/ARCHITECTURE.md).
 
 # Acceptance tests
-In order to avoid sudden changes in the validation output that might declare previously valid datasets invalid, all code changes in pull requests are tested against GTFS datasets in the [MobilityDatabase](http://mobilitydatabase.org/wiki/Main_Page). The acceptance test process is described in [ACCEPTANCE_TESTS.md](docs/ACCEPTANCE_TESTS.md).
+In order to avoid sudden changes in the validation output that might declare previously valid datasets invalid, all code changes in pull requests are tested against GTFS datasets in the [MobilityDatabase](http://old.mobilitydatabase.org/wiki/Main_Page). The acceptance test process is described in [ACCEPTANCE_TESTS.md](docs/ACCEPTANCE_TESTS.md).
 
 # License
 Code licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).

--- a/docs/ACCEPTANCE_TESTS.md
+++ b/docs/ACCEPTANCE_TESTS.md
@@ -12,7 +12,7 @@ If this step is skipped, newly declared invalid datasets could be rejected by GT
    
 ## Process description
 
-For the latest version of all GTFS datasets from the [MobilityDatabase](http://mobilitydatabase.org/wiki/Main_Page), the validation report from both the proposed and the reference validator are compared. An acceptance test report is generated: it quantifies for each agency/dataset the number of new errors (as defined [here](https://github.com/MobilityData/gtfs-validator/blob/master/RULES.md#definitions)) that have been introduced.
+For the latest version of all GTFS datasets from the [MobilityDatabase](http://old.mobilitydatabase.org/wiki/Main_Page), the validation report from both the proposed and the reference validator are compared. An acceptance test report is generated: it quantifies for each agency/dataset the number of new errors (as defined [here](https://github.com/MobilityData/gtfs-validator/blob/master/RULES.md#definitions)) that have been introduced.
 ![steps](https://user-images.githubusercontent.com/35747326/139877746-fd047437-38b3-44fa-aeb8-37d925c289e8.png)
 
 ## Github Actions
@@ -23,7 +23,7 @@ This workflow:
 1. packages the `output-comparator` module;
 1. packages the proposed version of the validator;
 1. downloads the version of the reference validator that is on the [`master` branch](https://github.com/MobilityData/gtfs-validator/tree/master);
-1. defines a matrix of urls (fetched from the [MobilityDatabase](http://mobilitydatabase.org/wiki/Main_Page)) that will be used in the further validation process; 
+1. defines a matrix of urls (fetched from the [MobilityDatabase](http://old.mobilitydatabase.org/wiki/Main_Page)) that will be used in the further validation process; 
 
 On each of these urls:
 1. the reference version of the validator is executed and the validation report is output as JSON (under `reference.json`);
@@ -117,9 +117,9 @@ Sample outputs:
   "maxPercentageCorruptedSources": 2
 } 
 ```
-Where each source id value come from the MobilityDatabase: they are a unique [property](http://mobilitydatabase.org/wiki/Property:P33) used to identify each source of data.
+Where each source id value come from the MobilityDatabase: they are a unique [property](http://old.mobilitydatabase.org/wiki/Property:P33) used to identify each source of data.
 
-The source id can be used to find all datasets versions of a source on the [MobilityDatabase](http://mobilitydatabase.org/wiki/Main_Page) for the sakes of debugging or exploration.
+The source id can be used to find all datasets versions of a source on the [MobilityDatabase](http://old.mobilitydatabase.org/wiki/Main_Page) for the sakes of debugging or exploration.
 
 ## Instructions to run the pipeline
 

--- a/scripts/comment_generator.py
+++ b/scripts/comment_generator.py
@@ -102,7 +102,7 @@ if __name__ == "__main__":
     else:
         comment = (
             comment
-            + " The changes in this pull request did not trigger any new errors on known GTFS datasets from the [MobilityDatabase](http://mobilitydatabase.org/wiki/Main_Page)."
+            + " The changes in this pull request did not trigger any new errors on known GTFS datasets from the [MobilityDatabase](http://old.mobilitydatabase.org/wiki/Main_Page)."
         )
     comment = (
         comment

--- a/scripts/mobility-database-harvester/harvest_latest_versions.py
+++ b/scripts/mobility-database-harvester/harvest_latest_versions.py
@@ -26,7 +26,7 @@ from tqdm import tqdm
 ###############################################################################
 
 # API constants
-API_URL = "http://mobilitydatabase.org/w/api.php?"
+API_URL = "http://old.mobilitydatabase.org/w/api.php?"
 ACTION = "action"
 ARCHIVES_ID_PROPERTY = "P33"
 CLAIMS = "claims"


### PR DESCRIPTION
**Summary:**

The Mobility Database is now hosted on old.mobilitydatabase.org as we are moving to a new solution in the upcoming months. Since the acceptance tests are leveraging the Mobility Database, the scripts using the URL had to be updated.

**Expected behavior:** 

Same as before.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~
