### PR TITLE
fix: Sign and Notarize MacOS App

### DIFF
--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -2,7 +2,7 @@ name: Package Installers
 
 on:
   push:
-    branches: [ master, issue/1200/sign-mac-os ]
+    branches: [ master ]
     paths-ignore:
       - '**.md'
   pull_request:

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -60,8 +60,9 @@ jobs:
       - name: "Package GUI app installer with Gradle"
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jpackage
-          arguments: -Psign-app=${{github.event_name == 'push' || github.event_name == 'release'}}
+          arguments: |
+            jpackage
+            -Psign-app=${{github.event_name == 'push' || github.event_name == 'release'}}
 
       # On MacOS, we now submit the app for "notarization", where Apple will scan the app for
       # malware and other issues.  This step can take a few minutes or more; the action will wait

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -60,7 +60,8 @@ jobs:
       - name: "Package GUI app installer with Gradle"
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jpackage -Psign-app=true
+          arguments: jpackage
+          arguments: -Psign-app=${{github.event_name == 'push' || github.event_name == 'release'}}
 
       # On MacOS, we now submit the app for "notarization", where Apple will scan the app for
       # malware and other issues.  This step can take a few minutes or more; the action will wait

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -2,7 +2,7 @@ name: Package Installers
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, issue/1200/sign-mac-os ]
     paths-ignore:
       - '**.md'
   pull_request:
@@ -33,6 +33,7 @@ jobs:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
+
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
@@ -40,28 +41,75 @@ jobs:
           java-version: '17'
           # We use the zulu distribution, which is an OpenJDK distro.
           distribution: 'zulu'
