### PR TITLE
Docs: Update rules.md stop_times.txt best practices reference link

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -1768,7 +1768,7 @@ The given field has no value in some input row, even though values are recommend
 The `timepoint` column should be provided.
 
 #### References
-* [stop_times.txt best practices](https://github.com/MobilityData/GTFS_Schedule_Best-Practices/blob/master/en/stop_times.md)
+* [stop_times.txt best practices](https://gtfs.org/schedule/reference/#stop_timestxt)
 <details>
 
 #### Notice fields description


### PR DESCRIPTION
Updating the Rules.md documentation to fix the stop_times.txt best practices  reference link 404 error.

In RULES.md, the link [stop_times.txt best practices](https://github.com/MobilityData/GTFS_Schedule_Best-Practices/blob/master/en/stop_times.md) provided in the missing_timepoint_column notice is broken.
Additionally, the Best Practice has no mention of timepoint, think link should refer to the specification instead.

It should be replaced by the following link:

https://gtfs.org/schedule/reference/#stop_timestxt
