### PR TITLE
fix: Bump queue_runner.sh max heap size to 10Gb

### DIFF
--- a/scripts/queue_runner.sh
+++ b/scripts/queue_runner.sh
@@ -13,7 +13,7 @@ do
    ID=$(jq '.id' <<< "$item")
    URL=$(jq '.url' <<< "$item")
    path_name=${ID//\"/}
-   java -Xmx8G -Xms8G -jar gtfs-validator-snapshot/gtfs-validator*.jar --url $URL --output_base $OUTPUT_BASE/output/$path_name --validation_report_name latest.json --system_errors_report_name latest_errors.json
-   java -Xmx8G -Xms8G -jar gtfs-validator-master/gtfs-validator*.jar --url $URL --output_base $OUTPUT_BASE/output/$path_name --validation_report_name reference.json --system_errors_report_name reference_errors.json
+   java -Xmx10G -Xms8G -jar gtfs-validator-snapshot/gtfs-validator*.jar --url $URL --output_base $OUTPUT_BASE/output/$path_name --validation_report_name latest.json --system_errors_report_name latest_errors.json
+   java -Xmx10G -Xms8G -jar gtfs-validator-master/gtfs-validator*.jar --url $URL --output_base $OUTPUT_BASE/output/$path_name --validation_report_name reference.json --system_errors_report_name reference_errors.json
    wait
 done


### PR DESCRIPTION
**Summary:**

Per issue #1226, I'd like to try bumping the max heap size for the validator in the acceptance test queue_runner.sh script to see if it helps with test cancellations.

- [X] Run the unit tests with `gradle test` to make sure you didn't break anything
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X] Linked all relevant issues
