### PR TITLE
fix: Bug with ssl network connections + Java module permissions.

### DIFF
--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -57,6 +57,9 @@ extraJavaModuleInfo {
         requires('java.prefs')
         requires('java.security.jgss')
         requires('java.sql')
+        // Need for SSL support for network connections.
+        requires('jdk.crypto.ec')
+        requires('jdk.crypto.cryptoki')
   }
 }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
@@ -86,11 +86,16 @@ public class VersionResolver {
 
     executor.submit(
         () -> {
-          Optional<String> currentVersion = resolveCurrentVersion();
-          Optional<String> latestReleaseVersion = resolveLatestReleaseVersion();
-          VersionInfo info = VersionInfo.create(currentVersion, latestReleaseVersion);
-          resolvedVersionInfo.set(info);
-          return info;
+          try {
+            Optional<String> currentVersion = resolveCurrentVersion();
+            Optional<String> latestReleaseVersion = resolveLatestReleaseVersion();
+            VersionInfo info = VersionInfo.create(currentVersion, latestReleaseVersion);
+            resolvedVersionInfo.set(info);
+            return info;
+          } catch (Throwable ex) {
+            logger.atSevere().withCause(ex).log("Error resolving version info");
+          }
+          return VersionInfo.empty();
         });
   }
 


### PR DESCRIPTION
See discussion in #1181.  Basically, the packaged app uses Java Modules, which requires explicit listing of all JRE dependencies.  `jdeps` picks up most of them, but we have a hidden dependency on the JRE's crypto functionality in order to pull https:// urls.  This manifested as an exception when querying the current app version from https://raw.githubusercontent.com but it also repros if you attempt to download an https:// feed.

Closes #1181.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [X] Run the unit tests with `gradle test` to make sure you didn't break anything
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
