### PR TITLE
fix: Docker Image push to GitHub Container Registry

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v2
         with:


### PR DESCRIPTION

Fixes #1105 : Docker builds are failing

This PR replaces the Personal Access Token (PAT) used in the `docker.yml` workflow with a GitHub Token. [According to GitHub](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#authenticating-to-the-container-registry), PATs used to authenticate to `ghcr.io` should be avoided. 

Along with the changes made in this PR, the steps shown [here](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-ghcrio) were followed so that the package could access the GitHub token.

**Expected behavior:** 

The Docker Image push to GitHub Container Registry should work properly.

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] ~Include screenshot(s) showing how this pull request works and fixes the issue(s)~
