### PR TITLE
docs: Remove dollar sign from commands

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -15,7 +15,7 @@ To build the application simply click the hammer in the header section
 ## Running unit tests
 1. Run the following command at the root of the project to run Java tests:
 ```
-$ ./gradlew test
+./gradlew test
 ```
 
 ## Packaging JAR with all dependencies
@@ -23,7 +23,7 @@ $ ./gradlew test
 To build a JAR that can run stand-alone without any additional classes on the classpath (sometimes called an "uber" or "fat" JAR), run:
 
 ```
-$ ./gradlew shadowJar
+./gradlew shadowJar
 ```
 
 ## Generating Javadocs
@@ -31,5 +31,5 @@ $ ./gradlew shadowJar
 To generate Javadocs for the project, run:
 
 ```
-$ ./gradlew aggregateJavadocs
+./gradlew aggregateJavadocs
 ```


### PR DESCRIPTION
**Summary:**

The `$` isn't actually part of the command you need to execute. 

IMHO the docs are better without it because it makes it easier to copy/paste if you're familiar with running things from the command line, and is less confusing if you're not as you'll get an error if you include the dollar sign in the command.

**Expected behavior:** 

Docs for commands should include exact commands that can be copy/paste into command line and execute.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
