### PR TITLE
fix: Correct GTFS input path handling on Windows

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -228,7 +228,7 @@ public class ValidationRunner {
       throws IOException, URISyntaxException {
     URI source = config.gtfsSource();
     if (source.getScheme().equals("file")) {
-      return GtfsInput.createFromPath(Paths.get(source.getPath()));
+      return GtfsInput.createFromPath(Paths.get(source));
     }
 
     if (config.storageDirectory().isEmpty()) {


### PR DESCRIPTION
**Summary:**

As reported in https://github.com/MobilityData/gtfs-validator/issues/1158, path handling for GTFS input changed and is now broken on Windows (but not Linux).

This PR fixes the path handling so it works on Windows as well.

**Expected behavior:** 

Path handling should work without issues when running on Windows or Linux.

I've also opened PR https://github.com/MobilityData/gtfs-validator/pull/1155 that will add a Windows end-to-end check on CI to catch these Windows-specific issues earlier.

Closes https://github.com/MobilityData/gtfs-validator/issues/1158

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
