### PR TITLE
fix(docker): update path to CLI jar

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 .git/
 .github/
+docs/
 Dockerfile
 build/
 config/
+scripts/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git/
+.github/
 Dockerfile
 build/
 config/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -105,7 +105,27 @@ jobs:
           echo ::set-output name=version::${AXION_VERSION}
           echo ::set-output name=tags::${DOCKER_TAGS}
           echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      - name: Build and push
+
+      # Build and push steps are split up in order to test the built contaire image in between
+      # - build-args and labels inputs _must_ be kept matching between both to prevent rebuild
+      # - See: https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md
+      - name: Build Docker container image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          build-args: |
+            VERSION_TAG=${{ steps.prep.outputs.version }}
+          load: true
+          tags: ${{ steps.prep.outputs.tags }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY,,}.git
+            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.prep.outputs.version }}
+      - name: Test Docker container image
+        run: docker run --rm ${{ steps.prep.outputs.tags }} --help
+      - name: Push Docker container image
         uses: docker/build-push-action@v3
         with:
           context: .

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN ./gradlew shadowJar \
 
 
 FROM openjdk:11-slim
-COPY --from=build /build/main/build/libs/gtfs-validator-*-cli.jar /gtfs-validator-cli.jar
+COPY --from=build /build/cli/build/libs/gtfs-validator-*-cli.jar /gtfs-validator-cli.jar
 WORKDIR /
 
 ARG VERSION_TAG

--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -68,7 +68,7 @@ public class Main {
       jCommander.usage();
       System.out.println(
           "⚠️ Note that parameters marked with an asterisk (*) in the help menu are mandatory.");
-      return null;
+      System.exit(0);
     }
     if (args.getExportNoticeSchema()) {
       exportNoticeSchema(args);


### PR DESCRIPTION
The current `:latest` Docker container build of the `master` branch is broken due to changes in #1229:

```console
$ docker pull ghcr.io/mobilitydata/gtfs-validator:latest
latest: Pulling from mobilitydata/gtfs-validator
1efc276f4ff9: Already exists 
a2f2f93da482: Already exists 
12cca292b13c: Already exists 
69e15dccd787: Already exists 
4f4fb700ef54: Already exists 
Digest: sha256:b796fee1fc8e99d857ab1fd6f6438af7d20c3dba74af4d1934f609c22e4dc1ac
Status: Downloaded newer image for ghcr.io/mobilitydata/gtfs-validator:latest
ghcr.io/mobilitydata/gtfs-validator:latest

$ docker run --rm ghcr.io/mobilitydata/gtfs-validator:latest --help
Error: Unable to access jarfile gtfs-validator-cli.jar
```

I've made the following changes in this PR to both fix the issue and add a testing step that would catch breaks in the Docker layer:

- Applied [the pattern recommended by the current `build-push-action` for testing the Docker image before pushing](https://github.com/docker/build-push-action/blob/master/docs/advanced/test-before-push.md)
- Adjusted the CLI to return exit code 0 when invoked with `--help`
  - Needed a simple command to run that would return 0 if the executable is healthy
  - Other available arguments require valid input
  - It is conventional for `--help` to return 0 and be used to verify you can run a command, the README currently provides it as such
  - `main`/`parseArguments` have a weird split of responsibilities currently. I tried a few ways to keep `System.exit()` within `main` as it is in all other cases, but they all ended up getting more gnarly. `parseArguments` is already handling direct output and having side effects, so is already not a pure function. 
- Fix the path in `Dockerfile` to the new CLI jar build output location
- Adds some more ancillary trees to `.dockerignore` to improve build caching when iterating locally