### PR TITLE
feat(ci): use slim base for runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM openjdk:11
+FROM openjdk:11-slim
 COPY main/build/libs/*.jar /
 WORKDIR /


### PR DESCRIPTION
Produces a smaller runtime Docker container image, does not appear to cause any issue in runtime