### PR TITLE
feat: apply recommended file notice to feed_info

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -99,6 +99,7 @@ Each Notice is associated with a severity: `INFO`, `WARNING`, `ERROR`.
 | [`inconsistent_agency_lang`](#inconsistent_agency_lang)                                       | Inconsistent language among agencies.                                                                                                                         |
 | [`leading_or_trailing_whitespaces`](#leading_or_trailing_whitespaces)                         | The value in CSV file has leading or trailing whitespaces.                                                                                                    |
 | [`missing_feed_info_date`](#missing_feed_info_date)                                           | `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided.                     |
+| [`missing_recommended_file`](#missing_recommended_file)                                       | A recommended file is missing.                     |
 | [`missing_timepoint_column`](#missing_timepoint_column)                                       | `timepoint` column is missing for a dataset.                                                                                                                  |
 | [`missing_timepoint_value`](#missing_timepoint_value)                                         | `stop_times.timepoint` value is missing for a record.                                                                                                         |
 | [`more_than_one_entity`](#more_than_one_entity)                                               | More than one row in CSV.                                                                                                                                     |
@@ -1695,6 +1696,24 @@ Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one
 </details>
 
 <a name="MissingTimepointColumnNotice"/>
+
+### missing_recommended_file
+
+A recommended file is missing.
+
+#### References
+* [feed_info.txt bets practices](https://github.com/MobilityData/GTFS_Schedule_Best-Practices/blob/master/en/best-practices.md#feed_infotxt)
+<details>
+
+#### Notice fields description
+| Field name   	| Description                    	| Type   	|
+|--------------	|--------------------------------	|--------	|
+| `filename`   	| The name of the faulty file.   	| String 	|
+
+#### Affected files
+* [`feed_info.txt`](http://gtfs.org/reference/static#feed_infotxt)
+
+</details>
 
 ### missing_timepoint_column
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFileNotice.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Google LLC
+ * Copyright 2020 Google LLC, Jarvus Innovations LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFileNotice.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+/**
+ * A recommended file is missing.
+ *
+ * <p>Severity: {@code SeverityLevel.WARNING}
+ */
+public class MissingRecommendedFileNotice extends ValidationNotice {
+  private final String filename;
+
+  public MissingRecommendedFileNotice(String filename) {
+    super(SeverityLevel.WARNING);
+    this.filename = filename;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -52,6 +52,18 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void exportRecommendedFileNotices() {
+    NoticeContainer container = new NoticeContainer();
+    container.addValidationNotice(new MissingRecommendedFileNotice("feed_info.txt"));
+
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
+        .isEqualTo(
+            "{\"notices\":[{\"code\":\"missing_recommended_file\",\"severity\":\"WARNING\","
+                + "\"totalNotices\":1,\"sampleNotices\":[{\"filename\":\"feed_info.txt"
+                + "\"}]}]}");
+  }
+
+  @Test
   public void exportInfinityInContext() {
     NoticeContainer container = new NoticeContainer();
     container.addValidationNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedInfoSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedInfoSchema.java
@@ -21,10 +21,12 @@ import org.mobilitydata.gtfsvalidator.annotation.EndRange;
 import org.mobilitydata.gtfsvalidator.annotation.FieldType;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.Recommended;
 import org.mobilitydata.gtfsvalidator.annotation.Required;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 
 @GtfsTable(value = "feed_info.txt", singleRow = true)
+@Recommended
 public interface GtfsFeedInfoSchema extends GtfsEntity {
   @Required
   String feedPublisherName();

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -47,6 +47,7 @@ import org.mobilitydata.gtfsvalidator.annotation.Generated;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsLoader;
 import org.mobilitydata.gtfsvalidator.notice.CsvParsingFailedNotice;
 import org.mobilitydata.gtfsvalidator.notice.EmptyFileNotice;
+import org.mobilitydata.gtfsvalidator.notice.MissingRecommendedFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvFile;
@@ -450,6 +451,11 @@ public class TableLoaderGenerator {
                 classNames.tableContainerTypeName(),
                 classNames.tableContainerTypeName(),
                 TableStatus.class)
+            .beginControlFlow("if (isRecommended())")
+            .addStatement(
+                "noticeContainer.addValidationNotice(new $T(gtfsFilename()))",
+                MissingRecommendedFileNotice.class)
+            .endControlFlow()
             .beginControlFlow("if (isRequired())")
             .addStatement(
                 "noticeContainer.addValidationNotice(new $T(gtfsFilename()))",


### PR DESCRIPTION
**Summary:**

Resolves #877 

Adds a new annotation for recommended files and applies this annotation to `feed_info.txt` ~and `shapes.txt`~.

**Expected behavior:** 

A new validator warning is generated when either `feed_info.txt` is missing

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)

Here is the sample output from the validator for a data set with missing `feed_info.txt`:

```json
{
  "notices": [
    {
      "code": "missing_recommended_file",
      "severity": "WARNING",
      "totalNotices": 1,
      "sampleNotices": [
        {
          "filename": "feed_info.txt"
        }
      ]
    }
]}
```
