### PR TITLE
fix: Temporary fix for MacOS validator app corruption

### DIFF
--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -39,7 +39,7 @@ jobs:
           # We need a recent version of Java with jpackage included.
           java-version: '17'
           # We use the zulu distribution, which is an OpenJDK distro.
-          distribution: 'temurin'
+          distribution: 'zulu'
       - name: Package GUI app installer with Gradle
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -44,6 +44,14 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: jpackage
+      - name:
+        if: matrix.os == 'macos-latest'
+        shell: bash
+        run: |
+          codesign --remove-signature app/pkg/build/jpackage/GTFS\ Validator.app
+          appVersion=$(./gradlew cV -q -Prelease.quiet)
+          appVersion=${appVersion//-SNAPSHOT/}
+          jpackage --type dmg --name 'GTFS Validator' --app-version ${appVersion} --app-image app/pkg/build/jpackage/GTFS\ Validator.app --dest app/pkg/build/jpackage
       - name: Upload Installer
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -44,7 +44,12 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: jpackage
-      - name:
+        # Per discussion in https://github.com/MobilityData/gtfs-validator/issues/1183, there is a
+        # bug with jpackage in Java 17 that caused Mac apps to be left in an ambiguous signing state
+        # that results in them being reported as 'damaged' when run.  As a temporary workaround, we
+        # unsign the app and repackage as a dmg.  This bug could be fixed in the future by upgrading
+        # to Java 18 or by officially signing the app.
+      - name: Unsign and package Mac OS app
         if: matrix.os == 'macos-latest'
         shell: bash
         run: |

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -39,7 +39,7 @@ jobs:
           # We need a recent version of Java with jpackage included.
           java-version: '17'
           # We use the zulu distribution, which is an OpenJDK distro.
-          distribution: 'zulu'
+          distribution: 'temurin'
       - name: Package GUI app installer with Gradle
         uses: gradle/gradle-build-action@v2
         with:
@@ -51,5 +51,4 @@ jobs:
           path: |
             app/pkg/build/jpackage/*.msi
             app/pkg/build/jpackage/*.dmg
-            app/pkg/build/jpackage/*.app
             app/pkg/build/jpackage/*.deb

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -51,4 +51,5 @@ jobs:
           path: |
             app/pkg/build/jpackage/*.msi
             app/pkg/build/jpackage/*.dmg
+            app/pkg/build/jpackage/*.app
             app/pkg/build/jpackage/*.deb

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -108,6 +108,7 @@ jlink {
             imageOptions = [
                     '--icon', "${projectDir}/src/main/icons/Icon.icns"
             ]
+            skipInstaller = true
         }
     }
 }


### PR DESCRIPTION
Per #1183, I'm investigating the corruption of `dmg` package on MacOS for the packaged app.  This PR introduces a temporary fix to unsign the app via the GitHub `package_installers.yml` workflow.  A more permanent fix will be to actually sign the app. 