### PR TITLE
Docs: fix typo for Missing RequiredFileNotice

### DIFF
--- a/docs/NOTICES.md
+++ b/docs/NOTICES.md
@@ -495,8 +495,6 @@
 | Field name   	| Description                    	| Type   	|
 |--------------	|--------------------------------	|--------	|
 | `filename`   	| The name of the faulty file.   	| String 	|
-| `csvRowNumber`| The row of the faulty record.  	| Long   	|
-| `fieldName`  	| The name of the missing field. 	| String 	|
 
 ##### Affected files
 [All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)


### PR DESCRIPTION
**Summary:**
The table in `NOTICES.md` was showing more values than what the notice produced. 

**Expected behaviour:** 
Only the file name is produced by this notice, as seen in the `MissingRequiredFileNotice.java` file:
```
public class MissingRequiredFileNotice extends ValidationNotice {
  private final String filename;

  public MissingRequiredFileNotice(String filename) {
    super(SeverityLevel.ERROR);
    this.filename = filename;
  }
}
```

Please make sure these boxes are checked before submitting your pull request - thanks!

~~- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything~~
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
