### PR TITLE
fix: Set encoding to UTF-8 for Javadoc generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,11 @@ repositories {
     mavenCentral()
 }
 
+// Setup and configure Javadoc plugin
 apply plugin: 'nebula-aggregate-javadocs'
+allprojects {
+    tasks.withType(Javadoc) { options.encoding = 'UTF-8' }
+}
 
 // A resolvable configuration to collect test reports data
 configurations {


### PR DESCRIPTION
**Summary:**

As mentioned in https://github.com/MobilityData/gtfs-validator/issues/1101#issuecomment-1103212380, we need to configure character encoding for the Javadoc generation plugin separately.

This PR sets the character encoding for the Javadoc plugin.

Closes https://github.com/MobilityData/gtfs-validator/issues/1101

**Expected behavior:** 

`./gradlew aggregateJavadocs` successfully runs on Windows.

I've tested on Windows 10 Home using JDK 11.0.12

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
