### PR TITLE
feat: Check validator subclasses are annotated with @GtfsValidator

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -50,8 +50,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
 public class ValidatorLoader {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-  private static final String DEFAULT_VALIDATOR_PACKAGE =
-      "org.mobilitydata.gtfsvalidator.validator";
+  public static final String DEFAULT_VALIDATOR_PACKAGE = "org.mobilitydata.gtfsvalidator.validator";
 
   private final ListMultimap<Class<? extends GtfsEntity>, Class<? extends SingleEntityValidator<?>>>
       singleEntityValidators = ArrayListMultimap.create();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/GtfsValidatorAnnotationTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/GtfsValidatorAnnotationTest.java
@@ -1,0 +1,49 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import com.google.common.collect.ImmutableList;
+import io.github.classgraph.AnnotationInfo;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.ScanResult;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+
+public class GtfsValidatorAnnotationTest {
+
+  /**
+   * This test ensures that any class that extends {@link SingleEntityValidator} or {@link
+   * FileValidator} is also annotated with {@link GtfsValidator}. Not including the annotation
+   * typically indicates an error, as the validator won't be picked up by scanning code in {@link
+   * ValidatorLoader}.
+   */
+  @Test
+  public void testAllValidatorSubclassesAreAnnotatedWithGtfsValidator() {
+    ImmutableList<String> validatorPackages =
+        ImmutableList.of(ValidatorLoader.DEFAULT_VALIDATOR_PACKAGE);
+    ImmutableList<Class> validatorBaseClasses =
+        ImmutableList.of(SingleEntityValidator.class, FileValidator.class);
+    for (String packageName : validatorPackages) {
+      try (ScanResult scanResult =
+          new ClassGraph()
+              .enableClassInfo()
+              .enableAnnotationInfo()
+              .acceptPackages(packageName)
+              .scan()) {
+        for (Class<?> validatorBaseClass : validatorBaseClasses) {
+          for (ClassInfo classInfo : scanResult.getSubclasses(validatorBaseClass)) {
+            AnnotationInfo annotationInfo = classInfo.getAnnotationInfo(GtfsValidator.class);
+            assertWithMessage(
+                    classInfo.getName()
+                        + ": "
+                        + validatorBaseClass.getSimpleName()
+                        + " validator subclass should be annotated with @GtfsValidator")
+                .that(annotationInfo != null)
+                .isTrue();
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #1262

Add a unit-test that checks that any subclass of SingleEntityValidator or FileValidator is also annotated with @GtfsValidator.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
