### PR TITLE
feat: Packaged Executable

### DIFF
--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           versionTag: ${{ needs.prepare-version-name.outputs.versionTag }}
         with:
-          arguments: aggregateJavadocs
+          arguments: aggregateJavadoc
       - name: Persist javadoc
         uses: actions/upload-artifact@v2
         with:

--- a/app/gui/build.gradle
+++ b/app/gui/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Google LLC, MobilityData IO
+ * Copyright 2020-2022 Google LLC, MobilityData IO
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/gui/build.gradle
+++ b/app/gui/build.gradle
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'application'
+    id 'java'
+    id 'com.github.johnrengelman.shadow' version '5.2.0'
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+mainClassName = 'org.mobilitydata.gtfsvalidator.app.gui.Main'
+compileJava.options.encoding = "UTF-8"
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':main')
+    implementation 'com.google.flogger:flogger:0.6'
+    implementation 'com.google.flogger:flogger-system-backend:0.6'
+}
+
+jar {
+    manifest {
+        attributes('Implementation-Title': rootProject.name,
+                'Implementation-Version': project.version,
+                'Main-Class': 'org.mobilitydata.gtfsvalidator.app.gui.Main')
+    }
+}
+
+shadowJar {
+    minimize {
+        // We don't want to minimize the :main project, as it will drop the validators
+        // loaded via reflection
+        exclude(project(':main'))
+
+        exclude(dependency('org.apache.httpcomponents:httpclient'))
+    }
+
+    // Some of our dependencies include their own module-info declarations.  We drop
+    // all of them, as we'll be wrapping the entire uber jar as a module in :app:pkg
+    // and we don't want these existing module-info declarations to conflict.
+    exclude 'module-info.class'
+    exclude 'META-INF/versions/*/module-info.class'
+}

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -8,10 +8,22 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The main entry point for the GUI application.
+ *
+ * Compared to the CLI jar, this entry point is designed to be packaged as a
+ * native application to be run directly by the user.
+ *
+ * TODO(bdferris): Follow up work will add a minimal UI for selecting the input
+ * GTFS and potentially the output directory.
+ */
 public class Main {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   public static void main(String[] args) {
+    // On Windows, if you drag a file onto the application shortcut, it will
+    // execute the app with the file as the first command-line argument.  This
+    // doesn't appear to work on Mac OS.
     if (args.length != 1) {
       System.exit(-1);
     }

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -1,0 +1,45 @@
+package org.mobilitydata.gtfsvalidator.app.gui;
+
+import com.google.common.flogger.FluentLogger;
+import java.awt.Desktop;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+public class Main {
+  private static final FluentLogger logger = FluentLogger.forEnclosingClass();
+
+  public static void main(String[] args) {
+    if (args.length != 1) {
+      System.exit(-1);
+    }
+
+    Path workingDirectory = null;
+    try {
+      workingDirectory = Files.createTempDirectory("GtfsValidator");
+    } catch (IOException ex) {
+      logger.atSevere().withCause(ex).log("Error creating working directory");
+      System.exit(-1);
+    }
+
+    List<String> cliArgs = new ArrayList<>();
+    cliArgs.add("-i");
+    cliArgs.add(args[0]);
+    cliArgs.add("-o");
+    cliArgs.add(workingDirectory.toString());
+    cliArgs.add("--pretty");
+
+    org.mobilitydata.gtfsvalidator.cli.Main.main(cliArgs.toArray(new String[] {}));
+
+    Path reportPath = workingDirectory.resolve("report.json");
+
+    try {
+      Desktop.getDesktop().browse(reportPath.toUri());
+    } catch (IOException ex) {
+      logger.atSevere().withCause(ex).log("Error opening browser");
+      System.exit(-1);
+    }
+  }
+}

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
  * <p>Compared to the CLI jar, this entry point is designed to be packaged as a native application
  * to be run directly by the user.
  *
- * <p>TODO(bdferris): Follow up work will add a minimal UI for selecting the input GTFS and
+ * <p>TODO(#1134): Follow up work will add a minimal UI for selecting the input GTFS and
  * potentially the output directory.
  */
 public class Main {
@@ -64,7 +64,8 @@ public class Main {
   }
 
   private static void run(String path) {
-
+    // TODO(#1135): Refactor this code to call GTFS validation code directly
+    // instead of constructing artifical command-line args and calling cli.Main.
     Path workingDirectory = null;
     try {
       workingDirectory = Files.createTempDirectory("GtfsValidator");

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.mobilitydata.gtfsvalidator.app.gui;
 
 import com.google.common.flogger.FluentLogger;

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -3,30 +3,52 @@ package org.mobilitydata.gtfsvalidator.app.gui;
 import com.google.common.flogger.FluentLogger;
 import java.awt.Desktop;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 /**
  * The main entry point for the GUI application.
  *
- * Compared to the CLI jar, this entry point is designed to be packaged as a
- * native application to be run directly by the user.
+ * <p>Compared to the CLI jar, this entry point is designed to be packaged as a native application
+ * to be run directly by the user.
  *
- * TODO(bdferris): Follow up work will add a minimal UI for selecting the input
- * GTFS and potentially the output directory.
+ * <p>TODO(bdferris): Follow up work will add a minimal UI for selecting the input GTFS and
+ * potentially the output directory.
  */
 public class Main {
+  static {
+    try (InputStream inputStream = Main.class.getResourceAsStream("/logging.properties")) {
+      LogManager.getLogManager().readConfiguration(inputStream);
+    } catch (IOException e) {
+      Logger.getAnonymousLogger().severe("Could not load default logging.properties file");
+      Logger.getAnonymousLogger().severe(e.getMessage());
+    }
+  }
+
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   public static void main(String[] args) {
+    logger.atInfo().log("gtfs-validator: start");
+
     // On Windows, if you drag a file onto the application shortcut, it will
     // execute the app with the file as the first command-line argument.  This
     // doesn't appear to work on Mac OS.
     if (args.length != 1) {
+      logger.atSevere().log("No GTFS input specified - args=%d", args.length);
       System.exit(-1);
+    } else {
+      run(args[0]);
     }
+
+    logger.atInfo().log("gtfs-validator: exit");
+  }
+
+  private static void run(String path) {
 
     Path workingDirectory = null;
     try {
@@ -38,7 +60,7 @@ public class Main {
 
     List<String> cliArgs = new ArrayList<>();
     cliArgs.add("-i");
-    cliArgs.add(args[0]);
+    cliArgs.add(path);
     cliArgs.add("-o");
     cliArgs.add(workingDirectory.toString());
     cliArgs.add("--pretty");

--- a/app/gui/src/main/resources/logging.properties
+++ b/app/gui/src/main/resources/logging.properties
@@ -1,0 +1,5 @@
+handlers=java.util.logging.FileHandler,java.util.logging.ConsoleHandler
+
+java.util.logging.FileHandler.pattern=%h/gtfs-validator.log
+java.util.logging.FileHandler.count=1
+java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter

--- a/app/gui/src/main/resources/logging.properties
+++ b/app/gui/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 handlers=java.util.logging.FileHandler,java.util.logging.ConsoleHandler
 
-java.util.logging.FileHandler.pattern=%h/gtfs-validator.log
+java.util.logging.FileHandler.pattern=%h/GtfsValidator/run.log
 java.util.logging.FileHandler.count=1
 java.util.logging.FileHandler.formatter=java.util.logging.SimpleFormatter

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC, MobilityData IO
+ * Copyright 2022 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -99,3 +99,12 @@ jlink {
     }
 }
 
+javadoc {
+    // Our complex use of a shadow jar dependency bundled as a Java Module
+    // (see above) causes problems for the Javadoc compiler, especially when
+    // run in aggregate mode over the entire project.  As such, we disable
+    // Javadoc for this sub-project to avoid issues.  Since there isn't much
+    // real source-code in the :pkg project, it's no big loss.
+    enabled = false
+}
+

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id 'java'
+    id "de.jjohannes.extra-java-module-info" version "0.11"
+    id "org.beryx.jlink" version "2.24.1"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Note that we depend on the :app:gui shadow jar, which bundles the gui
+    // application and all its dependencies into a single uber jar.
+    implementation project(path: ':app:gui', configuration: 'shadow')
+}
+
+extraJavaModuleInfo {
+    // JPackage (below) requires that we package our application as a Java
+    // Module.  Instead of attempting to modularize the entire gtfs-validator
+    // project, we instead make this project a module and moduarlize our single
+    // :app:gui uber-jar dependency by injecting a module-info.class entry into
+    // the jar with its native dependencies.
+    //
+    // See additional discussion in https://bit.ly/gtfs-validator-packaged-exe and
+    // https://docs.gradle.org/current/samples/sample_java_modules_with_transform.html
+    module('gui-all.jar', 'org.mobilitydata.gtfsvalidator.app.gui', project.version) {
+        exports('org.mobilitydata.gtfsvalidator.app.gui')
+
+        // This is the set of core Java modules that our application depends on.
+        // This list was hand-curated by looking at the output of `jdeps -s` on
+        // the full application jar, which produces some false positives given
+        // that not all code-paths in our dependencies are actually used.  I
+        // have also run the app with no module dependencies to see what kind
+        // of exceptions we get.
+        requires('java.compiler')
+        requires('java.desktop')
+        requires('java.logging')
+        requires('java.naming')
+        requires('java.security.jgss')
+        requires('java.sql')
+  }
+}
+
+sourceCompatibility = JavaVersion.VERSION_11
+compileJava.options.encoding = "UTF-8"
+
+java {
+    modularity.inferModulePath = true
+}
+
+application {
+    mainClass = 'org.mobilitydata.gtfsvalidator.app.pkg.Main'
+    mainModule = 'org.mobilitydata.gtfsvalidator.app.pkg'
+}
+
+jar {
+    // Add the manifest within the JAR, using gtfs-validator as the title
+    manifest {
+        attributes('Implementation-Title': rootProject.name,
+                'Implementation-Version': project.version)
+    }
+}
+
+// Debugging tips:
+// If you ever get an error when running the `jpackage` task like:
+//   Error reading module: app/pkg/build/jlinkbase/jlinkjars/pkg.jar
+// (and not much else), rerun the Gradle task with --debug specified and look
+// for the full command-line executed for `jlink` or `jpackage`.  Copy the
+// command-line and run it directly with a `-J-Djlink.debug=true` flag added
+// and you will get more useful information about what went wrong.
+jlink {
+    moduleName = 'org.mobilitydata.gtfsvalidator.app.pkg'
+    launcher {
+        name = 'GTFS Validator'
+    }
+    // Passed to jlink to create an even smaller JRE.
+    options = ['--strip-debug', '--compress', '2', '--no-header-files', '--no-man-pages']
+    jpackage {
+        if (org.gradle.internal.os.OperatingSystem.current().windows) {
+            installerOptions += ['--win-per-user-install', '--win-dir-chooser', '--win-menu', '--win-shortcut']
+            imageOptions += ['--win-console']
+        }
+    }
+}
+

--- a/app/pkg/src/main/java/module-info.java
+++ b/app/pkg/src/main/java/module-info.java
@@ -1,0 +1,3 @@
+module org.mobilitydata.gtfsvalidator.app.pkg {
+  requires org.mobilitydata.gtfsvalidator.app.gui;
+}

--- a/app/pkg/src/main/java/org/mobilitydata/gtfsvalidator/app/pkg/Main.java
+++ b/app/pkg/src/main/java/org/mobilitydata/gtfsvalidator/app/pkg/Main.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.mobilitydata.gtfsvalidator.app.pkg;
 
 /**

--- a/app/pkg/src/main/java/org/mobilitydata/gtfsvalidator/app/pkg/Main.java
+++ b/app/pkg/src/main/java/org/mobilitydata/gtfsvalidator/app/pkg/Main.java
@@ -1,0 +1,10 @@
+package org.mobilitydata.gtfsvalidator.app.pkg;
+
+/**
+ * This is just a simple stub around app.gui.Main to assist with Java modularization and packaging.
+ */
+public class Main {
+  public static void main(String[] args) {
+    org.mobilitydata.gtfsvalidator.app.gui.Main.main(args);
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -14,19 +14,10 @@
  * limitations under the License.
  */
 
-// so we can aggregate all Javadocs in one
-// see: https://github.com/nebula-plugins/gradle-aggregate-javadocs-plugin
-buildscript {
-    repositories { mavenCentral() }
-
-    dependencies {
-        classpath 'com.netflix.nebula:gradle-aggregate-javadocs-plugin:3.0.1'
-    }
-}
-
 plugins {
     id 'java'
     id 'com.github.sherter.google-java-format' version '0.9'
+    id "io.freefair.aggregate-javadoc-jar" version "6.4.3"
 }
 
 repositories {
@@ -34,7 +25,6 @@ repositories {
 }
 
 // Setup and configure Javadoc plugin
-apply plugin: 'nebula-aggregate-javadocs'
 allprojects {
     tasks.withType(Javadoc) { options.encoding = 'UTF-8' }
 }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'commons-validator:commons-validator:1.6'
     implementation 'com.googlecode.libphonenumber:libphonenumber:8.12.13'
     implementation 'com.google.flogger:flogger:0.6'
+    implementation 'io.github.classgraph:classgraph:4.8.146'
     testImplementation 'com.google.flogger:flogger-system-backend:0.6'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
     testImplementation "com.google.truth:truth:1.0.1"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,8 +1,17 @@
 # Architecture description
-`gtfs-validator` counts three principal modules: [`main`](/main), [`processor`](/processor) and [`core`](/core). These modules dependencies are illustrated in the following diagram:
-![architecture schema](https://user-images.githubusercontent.com/35747326/101182386-610e9400-3624-11eb-84b9-ec935e44aa2b.png)
+`gtfs-validator` is composed from a number modules, as shown in the following dependency diagram:
 
-This new architecture leverages `AutoValue` and annotations to auto-generate the following classes used for loading and validation:
+```mermaid
+graph BT;
+  core
+    main-->core;
+    main-->processor;
+    processor-->core;
+    app:gui-->main;
+    app:pkg-->app:gui;
+```
+
+The architecture leverages `AutoValue` and annotations to auto-generate the following classes used for loading and validation:
 * all classes used to internally represent GTFS data (such as `GtfsStopTime.java`) 
 * `*Schema.java` (such as `GtfsAgencySchema.java`)
 * `*Enum.java` (such as `GtfsFrequencyExactTimeEnum.java`)
@@ -42,6 +51,16 @@ _Depends on: nothing_
 - GTFS data type definitions such as `GtfsTime`, `GtfsDate`, or `GtfsColor`
 - `GtfsFeedLoader` to load for a whole GTFS feed with all its CSV files
 - GTFS feed's name
+
+## App:Gui
+_Depends on: `main`_
+
+A [GUI-based application](/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui) for running the validator as a desktop application.
+
+## App:Pkg
+_Depends on: `app:gui`_
+
+A [minimal wrapper]((/app/pkg/src/main/java/org/mobilitydata/gtfsvalidator/app/pkg)) around `app:gui` designed to facilitate packaging the GUI application as a Java Module and producing standalone executables and installers for various platforms.
 
 ## Data pipeline 📥➡️♨➡️📤
 

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -28,6 +28,9 @@ To build a JAR that can run stand-alone without any additional classes on the cl
 
 ## Packaging as Installable Application
 
+**NOTE:** The installable application is under active development.  It currently
+works best on Windows.
+
 To build an installable application package appropriate for your operating system
 (e.g. Windows, Mac OS, Linux), first make sure you have a recent version of the
 JDK installed (ver >= 15) that includes `jlink` and `jpackage`.  If you intend

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -26,6 +26,28 @@ To build a JAR that can run stand-alone without any additional classes on the cl
 $ ./gradlew shadowJar
 ```
 
+## Packaging as Installable Application
+
+To build an installable application package appropriate for your operating system
+(e.g. Windows, Mac OS, Linux), first make sure you have a recent version of the
+JDK installed (ver >= 15) that includes `jlink` and `jpackage`.  If you intend
+to redistribute the built application publicly, make sure it's an OpenJDK
+distribution (likely a recent build linked from https://openjdk.java.net/install/,
+ok if it's built by Oracle) and *NOT* an Oracle *commercial* JDK, where license
+and redistribution terms are murkier.
+
+To build the app and installer, run:
+
+```
+$ ./gradlew clean jpackage
+```
+
+and look for the resulting application artifacts in:
+
+```
+./app/pkg/build/jpackage/
+```
+
 ## Generating Javadocs
 
 To generate Javadocs for the project, run:

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -39,7 +39,7 @@ and redistribution terms are murkier.
 To build the app and installer, run:
 
 ```
-$ ./gradlew clean jpackage
+./gradlew clean jpackage
 ```
 
 and look for the resulting application artifacts in:

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -36,6 +36,17 @@ distribution (likely a recent build linked from https://openjdk.java.net/install
 ok if it's built by Oracle) and *NOT* an Oracle *commercial* JDK, where license
 and redistribution terms are murkier.
 
+If building on Windows, have https://wixtoolset.org/ installed on your path for
+Windows Installer support.  When installing WiX, if you get an error like:
+
+```
+WiX Toolset requires .NET Framework 3.5.1...
+```
+
+you can navigate to "Control Panel > All Control Panel Items > Programs and Features"
+and enable the Windows Features for .NET framework
+([stackoverflow](https://stackoverflow.com/a/57820594/937715)).
+
 To build the app and installer, run:
 
 ```

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,6 @@
 rootProject.name = 'gtfs-validator'
+include 'app:gui'
+include 'app:pkg'
 include 'core'
 include 'processor'
 include 'main'


### PR DESCRIPTION
**Summary:**

Introduces functionality to package the GTFS Validator as an installable application, including a bundled JRE, to make it easier for users to run the validator.  As discussed in issue #1112, https://bit.ly/gtfs-validator-packaged-exe, and #1124.

Note: This is an initial draft review to get agreement on package structure before additional follow-up work.

**Expected behavior:** 

Prerequisites:
* A Windows or Mac OS build machine (I haven't tested on Linux, but it should theoretically work there as well)
* A Java SDK that includes `jlink` and `jpackage`
* If building on Windows, have https://wixtoolset.org/ installed on your path for Windows Installer support

To package:
* run `./gradlew jpackage`

Expected:
* You should find a "GTFS Validator" application and installer in the `app/pkg/build/jpackage` directory.

The current application is just a simple wrapper around the existing CLI.  On Windows, you can run the validator by dragging a GTFS zip file onto the application shortcut.  On Mac OS, you still have to run it from the command-line while we wait on some simple GUI support (e.g. `GTFS\ Validator.app/Contents/MacOS/GTFS\ Validator path/to/your/gtfs.zip`).

Future work will include:
* refactor the `main` sub-project to separate table+validation code from the cli code
* adding a simple UI for selecting a GTFS feed, output directory, configuring the validator, etc