### PR TITLE
ci: Remove ubuntu-20.04 from CI

### DIFF
--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       matrix:
         java_version: [ 11, 17 ]
-        os: [ ubuntu-latest, windows-latest, ubuntu-20.04 ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK ${{ matrix.java_version }}
@@ -86,7 +86,7 @@ jobs:
     strategy:
       matrix:
         java_version: [ 11, 17 ]
-        os: [ ubuntu-latest, windows-latest, ubuntu-20.04 ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK ${{ matrix.java_version }}
@@ -117,7 +117,7 @@ jobs:
     strategy:
       matrix:
         java_version: [ 11, 17 ]
-        os: [ ubuntu-latest, ubuntu-20.04, windows-latest ]
+        os: [ ubuntu-latest, windows-latest ]
     steps:
       - uses: actions/checkout@v1
       - name: Set up JDK ${{ matrix.java_version }}


### PR DESCRIPTION
**Summary:**

I believe ubuntu-20.04 was originally added to troubleshoot issues discussed in PR https://github.com/MobilityData/gtfs-validator/pull/1086, which have since been resolved.

Given that:
* we have a lot of CI tests running, which makes review of the CI tests challenging (see https://github.com/MobilityData/gtfs-validator/issues/1095)
* these seem to be redundant given that we're also running on `ubuntu-latest`

...I'm proposing that we remove running on this specific version of ubuntu. 

This should remove 6 redundant checks (3 occurrences x 2 for each Java version 11 and 17) and will also reduce the amount of time required for all CI checks to complete.

**Expected behavior:** 

Don't run redundant CI tests.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
