### PR TITLE
fix: Do not return non-zero exit code when exporting schema via CLI.

### DIFF
--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -147,7 +147,11 @@ public class Arguments {
   }
 
   /** @return true if CLI parameter combination is legal, otherwise return false */
-  public boolean isValid() {
+  public boolean validate() {
+    if (getExportNoticeSchema() && abortAfterNoticeSchemaExport()) {
+      return true;
+    }
+
     if (input == null && url == null) {
       logger.atSevere().log(
           "One of the two following CLI parameter must be provided: '--input' and '--url'");
@@ -174,11 +178,6 @@ public class Arguments {
   }
 
   public boolean abortAfterNoticeSchemaExport() {
-    return input == null
-        && countryCode == null
-        && url == null
-        && storageDirectory == null
-        && validationReportName == null
-        && systemErrorsReportName == null;
+    return input == null && url == null;
   }
 }

--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -36,12 +36,29 @@ public class Main {
   private static final String NOTICE_SCHEMA_JSON = "notice_schema.json";
 
   public static void main(String[] argv) {
-    Arguments args = parseArguments(argv);
-    if (args == null) {
+    Arguments args = new Arguments();
+    JCommander jCommander = new JCommander(args);
+    jCommander.parse(argv);
+
+    if (args.getHelp()) {
+      jCommander.usage();
+      System.out.println(
+          "⚠️ Note that parameters marked with an asterisk (*) in the help menu are mandatory.");
+      System.exit(0);
+    }
+
+    if (!args.validate()) {
       System.exit(1);
     }
 
     try {
+      if (args.getExportNoticeSchema()) {
+        exportNoticeSchema(args);
+        if (args.abortAfterNoticeSchemaExport()) {
+          System.exit(0);
+        }
+      }
+
       ValidationRunner runner = new ValidationRunner(new VersionResolver());
       if (runner.run(args.toConfig()) != ValidationRunner.Status.SUCCESS) {
         System.exit(-1);
@@ -52,34 +69,6 @@ public class Main {
     }
 
     System.exit(0);
-  }
-
-  /**
-   * Performs parsing and sanity checks on CLI arguments.
-   *
-   * @param argv the CLI arguments
-   * @return the {@code Arguments} generated after parsing the command line
-   */
-  private static Arguments parseArguments(String[] argv) {
-    Arguments args = new Arguments();
-    JCommander jCommander = new JCommander(args);
-    jCommander.parse(argv);
-    if (args.getHelp()) {
-      jCommander.usage();
-      System.out.println(
-          "⚠️ Note that parameters marked with an asterisk (*) in the help menu are mandatory.");
-      System.exit(0);
-    }
-    if (args.getExportNoticeSchema()) {
-      exportNoticeSchema(args);
-    }
-    if (args.abortAfterNoticeSchemaExport()) {
-      return null;
-    }
-    if (!args.isValid()) {
-      return null;
-    }
-    return args;
   }
 
   private static void exportNoticeSchema(final Arguments args) {

--- a/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -164,7 +164,7 @@ public class ArgumentsTest {
   private static boolean validateArguments(String[] cliArguments) {
     Arguments args = new Arguments();
     new JCommander(args).parse(cliArguments);
-    return args.isValid();
+    return args.validate();
   }
 
   @Test
@@ -246,5 +246,29 @@ public class ArgumentsTest {
                   "--feed_name", "feed name"
                 }))
         .isFalse();
+  }
+
+  @Test
+  public void exportNoticesSchema_schemaOnly() {
+    String[] cliArguments = {"--export_notices_schema", "--output_base", "output value"};
+    Arguments args = new Arguments();
+    new JCommander(args).parse(cliArguments);
+
+    assertThat(args.validate()).isTrue();
+    assertThat(args.getExportNoticeSchema()).isTrue();
+    assertThat(args.abortAfterNoticeSchemaExport()).isTrue();
+  }
+
+  @Test
+  public void exportNoticesSchema_schemaAndValidation() {
+    String[] cliArguments = {
+      "--export_notices_schema", "--input", "input value", "--output_base", "output value"
+    };
+    Arguments args = new Arguments();
+    new JCommander(args).parse(cliArguments);
+
+    assertThat(args.validate()).isTrue();
+    assertThat(args.getExportNoticeSchema()).isTrue();
+    assertThat(args.abortAfterNoticeSchemaExport()).isFalse();
   }
 }


### PR DESCRIPTION
**Summary:**

Per discussion in #1256: refactor command-line argument parsing for clarity. Do not exit with non-zero exit code when exporting notices schema.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
