### PR TITLE
Use smaller integer field types for GTFS entity classes

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -39,6 +39,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.NumberOutOfRangeNotice;
 import org.mobilitydata.gtfsvalidator.notice.UnexpectedEnumValueNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsEnum;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
@@ -304,7 +305,8 @@ public class RowParser {
   }
 
   @Nullable
-  public <E> Integer asEnum(int columnIndex, FieldLevelEnum level, EnumCreator<E> enumCreator) {
+  public <E extends GtfsEnum> Integer asEnum(
+      int columnIndex, FieldLevelEnum level, EnumCreator<E> enumCreator, E unrecognized) {
     Integer i = asInteger(columnIndex, level);
     if (i == null) {
       return null;
@@ -313,6 +315,7 @@ public class RowParser {
       noticeContainer.addValidationNotice(
           new UnexpectedEnumValueNotice(
               fileName, row.getRowNumber(), header.getColumnName(columnIndex), i));
+      return unrecognized.getNumber();
     }
     return i;
   }

--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'com.univocity:univocity-parsers:2.9.0'
     implementation 'com.google.geometry:s2-geometry:2.0.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13'
+    testImplementation 'com.google.truth:truth:1.0.1'
 }
 
 test {

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
@@ -26,6 +26,7 @@ import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.hasMet
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.setterMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.GtfsEntityClasses.TABLE_PACKAGE_NAME;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.geometry.S2LatLng;
 import com.squareup.javapoet.CodeBlock;
 import com.squareup.javapoet.FieldSpec;
@@ -36,9 +37,11 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.math.BigDecimal;
 import java.time.ZoneId;
+import java.util.List;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.lang.model.element.Modifier;
+import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
 import org.mobilitydata.gtfsvalidator.annotation.Generated;
@@ -61,14 +64,44 @@ public class EntityImplementationGenerator {
   private static final String CSV_ROW_NUMBER = "csvRowNumber";
   private final GtfsFileDescriptor fileDescriptor;
   private final GtfsEntityClasses classNames;
+  private final ImmutableMap<String, TypeName> enumIntegerFieldTypes;
 
-  public EntityImplementationGenerator(GtfsFileDescriptor fileDescriptor) {
+  public EntityImplementationGenerator(
+      GtfsFileDescriptor fileDescriptor, List<GtfsEnumDescriptor> enumDescriptors) {
     this.fileDescriptor = fileDescriptor;
     this.classNames = new GtfsEntityClasses(fileDescriptor);
+    this.enumIntegerFieldTypes = createEnumIntegerFieldTypesMap(enumDescriptors);
+  }
+
+  static ImmutableMap<String, TypeName> createEnumIntegerFieldTypesMap(
+      List<GtfsEnumDescriptor> enumDescriptors) {
+    return enumDescriptors.stream()
+        .collect(
+            ImmutableMap.toImmutableMap(
+                GtfsEnumDescriptor::name,
+                EntityImplementationGenerator::chooseEnumIntegerFieldType));
+  }
+
+  static TypeName chooseEnumIntegerFieldType(GtfsEnumDescriptor enumDescriptor) {
+    int minValue = 0;
+    int maxValue = 0;
+    for (GtfsEnumValueDescriptor value : enumDescriptor.values()) {
+      minValue = Math.min(minValue, value.value());
+      maxValue = Math.max(maxValue, value.value());
+    }
+    if (minValue >= Byte.MIN_VALUE && maxValue <= Byte.MAX_VALUE) {
+      return TypeName.BYTE;
+    }
+    if (minValue >= Short.MIN_VALUE && maxValue <= Short.MAX_VALUE) {
+      return TypeName.SHORT;
+    }
+    return TypeName.INT;
   }
 
   private static int lastBitFieldNumber(int fieldCount) {
-    // Each bitField has 32 bits. We need bitField0_ to store 1..32 fields,
+    // All standard GTFS tables have less than 16 fields, so a bitmask fits into short.
+    // However, we want to support enormous tables that may have more than 32 fields.
+    // An int bitField has 32 bits. We need bitField0_ to store 1..32 fields,
     // bitField0_ and bitField1_ for 33..64 fields etc.
     return (fieldCount - 1) / 32;
   }
@@ -167,9 +200,10 @@ public class EntityImplementationGenerator {
     return getDefaultValue(field).toString().equals("null") ? Nullable.class : Nonnull.class;
   }
 
-  private static TypeName getClassFieldType(GtfsFieldDescriptor field) {
+  private TypeName getClassFieldType(GtfsFieldDescriptor field) {
     if (field.type() == FieldTypeEnum.ENUM) {
-      return TypeName.INT;
+      return enumIntegerFieldTypes.getOrDefault(
+          ((DeclaredType) field.javaType()).asElement().getSimpleName().toString(), TypeName.INT);
     }
     return TypeName.get(field.javaType());
   }
@@ -183,9 +217,20 @@ public class EntityImplementationGenerator {
     for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
       typeSpec.addField(getClassFieldType(field), field.name(), Modifier.PRIVATE);
     }
-    for (int i = 0; i <= lastBitFieldNumber(fileDescriptor.fields().size()); ++i) {
+    if (fileDescriptor.fields().size() <= 32) {
       typeSpec.addField(
-          FieldSpec.builder(int.class, "bitField" + i + "_", Modifier.PRIVATE).build());
+          FieldSpec.builder(
+                  fileDescriptor.fields().size() <= 8
+                      ? byte.class
+                      : fileDescriptor.fields().size() <= 16 ? short.class : int.class,
+                  "bitField0_",
+                  Modifier.PRIVATE)
+              .build());
+    } else {
+      for (int i = 0; i <= lastBitFieldNumber(fileDescriptor.fields().size()); ++i) {
+        typeSpec.addField(
+            FieldSpec.builder(int.class, "bitField" + i + "_", Modifier.PRIVATE).build());
+      }
     }
   }
 
@@ -324,18 +369,30 @@ public class EntityImplementationGenerator {
   }
 
   private MethodSpec generateSetterMethod(GtfsFieldDescriptor field, int fieldNumber) {
-    return MethodSpec.methodBuilder(setterMethodName(field.name()))
-        .addModifiers(Modifier.PUBLIC)
-        .returns(classNames.entityBuilderTypeName())
-        .addAnnotation(Nonnull.class)
-        .addParameter(
-            ParameterSpec.builder(getClassFieldType(field).box(), "value")
-                .addAnnotation(Nullable.class)
-                .build())
-        .beginControlFlow("if (value == null)")
-        .addStatement("return $L()", clearMethodName(field.name()))
-        .endControlFlow()
-        .addStatement("$L = value", field.name())
+    TypeName fieldType = getClassFieldType(field);
+    MethodSpec.Builder method =
+        MethodSpec.methodBuilder(setterMethodName(field.name()))
+            .addModifiers(Modifier.PUBLIC)
+            .returns(classNames.entityBuilderTypeName())
+            .addAnnotation(Nonnull.class)
+            .addParameter(
+                ParameterSpec.builder(
+                        (field.type() == FieldTypeEnum.ENUM ? TypeName.INT : fieldType).box(),
+                        "value")
+                    .addAnnotation(Nullable.class)
+                    .build())
+            .beginControlFlow("if (value == null)")
+            .addStatement("return $L()", clearMethodName(field.name()))
+            .endControlFlow();
+
+    if (field.type() == FieldTypeEnum.ENUM) {
+      // Enums are usually cast to a smaller integer type using Integer.byteValue() or
+      // Integer.shortValue().
+      method.addStatement("$L = value.$LValue()", field.name(), fieldType.toString());
+    } else {
+      method.addStatement("$L = value", field.name());
+    }
+    return method
         .addStatement(
             "$L |= $L", bitFieldForFieldNumber(fieldNumber), maskForFieldNumber(fieldNumber))
         .addStatement("return this")

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
@@ -83,12 +83,8 @@ public class EntityImplementationGenerator {
   }
 
   static TypeName chooseEnumIntegerFieldType(GtfsEnumDescriptor enumDescriptor) {
-    int minValue = 0;
-    int maxValue = 0;
-    for (GtfsEnumValueDescriptor value : enumDescriptor.values()) {
-      minValue = Math.min(minValue, value.value());
-      maxValue = Math.max(maxValue, value.value());
-    }
+    final int minValue = EnumGenerator.getMinUnrecognizedValue(enumDescriptor);
+    final int maxValue = EnumGenerator.getMaxValue(enumDescriptor);
     if (minValue >= Byte.MIN_VALUE && maxValue <= Byte.MAX_VALUE) {
       return TypeName.BYTE;
     }
@@ -99,7 +95,7 @@ public class EntityImplementationGenerator {
   }
 
   private static int lastBitFieldNumber(int fieldCount) {
-    // All standard GTFS tables have less than 16 fields, so a bitmask fits into short.
+    // Most standard GTFS tables have less than 16 fields, so a bitmask fits into short.
     // However, we want to support enormous tables that may have more than 32 fields.
     // An int bitField has 32 bits. We need bitField0_ to store 1..32 fields,
     // bitField0_ and bitField1_ for 33..64 fields etc.

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsAnnotationProcessor.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsAnnotationProcessor.java
@@ -96,7 +96,9 @@ public class GtfsAnnotationProcessor extends AbstractProcessor {
       fileDescriptors.add(analyser.analyzeGtfsFileType(type));
     }
     for (GtfsFileDescriptor fileDescriptor : fileDescriptors) {
-      writeJavaFile(new EntityImplementationGenerator(fileDescriptor).generateGtfsEntityJavaFile());
+      writeJavaFile(
+          new EntityImplementationGenerator(fileDescriptor, enumDescriptors)
+              .generateGtfsEntityJavaFile());
       writeJavaFile(new TableLoaderGenerator(fileDescriptor).generateGtfsTableLoaderJavaFile());
       writeJavaFile(new TableContainerGenerator(fileDescriptor).generateGtfsContainerJavaFile());
     }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -301,7 +301,7 @@ public class TableLoaderGenerator {
     for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
       CodeBlock fieldValue =
           CodeBlock.of(
-              "rowParser.$L($L, $T.$L$L)",
+              "rowParser.$L(\n$L, $T.$L$L)",
               gtfsTypeToParserMethod(field.type()),
               fieldColumnIndex(field.name()),
               FieldLevelEnum.class,
@@ -311,7 +311,11 @@ public class TableLoaderGenerator {
               field.numberBounds().isPresent()
                   ? ", RowParser.NumberBounds." + field.numberBounds().get()
                   : field.type() == FieldTypeEnum.ENUM
-                      ? ", " + field.javaType().toString() + "::forNumber"
+                      ? ",\n"
+                          + field.javaType().toString()
+                          + "::forNumber, "
+                          + field.javaType().toString()
+                          + ".UNRECOGNIZED"
                       : "");
       if (cachingEnabled(field)) {
         fieldValue = CodeBlock.of("$L.addIfAbsent($L)", fieldColumnCache(field), fieldValue);

--- a/processor/src/test/java/org/mobilitydata/gtfsvalidator/processor/EnumGeneratorTest.java
+++ b/processor/src/test/java/org/mobilitydata/gtfsvalidator/processor/EnumGeneratorTest.java
@@ -1,0 +1,24 @@
+package org.mobilitydata.gtfsvalidator.processor;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class EnumGeneratorTest {
+  @Test
+  public void testGetMinMaxValue() {
+    GtfsEnumDescriptor.Builder builder = GtfsEnumDescriptor.builder().setName("MyEnum");
+    builder
+        .valuesBuilder()
+        .add(GtfsEnumValueDescriptor.create("STOP", 0))
+        .add(GtfsEnumValueDescriptor.create("ENTRANCE", 2))
+        .add(GtfsEnumValueDescriptor.create("STATION", 1));
+    GtfsEnumDescriptor enumDescriptor = builder.build();
+
+    assertThat(EnumGenerator.getMinUnrecognizedValue(enumDescriptor)).isEqualTo(-1);
+    assertThat(EnumGenerator.getMaxValue(enumDescriptor)).isEqualTo(2);
+  }
+}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ByteGtfsEnum.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ByteGtfsEnum.java
@@ -5,5 +5,5 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
 @GtfsEnumValue(name = "ZERO", value = 0)
 @GtfsEnumValue(name = "ONE", value = 1)
 @GtfsEnumValue(name = "MAX_BYTE", value = 127)
-@GtfsEnumValue(name = "MIN_BYTE", value = -128)
+@GtfsEnumValue(name = "MIN_BYTE", value = -127)
 public class ByteGtfsEnum {}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ByteGtfsEnum.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ByteGtfsEnum.java
@@ -1,0 +1,9 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
+
+@GtfsEnumValue(name = "ZERO", value = 0)
+@GtfsEnumValue(name = "ONE", value = 1)
+@GtfsEnumValue(name = "MAX_BYTE", value = 127)
+@GtfsEnumValue(name = "MIN_BYTE", value = -128)
+public class ByteGtfsEnum {}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/EnumSizesSchema.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/EnumSizesSchema.java
@@ -1,0 +1,15 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.table.ByteGtfs;
+import org.mobilitydata.gtfsvalidator.table.IntGtfs;
+import org.mobilitydata.gtfsvalidator.table.ShortGtfs;
+
+@GtfsTable("enum_sizes.txt")
+public interface EnumSizesSchema {
+  ShortGtfs shortEnum();
+
+  ByteGtfs byteEnum();
+
+  IntGtfs intEnum();
+}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/IntGtfsEnum.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/IntGtfsEnum.java
@@ -1,0 +1,11 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
+
+@GtfsEnumValue(name = "ZERO", value = 0)
+@GtfsEnumValue(name = "ONE", value = 1)
+@GtfsEnumValue(name = "MAX_INT", value = Integer.MAX_VALUE)
+// MIN_INT is set to (MIN_VALUE + 1) since Integer.MIN_VALUE will be a special UNRECOGNIZED
+// constant.
+@GtfsEnumValue(name = "MIN_INT", value = Integer.MIN_VALUE + 1)
+public interface IntGtfsEnum {}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchema.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchema.java
@@ -1,0 +1,26 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+
+@GtfsTable("many_fields.txt")
+public interface ManyFieldsSchema {
+  int field1();
+
+  int field2();
+
+  int field3();
+
+  int field4();
+
+  int field5();
+
+  int field6();
+
+  int field7();
+
+  int field8();
+
+  int field9();
+
+  int field10();
+}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchema.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchema.java
@@ -19,8 +19,4 @@ public interface ManyFieldsSchema {
   int field7();
 
   int field8();
-
-  int field9();
-
-  int field10();
 }

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ShortGtfsEnum.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ShortGtfsEnum.java
@@ -1,0 +1,9 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
+
+@GtfsEnumValue(name = "ZERO", value = 0)
+@GtfsEnumValue(name = "ONE", value = 1)
+@GtfsEnumValue(name = "MAX_SHORT", value = Short.MAX_VALUE)
+@GtfsEnumValue(name = "MIN_SHORT", value = Short.MIN_VALUE)
+public interface ShortGtfsEnum {}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ShortGtfsEnum.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/ShortGtfsEnum.java
@@ -5,5 +5,5 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
 @GtfsEnumValue(name = "ZERO", value = 0)
 @GtfsEnumValue(name = "ONE", value = 1)
 @GtfsEnumValue(name = "MAX_SHORT", value = Short.MAX_VALUE)
-@GtfsEnumValue(name = "MIN_SHORT", value = Short.MIN_VALUE)
+@GtfsEnumValue(name = "MIN_SHORT", value = -Short.MAX_VALUE)
 public interface ShortGtfsEnum {}

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/EnumSizesSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/EnumSizesSchemaTest.java
@@ -28,18 +28,6 @@ public class EnumSizesSchemaTest {
     EnumSizes enumSizes = new EnumSizes.Builder().setByteEnum(10).build();
     // 10 is not a valid constant for ByteGtfs.
     assertThat(enumSizes.byteEnum()).isEqualTo(ByteGtfs.UNRECOGNIZED);
-    // However, 10 can be still retrieved using byteEnumValue method.
-    assertThat(enumSizes.byteEnumValue()).isEqualTo(10);
-  }
-
-  @Test
-  public void testByteEnumOutOfBounds() {
-    // Short.MIN_VALUE is out of bounds for byte. It cannot be retrieved with byteEnumValue.
-    assertThat(new EnumSizes.Builder().setByteEnum((int) Short.MIN_VALUE).build().byteEnumValue())
-        .isEqualTo(0);
-    // Short.MAX_VALUE is out of bounds for byte. It cannot be retrieved with byteEnumValue.
-    assertThat(new EnumSizes.Builder().setByteEnum((int) Short.MAX_VALUE).build().byteEnumValue())
-        .isEqualTo(-1);
   }
 
   @Test
@@ -57,18 +45,6 @@ public class EnumSizesSchemaTest {
     EnumSizes enumSizes = new EnumSizes.Builder().setShortEnum(10).build();
     // 10 is not a valid constant for ShortGtfs.
     assertThat(enumSizes.shortEnum()).isEqualTo(ShortGtfs.UNRECOGNIZED);
-    // However, 10 can be still retrieved using shortEnumValue method.
-    assertThat(enumSizes.shortEnumValue()).isEqualTo(10);
-  }
-
-  @Test
-  public void testShortEnumOutOfBounds() {
-    // Integer.MIN_VALUE is out of bounds for short. It cannot be retrieved with ShortEnumValue.
-    assertThat(new EnumSizes.Builder().setShortEnum(Integer.MIN_VALUE).build().shortEnumValue())
-        .isEqualTo(0);
-    // Integer.MAX_VALUE is out of bounds for short. It cannot be retrieved with ShortEnumValue.
-    assertThat(new EnumSizes.Builder().setShortEnum(Integer.MAX_VALUE).build().shortEnumValue())
-        .isEqualTo(-1);
   }
 
   @Test
@@ -86,7 +62,5 @@ public class EnumSizesSchemaTest {
     EnumSizes enumSizes = new EnumSizes.Builder().setIntEnum(10).build();
     // 10 is not a valid constant for ShortGtfs.
     assertThat(enumSizes.intEnum()).isEqualTo(IntGtfs.UNRECOGNIZED);
-    // However, 10 can be still retrieved using shortEnumValue method.
-    assertThat(enumSizes.intEnumValue()).isEqualTo(10);
   }
 }

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/EnumSizesSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/EnumSizesSchemaTest.java
@@ -1,0 +1,92 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.table.ByteGtfs;
+import org.mobilitydata.gtfsvalidator.table.EnumSizes;
+import org.mobilitydata.gtfsvalidator.table.IntGtfs;
+import org.mobilitydata.gtfsvalidator.table.ShortGtfs;
+
+@RunWith(JUnit4.class)
+public class EnumSizesSchemaTest {
+
+  @Test
+  public void testByteEnumValid() {
+    assertThat(new EnumSizes.Builder().setByteEnum(ByteGtfs.ONE).build().byteEnum())
+        .isEqualTo(ByteGtfs.ONE);
+    assertThat(new EnumSizes.Builder().setByteEnum(ByteGtfs.MAX_BYTE).build().byteEnum())
+        .isEqualTo(ByteGtfs.MAX_BYTE);
+    assertThat(new EnumSizes.Builder().setByteEnum(ByteGtfs.MIN_BYTE).build().byteEnum())
+        .isEqualTo(ByteGtfs.MIN_BYTE);
+  }
+
+  @Test
+  public void testByteEnumInvalid() {
+    EnumSizes enumSizes = new EnumSizes.Builder().setByteEnum(10).build();
+    // 10 is not a valid constant for ByteGtfs.
+    assertThat(enumSizes.byteEnum()).isEqualTo(ByteGtfs.UNRECOGNIZED);
+    // However, 10 can be still retrieved using byteEnumValue method.
+    assertThat(enumSizes.byteEnumValue()).isEqualTo(10);
+  }
+
+  @Test
+  public void testByteEnumOutOfBounds() {
+    // Short.MIN_VALUE is out of bounds for byte. It cannot be retrieved with byteEnumValue.
+    assertThat(new EnumSizes.Builder().setByteEnum((int) Short.MIN_VALUE).build().byteEnumValue())
+        .isEqualTo(0);
+    // Short.MAX_VALUE is out of bounds for byte. It cannot be retrieved with byteEnumValue.
+    assertThat(new EnumSizes.Builder().setByteEnum((int) Short.MAX_VALUE).build().byteEnumValue())
+        .isEqualTo(-1);
+  }
+
+  @Test
+  public void testShortEnumValid() {
+    assertThat(new EnumSizes.Builder().setShortEnum(ShortGtfs.ONE).build().shortEnum())
+        .isEqualTo(ShortGtfs.ONE);
+    assertThat(new EnumSizes.Builder().setShortEnum(ShortGtfs.MAX_SHORT).build().shortEnum())
+        .isEqualTo(ShortGtfs.MAX_SHORT);
+    assertThat(new EnumSizes.Builder().setShortEnum(ShortGtfs.MIN_SHORT).build().shortEnum())
+        .isEqualTo(ShortGtfs.MIN_SHORT);
+  }
+
+  @Test
+  public void testShortEnumInvalid() {
+    EnumSizes enumSizes = new EnumSizes.Builder().setShortEnum(10).build();
+    // 10 is not a valid constant for ShortGtfs.
+    assertThat(enumSizes.shortEnum()).isEqualTo(ShortGtfs.UNRECOGNIZED);
+    // However, 10 can be still retrieved using shortEnumValue method.
+    assertThat(enumSizes.shortEnumValue()).isEqualTo(10);
+  }
+
+  @Test
+  public void testShortEnumOutOfBounds() {
+    // Integer.MIN_VALUE is out of bounds for short. It cannot be retrieved with ShortEnumValue.
+    assertThat(new EnumSizes.Builder().setShortEnum(Integer.MIN_VALUE).build().shortEnumValue())
+        .isEqualTo(0);
+    // Integer.MAX_VALUE is out of bounds for short. It cannot be retrieved with ShortEnumValue.
+    assertThat(new EnumSizes.Builder().setShortEnum(Integer.MAX_VALUE).build().shortEnumValue())
+        .isEqualTo(-1);
+  }
+
+  @Test
+  public void testIntEnumValid() {
+    assertThat(new EnumSizes.Builder().setIntEnum(IntGtfs.ONE).build().intEnum())
+        .isEqualTo(IntGtfs.ONE);
+    assertThat(new EnumSizes.Builder().setIntEnum(IntGtfs.MAX_INT).build().intEnum())
+        .isEqualTo(IntGtfs.MAX_INT);
+    assertThat(new EnumSizes.Builder().setIntEnum(IntGtfs.MIN_INT).build().intEnum())
+        .isEqualTo(IntGtfs.MIN_INT);
+  }
+
+  @Test
+  public void testIntEnumInvalid() {
+    EnumSizes enumSizes = new EnumSizes.Builder().setIntEnum(10).build();
+    // 10 is not a valid constant for ShortGtfs.
+    assertThat(enumSizes.intEnum()).isEqualTo(IntGtfs.UNRECOGNIZED);
+    // However, 10 can be still retrieved using shortEnumValue method.
+    assertThat(enumSizes.intEnumValue()).isEqualTo(10);
+  }
+}

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchemaTest.java
@@ -11,16 +11,14 @@ import org.mobilitydata.gtfsvalidator.table.ManyFields;
 public class ManyFieldsSchemaTest {
   @Test
   public void testHasField() {
-    ManyFields manyFields = new ManyFields.Builder().setField2(2).setField9(9).build();
+    ManyFields manyFields = new ManyFields.Builder().setField2(2).setField8(9).build();
 
     assertThat(manyFields.hasField1()).isFalse();
     assertThat(manyFields.hasField2()).isTrue();
-    assertThat(manyFields.hasField9()).isTrue();
-    assertThat(manyFields.hasField10()).isFalse();
+    assertThat(manyFields.hasField8()).isTrue();
 
     assertThat(manyFields.field1()).isEqualTo(0);
     assertThat(manyFields.field2()).isEqualTo(2);
-    assertThat(manyFields.field9()).isEqualTo(9);
-    assertThat(manyFields.field10()).isEqualTo(0);
+    assertThat(manyFields.field8()).isEqualTo(9);
   }
 }

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/ManyFieldsSchemaTest.java
@@ -1,0 +1,26 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.table.ManyFields;
+
+@RunWith(JUnit4.class)
+public class ManyFieldsSchemaTest {
+  @Test
+  public void testHasField() {
+    ManyFields manyFields = new ManyFields.Builder().setField2(2).setField9(9).build();
+
+    assertThat(manyFields.hasField1()).isFalse();
+    assertThat(manyFields.hasField2()).isTrue();
+    assertThat(manyFields.hasField9()).isTrue();
+    assertThat(manyFields.hasField10()).isFalse();
+
+    assertThat(manyFields.field1()).isEqualTo(0);
+    assertThat(manyFields.field2()).isEqualTo(2);
+    assertThat(manyFields.field9()).isEqualTo(9);
+    assertThat(manyFields.field10()).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
GTFS enums usually fit into one byte, so we don't need an int. GTFS tables usually less than 16 fields, so we need a byte or a short int for storing a bitmask of assigned fields.

Smaller fields allow us to save memory for the largest table - stop_times.txt that may have 30 M lines.

Instead of:
```
class GtfsStopTime {
  // ...
  private int pickupType;
  private int dropOffType;
  private int continuousPickup;
  private int continuousDropOff;
  private int timepoint;
  private int bitField0_;
}
```
we have now:
```
class GtfsStopTime {
  // ...
  private byte pickupType;
  private byte dropOffType;
  private byte continuousPickup;
  private byte continuousDropOff;
  private byte timepoint;
  private short bitField0_;
}
```
which is 5 * (4 - 1) + 2 = 17 bytes smaller. Java aligns classes by 8 bytes, so we actually save 16 bytes per line.

Total save: 0.5 GiB for 30 M lines in stop_times.txt
