### PR TITLE
feat(ci): handle gradle build in Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git/
+Dockerfile

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,4 @@
 .git/
 Dockerfile
+build/
+config/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,6 +61,7 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
             VERSION=${VERSION#v}
+            echo ::set-output name=gradleVersionTag::${VERSION}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
@@ -70,7 +71,6 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             TAGS="${DOCKER_IMAGE}:latest"
           fi
-          echo ::set-output name=gradleVersionTag::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Set up JDK 11

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,8 +95,6 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          build-args: |
-            VERSION_TAG=${{ steps.prep.outputs.gradleVersionTag }}
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,10 +56,11 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=ghcr.io/mobilitydata/gtfs-validator
+          DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY}
           VERSION=edge
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}
+            VERSION=${VERSION#v}
           elif [[ $GITHUB_REF == refs/heads/* ]]; then
             VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
           elif [[ $GITHUB_REF == refs/pull/* ]]; then
@@ -69,6 +70,7 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             TAGS="${DOCKER_IMAGE}:latest"
           fi
+          echo ::set-output name=gradleVersionTag::${VERSION}
           echo ::set-output name=tags::${TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Set up JDK 11
@@ -95,6 +97,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            VERSION_TAG=${{ steps.prep.outputs.gradleVersionTag }}
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Prepare
         id: prep
         run: |
-          DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY}
+          DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}
           VERSION=edge
           if [[ $GITHUB_REF == refs/tags/* ]]; then
             VERSION=${GITHUB_REF#refs/tags/}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -82,10 +82,6 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
-      - name: Package cli app jar with Gradle
-        uses: eskatos/gradle-command-action@v1
-        with:
-          arguments: shadowJar
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Login to GitHub Container Registry
@@ -99,6 +95,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          build-args: |
+            VERSION_TAG=${{ steps.prep.outputs.gradleVersionTag }}
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,25 +53,31 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Prepare
+      - name: Initialize Gradle
+        run: |
+          # The first time gradlew is invoked it downloads gradle and outputs progress about that to STDOUT.
+          # This "dummy" invokation gets that out of the way so future gradlew commands have clean output
+          ./gradlew --version
+      - name: Prepare version metadata
         id: prep
         run: |
+          # ghcr.io path should match current repo but be all lowercase
           DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}
-          VERSION=edge
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-            VERSION=${VERSION#v}
-            echo ::set-output name=gradleVersionTag::${VERSION}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-          elif [[ $GITHUB_REF == refs/pull/* ]]; then
-            VERSION=pr-${{ github.event.number }}
+
+          # delegate to axion-release-plugin to generate version string from Git repository state
+          AXION_VERSION="$(./gradlew currentVersion -q -Prelease.quiet)"
+
+          # determine docker tags
+          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
+            # tag releases with version determined by axion-release-plugin
+            DOCKER_TAGS="${DOCKER_IMAGE}:${AXION_VERSION}"
+          else
+            # tag pushes to master as "latest"
+            DOCKER_TAGS="${DOCKER_IMAGE}:latest"
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [ "${{ github.event_name }}" = "push" ]; then
-            TAGS="${DOCKER_IMAGE}:latest"
-          fi
-          echo ::set-output name=tags::${TAGS}
+
+          echo ::set-output name=version::${AXION_VERSION}
+          echo ::set-output name=tags::${DOCKER_TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Set up JDK 11
         uses: actions/setup-java@v2
@@ -98,11 +104,12 @@ jobs:
           context: .
           file: ./Dockerfile
           build-args: |
-            VERSION_TAG=${{ steps.prep.outputs.gradleVersionTag }}
+            VERSION_TAG=${{ steps.prep.outputs.version }}
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=https://github.com/mobilitydata/gtfs-validator.git
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
 # should be org.opencontainers.image.source=${{ github.event.repository.clone_url }} but caps in MobilityData seem to break something

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,13 +10,13 @@ jobs:
   validate_gradle_wrapper:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: gradle/wrapper-validation-action@v1
   test:
     needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -52,7 +52,7 @@ jobs:
     name: Build and push Docker image
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0 # need full clone so ./grade
       - name: Set up JDK 11

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -118,4 +118,3 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.prep.outputs.version }}
-# should be org.opencontainers.image.source=${{ github.event.repository.clone_url }} but caps in MobilityData seem to break something

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,6 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # need full clone so ./grade
       - name: Initialize Gradle
         run: |
           # The first time gradlew is invoked it downloads gradle and outputs progress about that to STDOUT.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -108,7 +108,7 @@ jobs:
           push: true
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
-            org.opencontainers.image.source=https://github.com/mobilitydata/gtfs-validator.git
+            org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY,,}.git
             org.opencontainers.image.created=${{ steps.prep.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.version=${{ steps.prep.outputs.version }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,9 +63,12 @@ jobs:
         run: |
           # ghcr.io path should match current repo but be all lowercase
           DOCKER_IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}
+          echo "Set DOCKER_IMAGE=${DOCKER_IMAGE}"
 
           # delegate to axion-release-plugin to generate version string from Git repository state
+          echo "Detecting version with ./gradlew currentVersion"
           AXION_VERSION="$(./gradlew currentVersion -q -Prelease.quiet)"
+          echo "Set AXION_VERSION=${AXION_VERSION}"
 
           # determine docker tags
           if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
@@ -75,6 +78,7 @@ jobs:
             # tag pushes to master as "latest"
             DOCKER_TAGS="${DOCKER_IMAGE}:latest"
           fi
+          echo "Set DOCKER_TAGS=${DOCKER_TAGS}"
 
           echo ::set-output name=version::${AXION_VERSION}
           echo ::set-output name=tags::${DOCKER_TAGS}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -67,7 +67,7 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,7 @@ jobs:
           echo ::set-output name=tags::${DOCKER_TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       - name: Build and push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -55,6 +55,25 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0 # need full clone so ./grade
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Initialize Gradle
         run: |
           # The first time gradlew is invoked it downloads gradle and outputs progress about that to STDOUT.
@@ -85,25 +104,6 @@ jobs:
           echo ::set-output name=version::${AXION_VERSION}
           echo ::set-output name=tags::${DOCKER_TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      - name: Set up JDK 11
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'temurin'
-      - name: Cache Gradle packages
-        uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 # need full clone so ./grade
+          fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ FROM gradle:7-jdk11-alpine AS build
 COPY --chown=gradle:gradle . /build
 WORKDIR /build
 
-ARG VERSION_TAG
-ENV versionTag=$VERSION_TAG
 RUN gradle shadowJar --no-daemon
 
 
@@ -12,7 +10,4 @@ FROM openjdk:11
 COPY --from=build /build/main/build/libs/*.jar /
 WORKDIR /
 
-ARG VERSION_TAG
-RUN echo "#!/bin/bash\nexec java -jar gtfs-validator-${VERSION_TAG}_cli.jar \"\$@\"" > /entrypoint.sh \
-    && chmod +x /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "java", "-jar", "gtfs-validator-0.1.0-SNAPSHOT-cli.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,18 @@ FROM gradle:7-jdk11-alpine AS build
 COPY --chown=gradle:gradle . /build
 WORKDIR /build
 
-RUN gradle shadowJar --no-daemon
+ARG VERSION_TAG
+RUN ./gradlew shadowJar \
+    --no-daemon \
+    -Prelease.forceVersion=$VERSION_TAG
 
 
 FROM openjdk:11
 COPY --from=build /build/main/build/libs/*.jar /
 WORKDIR /
 
-ENTRYPOINT [ "java", "-jar", "gtfs-validator-0.1.0-SNAPSHOT-cli.jar" ]
+ARG VERSION_TAG
+ENV VERSION_TAG=$VERSION_TAG
+RUN echo "#!/bin/bash\nexec java -jar /gtfs-validator-${VERSION_TAG}-SNAPSHOT-cli.jar \"\$@\"" > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,9 @@ RUN ./gradlew shadowJar \
 
 
 FROM openjdk:11
-COPY --from=build /build/main/build/libs/*.jar /
+COPY --from=build /build/main/build/libs/gtfs-validator-*-cli.jar /gtfs-validator-cli.jar
 WORKDIR /
 
 ARG VERSION_TAG
 ENV VERSION_TAG=$VERSION_TAG
-RUN echo "#!/bin/bash\nexec java -jar /gtfs-validator-${VERSION_TAG}-SNAPSHOT-cli.jar \"\$@\"" > /entrypoint.sh \
-    && chmod +x /entrypoint.sh
-ENTRYPOINT [ "/entrypoint.sh" ]
+ENTRYPOINT [ "java", "-jar", "gtfs-validator-cli.jar" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 
 ARG VERSION_TAG
 ENV versionTag=$VERSION_TAG
-RUN gradle build --no-daemon
+RUN gradle shadowJar --no-daemon
 
 
 FROM openjdk:11

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,3 +11,8 @@ RUN gradle build --no-daemon
 FROM openjdk:11
 COPY --from=build /build/main/build/libs/*.jar /
 WORKDIR /
+
+ARG VERSION_TAG
+RUN echo "#!/bin/bash\nexec java -jar gtfs-validator-${VERSION_TAG}_cli.jar \"\$@\"" > /entrypoint.sh \
+    && chmod +x /entrypoint.sh
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,13 @@
+FROM gradle:7-jdk11-alpine AS build
+
+COPY --chown=gradle:gradle . /build
+WORKDIR /build
+
+ARG VERSION_TAG
+ENV versionTag=$VERSION_TAG
+RUN gradle build --no-daemon
+
+
 FROM openjdk:11
-COPY main/build/libs/*.jar /
+COPY --from=build /build/main/build/libs/*.jar /
 WORKDIR /

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN ./gradlew shadowJar \
     -Prelease.forceVersion="${VERSION_TAG%-SNAPSHOT}"
 
 
-FROM openjdk:11
+FROM openjdk:11-slim
 COPY --from=build /build/main/build/libs/gtfs-validator-*-cli.jar /gtfs-validator-cli.jar
 WORKDIR /
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /build
 ARG VERSION_TAG
 RUN ./gradlew shadowJar \
     --no-daemon \
-    -Prelease.forceVersion=$VERSION_TAG
+    -Prelease.forceVersion="${VERSION_TAG%-SNAPSHOT}"
 
 
 FROM openjdk:11

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A GTFS Schedule (static) [General Transit Feed Specification (GTFS)](https://gtfs.mobilitydata.org/spec/gtfs-schedule) feed validator
 
-This README contains information for the latest version of the project, which is under active development.  You can find the current version of the validator application on the [Releases page](https://github.com/MobilityData/gtfs-validator/releases). 
+This README contains information for the latest version of the project, which is under active development.  You can find the current version of the validator application on the [Releases page](https://github.com/MobilityData/gtfs-validator/releases).
 
 # Introduction
 This is a cross-platform application written in Java that performs the following steps:
@@ -26,7 +26,7 @@ Once installed, run the application and you will see the following screen:
 
 There are two primary options to set:
 
-* `GTFS Input`: Use this to specify the GTFS feed to validate.  You can specify a URL, ZIP file, or a directory containing the individual `.txt` files of a feed.  You can paste the input location directly into the input field or use the `Choose Local File...` button to open a file-chooser dialog to select a file on your local system.  
+* `GTFS Input`: Use this to specify the GTFS feed to validate.  You can specify a URL, ZIP file, or a directory containing the individual `.txt` files of a feed.  You can paste the input location directly into the input field or use the `Choose Local File...` button to open a file-chooser dialog to select a file on your local system.
 * `Output Directory`: This is the directory where the validation reports will be written.
 
 With these two options set, click the "Validate" button to begin validation.
@@ -45,13 +45,13 @@ Before running validation, tap the `Advanced` button to configure other aspects 
 
 # Run the app via command line
 ### Setup
-1. Install [Java 11 or higher](https://www.oracle.com/java/technologies/javase-downloads.html). To check which version of Java is installed on your computer, type the following command in the terminal: `java --version`. 
-2. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` CLI jar (not OS-specific). It is located in the **Assets** section of the release, and it looks like `gtfs-validator-vX.X.X_cli.jar` 
+1. Install [Java 11 or higher](https://www.oracle.com/java/technologies/javase-downloads.html). To check which version of Java is installed on your computer, type the following command in the terminal: `java --version`.
+2. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` CLI jar (not OS-specific). It is located in the **Assets** section of the release, and it looks like `gtfs-validator-vX.X.X_cli.jar`
 3. Open the terminal on your computer
-4. Navigate to the directory containing the jar file. You can do this by typing the following command in the terminal:`cd {directory path}`, where {directory path} is the absolute or relative path to the directory. You can then make sure you're in the right directory by typing `pwd` in the terminal (this stands for *present working directory*). You can also make sure the jar file is there by typing `ls` in the terminal (this stands for *list* and will display the list of files in this directory). More about commands to navigate file and directories [here](https://help.ubuntu.com/community/UsingTheTerminal#File_.26_Directory_Commands). 
+4. Navigate to the directory containing the jar file. You can do this by typing the following command in the terminal:`cd {directory path}`, where {directory path} is the absolute or relative path to the directory. You can then make sure you're in the right directory by typing `pwd` in the terminal (this stands for *present working directory*). You can also make sure the jar file is there by typing `ls` in the terminal (this stands for *list* and will display the list of files in this directory). More about commands to navigate file and directories [here](https://help.ubuntu.com/community/UsingTheTerminal#File_.26_Directory_Commands).
 
 ### Run it
-You can run this validator using a GTFS dataset on your computer, or from a URL. 
+You can run this validator using a GTFS dataset on your computer, or from a URL.
 - To validate a GTFS dataset on your computer, run the following command in the terminal, replacing the text in brackets:
   - `java -jar {name of the jar file} -i {path to the GTFS file} -o {name of the output directory that will be created}`
   - here is an example of what the command could look like:  `java -jar gtfs-validator-cli.jar -i /myDirectory/gtfs.zip -o output`
@@ -86,6 +86,20 @@ where:
 `... c:/myDirectory:/theContainerDirectory ...`
 
 The validator can then be executed via bash commands. See the [preceeding instructions for command line usage](#run-the-app-via-command-line).
+
+### Build Docker container locally
+
+To build a Docker image locally from source (e.g. to test an unmerged branch):
+
+```bash
+docker build . --build-arg=VERSION_TAG=v3 -t gtfs-validator:latest
+```
+
+The locally-built image could then be run via the local `gtfs-validator:latest` assigned above:
+
+```bash
+docker run --rm gtfs-validator:latest --help
+```
 
 ### Visualize the results
 In the output directory, the reports will be created as described [here](#visualize-the-results).
@@ -123,4 +137,4 @@ In order to avoid sudden changes in the validation output that might declare pre
 Code licensed under the [Apache 2.0 License](http://www.apache.org/licenses/LICENSE-2.0).
 
 # Contributing
-We welcome contributions to the project! Please check out our [Contribution guidelines](/docs/CONTRIBUTING.md) for details. 
+We welcome contributions to the project! Please check out our [Contribution guidelines](/docs/CONTRIBUTING.md) for details.

--- a/README.md
+++ b/README.md
@@ -68,38 +68,43 @@ In the output directory, the reports will be created as described [here](#visual
 # Run the app using Docker
 ### Setup
 1. Download and install [Docker](https://docs.docker.com/get-started/)
-1. Pull the [latest Docker image for this project](https://github.com/orgs/MobilityData/packages/container/package/gtfs-validator). For example, `docker pull ghcr.io/mobilitydata/gtfs-validator` for the latest snapshot version of the validator.
+1. To obtain a validator Docker container image, you have two options:
+    * Pull [a published Docker container image from GitHub](https://github.com/orgs/MobilityData/packages/container/package/gtfs-validator). For example, to pull the latest build of the `master` branch:
+
+        ```bash
+        docker pull ghcr.io/mobilitydata/gtfs-validator:latest
+        ```
+
+    * Build a Docker container image locally from any branch or working tree:
+
+        ```bash
+        docker build . -t ghcr.io/mobilitydata/gtfs-validator:latest
+        ```
 
 ### Run it
 
 #### For Mac and Linux
 
-To run the Docker image in a new container:
+To verify you can run the Docker image in a new container and see the help text:
 
-`docker run -v /myDirectory:/theContainerDirectory -it ghcr.io/mobilitydata/gtfs-validator:latest`
+```bash
+docker run --rm ghcr.io/mobilitydata/gtfs-validator:latest --help
+```
+
+In order to pass files in and out of the validator, you'll need to use a volume mount to share a directory between your host computer and the Docker container:
+
+```bash
+docker run --rm -v /myDirectory:/work ghcr.io/mobilitydata/gtfs-validator:latest -i /work/gtfs.zip -o /work/output
+```
 
 where:
-* `-v /myDirectory:/theContainerDirectory`: syntax to share directories and data between the container and the host (your computer). With the above command, any files that you place in `/myDirectory` on the host will show up in `/theContainerDirectory` inside the container and vice versa.
+* `-v /myDirectory:/work`: syntax to share directories and data between the container and the host (your computer). With the above command, any files that you place in `/myDirectory` on the host will show up in `/work` inside the container and vice versa.
 
 ***NOTE:*** On Windows, you must provide the local volume (e.g., `c:`) as well:
 
-`... c:/myDirectory:/theContainerDirectory ...`
+`... c:/myDirectory:/work ...`
 
 The validator can then be executed via bash commands. See the [preceeding instructions for command line usage](#run-the-app-via-command-line).
-
-### Build Docker container locally
-
-To build a Docker image locally from source (e.g. to test an unmerged branch):
-
-```bash
-docker build . --build-arg=VERSION_TAG=v3 -t gtfs-validator:latest
-```
-
-The locally-built image could then be run via the local `gtfs-validator:latest` assigned above:
-
-```bash
-docker run --rm gtfs-validator:latest --help
-```
 
 ### Visualize the results
 In the output directory, the reports will be created as described [here](#visualize-the-results).


### PR DESCRIPTION
**Summary:**

As a new contributor wanting to try building/running PR branches locally, I was surprised that the `Dockerfile` didn't actually build the application but rather relied on it being built first by a toolchain on the host machine. The intent of `Dockerfile` is usually to capture and pin the build dependencies as well as runtime environment.

**Expected behavior:** 

`docker build .` always goes from branch source to ready-to-run container image

**Proposal:**

Ideally `Dockerfile` handles a full build from source. I also configured the default entrypoint to handle running the CLI, as the instructions indicated running the Docker container would give you a shell you could run the jar on but you'd need to override the entrypoint to `sh` to get that rather than the jShell the JDK base image comes with.

**Testing:**

```bash
docker build . --build-arg=VERSION_TAG=3.4.5 -t gtfs-validator:latest
docker run --rm gtfs-validator:latest --help
```

**Potential improvements:**

- ~~Inserting `RUN apk add npm` after the first `FROM` line is needed on branches that include the HTML UI~~
- [X] Update/extend the Docker instructions in the README if these changes are acceptable in spirit
- [X] Use `openjdk:11-slim` or `openjdk:19-alpine` as the runtime base image
   - Alpine would be ideal as it offers the smallest base image, but `-alpine` variants are only available starting with the latest major version 19, so we would need to verify that everything functions correctly under JDK 19
   - This might best be done in a separate PR since it introduces a higher risk of runtime behavior change and this PR as-is is fairly isolated from causing any runtime behavior changes (see #1185)

**Open questions:**

- Is this an acceptable change?
- Are there any other processes besides the GitHub workflow I updated in this PR that script what happens before `docker build` that would need updating too?