### PR TITLE
feat: Persist GUI app settings between executions

### DIFF
--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferences.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferences.java
@@ -1,0 +1,76 @@
+package org.mobilitydata.gtfsvalidator.app.gui;
+
+import java.nio.file.Path;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.prefs.Preferences;
+
+/**
+ * Supports loading and saving application preferences from a persistent {@link Preferences} backend
+ * across application runs.
+ */
+public class GtfsValidatorPreferences {
+
+  private static final String KEY_GTFS_SOURCE = "gtfs_source";
+  private static final String KEY_OUTPUT_DIRECTORY = "output_directory";
+  private static final String KEY_NUM_THREADS = "num_threads";
+  private static final String KEY_COUNTRY_CODE = "country_code";
+
+  private final Preferences prefs;
+
+  public GtfsValidatorPreferences() {
+    this(Preferences.userNodeForPackage(GtfsValidatorPreferences.class));
+  }
+
+  GtfsValidatorPreferences(Preferences prefs) {
+    this.prefs = prefs;
+  }
+
+  public void loadPreferences(GtfsValidatorApp app) {
+    loadStringSetting(KEY_GTFS_SOURCE, app::setGtfsSource);
+    loadPathSetting(KEY_OUTPUT_DIRECTORY, app::setOutputDirectory);
+    loadIntSetting(KEY_NUM_THREADS, app::setNumThreads);
+    loadStringSetting(KEY_COUNTRY_CODE, app::setCountryCode);
+  }
+
+  public void savePreferences(GtfsValidatorApp app) {
+    saveStringSetting(app::getGtfsSource, KEY_GTFS_SOURCE);
+    saveStringSetting(app::getOutputDirectory, KEY_OUTPUT_DIRECTORY);
+    saveIntSetting(app::getNumThreads, KEY_NUM_THREADS);
+    saveStringSetting(app::getCountryCode, KEY_COUNTRY_CODE);
+  }
+
+  private void loadStringSetting(String key, Consumer<String> setter) {
+    String value = prefs.get(key, "");
+    if (!value.isBlank()) {
+      setter.accept(value);
+    }
+  }
+
+  private void loadIntSetting(String key, Consumer<Integer> setter) {
+    loadStringSetting(key, (value) -> setter.accept(Integer.parseInt(value)));
+  }
+
+  private void loadPathSetting(String key, Consumer<Path> setter) {
+    loadStringSetting(key, (value) -> setter.accept(Path.of(value)));
+  }
+
+  private void saveStringSetting(Supplier<String> getter, String key) {
+    String value = getter.get();
+    if (!value.isBlank()) {
+      prefs.put(key, value);
+    }
+  }
+
+  private void saveIntSetting(Supplier<Integer> getter, String key) {
+    saveStringSetting(
+        () -> {
+          Integer value = getter.get();
+          if (value == null || value == 0) {
+            return "";
+          }
+          return value.toString();
+        },
+        key);
+  }
+}

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferences.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferences.java
@@ -19,11 +19,7 @@ public class GtfsValidatorPreferences {
   private final Preferences prefs;
 
   public GtfsValidatorPreferences() {
-    this(Preferences.userNodeForPackage(GtfsValidatorPreferences.class));
-  }
-
-  GtfsValidatorPreferences(Preferences prefs) {
-    this.prefs = prefs;
+    this.prefs = Preferences.userNodeForPackage(GtfsValidatorPreferences.class);
   }
 
   public void loadPreferences(GtfsValidatorApp app) {

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -58,12 +58,16 @@ public class Main {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   public static void main(String[] args) {
+    Thread.setDefaultUncaughtExceptionHandler(new LogUncaughtExceptionHandler());
+
     logger.atInfo().log("gtfs-validator: start");
     SwingUtilities.invokeLater(() -> createAndShowGUI(args));
     logger.atInfo().log("gtfs-validator: exit");
   }
 
   private static void createAndShowGUI(String[] args) {
+    Thread.currentThread().setUncaughtExceptionHandler(new LogUncaughtExceptionHandler());
+
     try {
       UIManager.setLookAndFeel(UIManager.getSystemLookAndFeelClassName());
     } catch (Exception e) {
@@ -127,5 +131,15 @@ public class Main {
       System.exit(-1);
     }
     return workingDirectory;
+  }
+
+  /**
+   * We introduce a catch-all for uncaught exceptions to make sure they make it into our application
+   * logs.
+   */
+  public static class LogUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
+    public void uncaughtException(Thread thread, Throwable thrown) {
+      logger.atSevere().withCause(thrown).log("Uncaught application exception");
+    }
   }
 }

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/Main.java
@@ -76,6 +76,14 @@ public class Main {
     GtfsValidatorApp app = new GtfsValidatorApp(runner, display);
     app.constructUI();
 
+    GtfsValidatorPreferences prefs = new GtfsValidatorPreferences();
+    prefs.loadPreferences(app);
+    // We save preferences each time validation is run.
+    app.addPreValidationCallback(
+        () -> {
+          prefs.savePreferences(app);
+        });
+
     // On Windows, if you drag a file onto the application shortcut, it will
     // execute the app with the file as the first command-line argument.  This
     // doesn't appear to work on Mac OS.
@@ -83,7 +91,11 @@ public class Main {
       app.setGtfsSource(args[0]);
     }
 
-    app.setOutputDirectory(getDefaultOutputDirectory());
+    // We set a default output directory as a fallback if the user didn't
+    // have one previously set.
+    if (app.getOutputDirectory().isBlank()) {
+      app.setOutputDirectory(getDefaultOutputDirectory());
+    }
 
     app.pack();
     // This causes the application window to center in the screen.

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
@@ -82,4 +82,17 @@ public class GtfsValidatorAppTest {
     assertThat(config.numThreads()).isEqualTo(5);
     assertThat(config.countryCode().getCountryCode()).isEqualTo("US");
   }
+
+  @Test
+  public void testPreValidationCallback() throws URISyntaxException {
+    app.setGtfsSource("http://transit/gtfs.zip");
+    app.setOutputDirectory(Path.of("/path/to/output"));
+
+    Runnable callback = Mockito.mock(Runnable.class);
+    app.addPreValidationCallback(callback);
+
+    app.getValidateButtonForTesting().doClick();
+
+    verify(callback).run();
+  }
 }

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferencesTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferencesTest.java
@@ -1,0 +1,44 @@
+package org.mobilitydata.gtfsvalidator.app.gui;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnit;
+import org.mockito.junit.MockitoRule;
+import org.mockito.quality.Strictness;
+
+public class GtfsValidatorPreferencesTest {
+
+  @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);
+
+  @Mock private MonitoredValidationRunner runner;
+  @Mock private ValidationDisplay display;
+
+  @Test
+  public void testEndToEnd() {
+    {
+      GtfsValidatorApp source = new GtfsValidatorApp(runner, display);
+      source.setGtfsSource("http://gtfs.org/gtfs.zip");
+      source.setOutputDirectory(Path.of("/tmp/gtfs"));
+      source.setNumThreads(3);
+      source.setCountryCode("CA");
+
+      GtfsValidatorPreferences prefs = new GtfsValidatorPreferences();
+      prefs.savePreferences(source);
+    }
+
+    {
+      GtfsValidatorPreferences prefs = new GtfsValidatorPreferences();
+      GtfsValidatorApp dest = new GtfsValidatorApp(runner, display);
+      prefs.loadPreferences(dest);
+
+      assertThat(dest.getGtfsSource()).isEqualTo("http://gtfs.org/gtfs.zip");
+      assertThat(dest.getOutputDirectory()).isEqualTo("/tmp/gtfs");
+      assertThat(dest.getNumThreads()).isEqualTo(3);
+      assertThat(dest.getCountryCode()).isEqualTo("CA");
+    }
+  }
+}

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferencesTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferencesTest.java
@@ -5,11 +5,14 @@ import static com.google.common.truth.Truth.assertThat;
 import java.nio.file.Path;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
 import org.mockito.quality.Strictness;
 
+@RunWith(JUnit4.class)
 public class GtfsValidatorPreferencesTest {
 
   @Rule public MockitoRule rule = MockitoJUnit.rule().strictness(Strictness.STRICT_STUBS);

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -52,6 +52,7 @@ extraJavaModuleInfo {
         requires('java.desktop')
         requires('java.logging')
         requires('java.naming')
+        requires('java.prefs')
         requires('java.security.jgss')
         requires('java.sql')
   }


### PR DESCRIPTION
Currently, the GUI app does not remember settings (input and output paths, advanced settings) between different executions of the app.   This PR adds support for persisting settings between runs of the validator, using the Java Preferences API for storage.

Closes #1165.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `gradle test` to make sure you didn't break anything
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