-      - name: Package GUI app installer with Gradle
+
+      # We create a code-signing keychain on MacOS before building and packaging the app, as the
+      # app will be signed as part of the jpackage build phase.
+      - name: "MacOS - Import Certificate: Developer ID Application"
+        if: matrix.os == 'macos-latest' && (github.event_name == 'push' || github.event_name == 'release')
+        uses: devbotsxyz/import-signing-certificate@main
+        with:
+          # This should be a certificate + private key, exported as a p12 file and base64 encoded as
+          # a GitHub secret.  The certificate should be the:
+          # 'Developer ID Application: The International Data Organization For Transport (BF2U75HN4D)'
+          # certificate, locked with the specified passphrase.
+          certificate-data: ${{ secrets.DEVELOPER_ID_APPLICATION_CERTIFICATE_P12_BASE64 }}
+          certificate-passphrase: ${{ secrets.DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
+          # The resulting keychain will be locked with this separate password.
+          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+
+      - name: "Package GUI app installer with Gradle"
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: jpackage
-        # Per discussion in https://github.com/MobilityData/gtfs-validator/issues/1183, there is a
-        # bug with jpackage in Java 17 that caused Mac apps to be left in an ambiguous signing state
-        # that results in them being reported as 'damaged' when run.  As a temporary workaround, we
-        # unsign the app and repackage as a dmg.  This bug could be fixed in the future by upgrading
-        # to Java 18 or by officially signing the app.
-      - name: Unsign and package Mac OS app
+          arguments: jpackage -Psign-app=true
+
+      # On MacOS, we now submit the app for "notarization", where Apple will scan the app for
+      # malware and other issues.  This step can take a few minutes or more; the action will wait
+      # until the report is available.
+      - name: "MacOS - Notarize Release Build"
+        if: matrix.os == 'macos-latest' && (github.event_name == 'push' || github.event_name == 'release')
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: "app/pkg/build/jpackage/GTFS Validator.app"
+          # The Apple developer account used to run notarization.  This account will receive an
+          # email every time notarization is run.
+          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+          # The app-specific password configured for the Apple developer account that will be used
+          # for authentication (different from the main password for the dev account).
+          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+
+      # Now that we have a notarization report, we attach it to the app binary.
+      - name: "Mac OS - Staple Release Build"
+        if: matrix.os == 'macos-latest' && (github.event_name == 'push' || github.event_name == 'release')
+        uses: devbotsxyz/xcode-staple@v1
+        with:
+          product-path: "app/pkg/build/jpackage/GTFS Validator.app"
+
+      # Now that we have a notarized app, we can package it.
+      - name: "Mac OS - Package the app"
         if: matrix.os == 'macos-latest'
         shell: bash
         run: |
-          codesign --remove-signature app/pkg/build/jpackage/GTFS\ Validator.app
           appVersion=$(./gradlew cV -q -Prelease.quiet)
           appVersion=${appVersion//-SNAPSHOT/}
-          jpackage --type dmg --name 'GTFS Validator' --app-version ${appVersion} --app-image app/pkg/build/jpackage/GTFS\ Validator.app --dest app/pkg/build/jpackage
-      - name: Upload Installer
+          jpackage \
+           --type dmg \
+           --name 'GTFS Validator' \
+           --app-version ${appVersion} \
+           --app-image app/pkg/build/jpackage/GTFS\ Validator.app \
+           --dest app/pkg/build/jpackage
+          jpackage \
+           --type pkg \
+           --name 'GTFS Validator' \
+           --app-version ${appVersion} \
+           --app-image app/pkg/build/jpackage/GTFS\ Validator.app \
+           --dest app/pkg/build/jpackage
+
+      - name: "Upload Installer"
         uses: actions/upload-artifact@v2
         with:
           name: Installer - ${{matrix.os}}
           path: |
             app/pkg/build/jpackage/*.msi
             app/pkg/build/jpackage/*.dmg
+            app/pkg/build/jpackage/*.pkg
             app/pkg/build/jpackage/*.deb

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -46,16 +46,16 @@ jobs:
       # app will be signed as part of the jpackage build phase.
       - name: "MacOS - Import Certificate: Developer ID Application"
         if: matrix.os == 'macos-latest' && (github.event_name == 'push' || github.event_name == 'release')
-        uses: devbotsxyz/import-signing-certificate@main
+        uses: devbotsxyz/import-signing-certificate@v1
         with:
           # This should be a certificate + private key, exported as a p12 file and base64 encoded as
           # a GitHub secret.  The certificate should be the:
           # 'Developer ID Application: The International Data Organization For Transport (BF2U75HN4D)'
           # certificate, locked with the specified passphrase.
-          certificate-data: ${{ secrets.DEVELOPER_ID_APPLICATION_CERTIFICATE_P12_BASE64 }}
-          certificate-passphrase: ${{ secrets.DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
+          certificate-data: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_P12_BASE64 }}
+          certificate-passphrase: ${{ secrets.MACOS_DEVELOPER_ID_APPLICATION_CERTIFICATE_PASSWORD }}
           # The resulting keychain will be locked with this separate password.
-          keychain-password: ${{ secrets.KEYCHAIN_PASSWORD }}
+          keychain-password: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
 
       - name: "Package GUI app installer with Gradle"
         uses: gradle/gradle-build-action@v2
@@ -72,10 +72,10 @@ jobs:
           product-path: "app/pkg/build/jpackage/GTFS Validator.app"
           # The Apple developer account used to run notarization.  This account will receive an
           # email every time notarization is run.
-          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
+          appstore-connect-username: ${{ secrets.MACOS_NOTARIZATION_USERNAME }}
           # The app-specific password configured for the Apple developer account that will be used
           # for authentication (different from the main password for the dev account).
-          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+          appstore-connect-password: ${{ secrets.MACOS_NOTARIZATION_PASSWORD }}
 
       # Now that we have a notarization report, we attach it to the app binary.
       - name: "Mac OS - Staple Release Build"

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -111,7 +111,7 @@ jlink {
             imageOptions += [
                     '--icon', "${projectDir}/src/main/icons/Icon.icns"
             ]
-            if (project.hasProperty('sign-app')) {
+            if (project.hasProperty('sign-app') && project.property('sign-app') == 'true') {
                 imageOptions += [
                         '--mac-sign',
                         // jpackage is expecting to use a "Developer ID Application" certificate for

--- a/app/pkg/build.gradle
+++ b/app/pkg/build.gradle
@@ -108,9 +108,29 @@ jlink {
             ]
         }
         if (OperatingSystem.current().isMacOsX()) {
-            imageOptions = [
+            imageOptions += [
                     '--icon', "${projectDir}/src/main/icons/Icon.icns"
             ]
+            if (project.hasProperty('sign-app')) {
+                imageOptions += [
+                        '--mac-sign',
+                        // jpackage is expecting to use a "Developer ID Application" certificate for
+                        // signing the app, so make sure your keychain contains this certificate, along
+                        // with the corresponding private key, if you wish to sign.  The certificate
+                        // should have a full name of:
+                        // 'Developer ID Application: The International Data Organization For Transport (BF2U75HN4D)'
+                        // jpackage will supply the 'Developer ID Application: ' prefix when calling the
+                        // codesign tool.
+                        '--mac-signing-key-user-name',
+                        'The International Data Organization For Transport (BF2U75HN4D)',
+                        // Entitlements are required for eventual notarization of the app.
+                        '--mac-entitlements',
+                        "${projectDir}/src/main/mac-resources/entitlements.plist"
+                ]
+            }
+            // We skip creating a dmg/pkg installer here because we need to notarize the app before
+            // packaging, which jpackage does not currently support.  See `package_installers.yml`
+            // for actual packaging.
             skipInstaller = true
         }
     }

--- a/app/pkg/src/main/mac-resources/entitlements.plist
+++ b/app/pkg/src/main/mac-resources/entitlements.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
**Summary:**

As tracked in #1200, this PR adds support for code-signing and notarizing the MacOS app.  This will mean the user no longer has to ⌘-click the app to open it the first time.  Note that they will still get the following warning when running the app for the first time:

<img width="415" alt="Screen Shot 2022-08-23 at 7 34 14 PM" src="https://user-images.githubusercontent.com/26211219/186963643-d7a4b3f8-4f98-4f49-8bef-05d3ce707e1b.png">

But they can just click "Ok" and the app will run.  I don't think there is any way to avoid that dialog without distributing the app through the Mac App Store.

Closing #1200.

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)