### PR TITLE
docs: Add gradle commands shadowJar and aggregateJavadocs

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -17,3 +17,19 @@ To build the application simply click the hammer in the header section
 ```
 $ ./gradlew test
 ```
+
+## Packaging JAR with all dependencies
+
+To build a JAR that can run stand-alone without any additional classes on the classpath (sometimes called an "uber" or "fat" JAR), run:
+
+```
+$ ./gradlew shadowJar
+```
+
+## Generating Javadocs
+
+To generate Javadocs for the project, run:
+
+```
+$ ./gradlew aggregateJavadocs
+```


### PR DESCRIPTION
**Summary:**

Gradle commands `shadowJar` and `aggregateJavadocs` are currently missing from the build docs. Currently you have to hunt through the GitHub Action CI code to find them.

This PR adds them to the build docs to make them more obvious.

**Expected behavior:** 

I should be able to read the build docs and understand all the key Gradle tasks that help me to build and run the project.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
