### PR TITLE
ci: Change Java distribution adopt->temurin

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -67,9 +67,10 @@ jobs:
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: '11'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -115,9 +116,10 @@ jobs:
           fi
           echo ::set-output name=versionTag::${VERSION_TAG}
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: '11'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -105,7 +105,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/end_to_end_100.yml
+++ b/.github/workflows/end_to_end_100.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/end_to_end_big.yml
+++ b/.github/workflows/end_to_end_big.yml
@@ -57,7 +57,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -94,7 +94,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:
@@ -136,7 +136,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           java-version: '11'
-          distribution: 'adopt'
+          distribution: 'temurin'
       - name: Cache Gradle packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
**Summary:**

https://github.com/actions/setup-java#supported-distributions says:
>NOTE: Adopt OpenJDK got moved to Eclipse Temurin and won't be updated anymore. It is highly recommended to migrate workflows from adopt to temurin to keep receiving software and security updates. See more details in the [Good-bye AdoptOpenJDK post](https://blog.adoptopenjdk.net/2021/08/goodbye-adoptopenjdk-hello-adoptium/).)

This PR changes GitHub Actions to use temurin instead of adopt as highly recommended above.

It also updates acceptance_test to use `actions/setup-java@v2` instead of `actions/setup-java@v1` to be consistent with the other GitHub Actions.

**Expected behavior:** 

Use temurin Java distribution on CI instead of adopt, use `actions/setup-java@v2` consistently.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
