### PR TITLE
Move GTFS field names from table loader to entity classes

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -26,7 +26,6 @@ import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableLoader;
 
 /**
  * Validates that all agencies have the same timezone and language and that agency_id field is set
@@ -63,7 +62,7 @@ public class AgencyConsistencyValidator extends FileValidator {
             new MissingRequiredFieldNotice(
                 agencyTable.gtfsFilename(),
                 agency.csvRowNumber(),
-                GtfsAgencyTableLoader.AGENCY_ID_FIELD_NAME));
+                GtfsAgency.AGENCY_ID_FIELD_NAME));
       }
     }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsTripServiceIdForeignKeyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/GtfsTripServiceIdForeignKeyValidator.java
@@ -20,13 +20,12 @@ import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.ForeignKeyViolationNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendar;
+import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDate;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableLoader;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableLoader;
 import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
 import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsTripTableLoader;
 
 /**
  * Validates that service_id field in "trips.txt" references a valid service_id in "calendar.txt" or
@@ -57,10 +56,10 @@ public class GtfsTripServiceIdForeignKeyValidator extends FileValidator {
       if (!hasReferencedKey(childKey, calendarContainer, calendarDateContainer)) {
         noticeContainer.addValidationNotice(
             new ForeignKeyViolationNotice(
-                GtfsTripTableLoader.FILENAME,
-                GtfsTripTableLoader.SERVICE_ID_FIELD_NAME,
-                GtfsCalendarTableLoader.FILENAME + " or " + GtfsCalendarDateTableLoader.FILENAME,
-                GtfsCalendarTableLoader.SERVICE_ID_FIELD_NAME,
+                GtfsTrip.FILENAME,
+                GtfsTrip.SERVICE_ID_FIELD_NAME,
+                GtfsCalendar.FILENAME + " or " + GtfsCalendarDate.FILENAME,
+                GtfsCalendar.SERVICE_ID_FIELD_NAME,
                 childKey,
                 trip.csvRowNumber()));
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -16,8 +16,8 @@
 
 package org.mobilitydata.gtfsvalidator.validator;
 
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.ARRIVAL_TIME_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.DEPARTURE_TIME_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.ARRIVAL_TIME_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.DEPARTURE_TIME_FIELD_NAME;
 
 import com.google.common.collect.Multimaps;
 import java.util.List;

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
@@ -24,7 +24,6 @@ import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsPathway;
 import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsPathwayTableLoader;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 
@@ -54,15 +53,9 @@ public class PathwayEndpointTypeValidator extends FileValidator {
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsPathway pathway : pathwayTable.getEntities()) {
       checkEndpoint(
-          pathway,
-          GtfsPathwayTableLoader.FROM_STOP_ID_FIELD_NAME,
-          pathway.fromStopId(),
-          noticeContainer);
+          pathway, GtfsPathway.FROM_STOP_ID_FIELD_NAME, pathway.fromStopId(), noticeContainer);
       checkEndpoint(
-          pathway,
-          GtfsPathwayTableLoader.TO_STOP_ID_FIELD_NAME,
-          pathway.toStopId(),
-          noticeContainer);
+          pathway, GtfsPathway.TO_STOP_ID_FIELD_NAME, pathway.toStopId(), noticeContainer);
     }
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
@@ -25,7 +25,6 @@ import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 
 /**
@@ -64,8 +63,8 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
                   stopTime.tripId(),
                   stopTime.stopSequence(),
                   hasArrival
-                      ? GtfsStopTimeTableLoader.ARRIVAL_TIME_FIELD_NAME
-                      : GtfsStopTimeTableLoader.DEPARTURE_TIME_FIELD_NAME));
+                      ? GtfsStopTime.ARRIVAL_TIME_FIELD_NAME
+                      : GtfsStopTime.DEPARTURE_TIME_FIELD_NAME));
         }
         if (hasArrival
             && previousDepartureRow != -1

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
@@ -23,7 +23,6 @@ import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTimepoint;
 
 /**
@@ -49,7 +48,7 @@ public class TimepointTimeValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    if (!stopTimes.hasColumn(GtfsStopTimeTableLoader.TIMEPOINT_FIELD_NAME)) {
+    if (!stopTimes.hasColumn(GtfsStopTime.TIMEPOINT_FIELD_NAME)) {
       // legacy datasets do not use timepoint column in stop_times.txt as a result:
       // - this should be flagged;
       // - but also no notice regarding the absence of arrival_time or departure_time should be
@@ -65,12 +64,12 @@ public class TimepointTimeValidator extends FileValidator {
         if (!stopTime.hasArrivalTime()) {
           noticeContainer.addValidationNotice(
               new StopTimeTimepointWithoutTimesNotice(
-                  stopTime, GtfsStopTimeTableLoader.ARRIVAL_TIME_FIELD_NAME));
+                  stopTime, GtfsStopTime.ARRIVAL_TIME_FIELD_NAME));
         }
         if (!stopTime.hasDepartureTime()) {
           noticeContainer.addValidationNotice(
               new StopTimeTimepointWithoutTimesNotice(
-                  stopTime, GtfsStopTimeTableLoader.DEPARTURE_TIME_FIELD_NAME));
+                  stopTime, GtfsStopTime.DEPARTURE_TIME_FIELD_NAME));
         }
       }
     }
@@ -128,7 +127,7 @@ public class TimepointTimeValidator extends FileValidator {
 
     MissingTimepointColumnNotice() {
       super(SeverityLevel.WARNING);
-      this.filename = GtfsStopTimeTableLoader.FILENAME;
+      this.filename = GtfsStopTime.FILENAME;
     }
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransferDirection.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransferDirection.java
@@ -1,7 +1,6 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import org.mobilitydata.gtfsvalidator.table.GtfsTransfer;
-import org.mobilitydata.gtfsvalidator.table.GtfsTransferTableLoader;
 
 /**
  * An enum type, along with various convenience methods, for identifying the direction of transfer
@@ -20,9 +19,7 @@ public enum TransferDirection {
   TRANSFER_TO;
 
   public String stopIdFieldName() {
-    return isFrom()
-        ? GtfsTransferTableLoader.FROM_STOP_ID_FIELD_NAME
-        : GtfsTransferTableLoader.TO_STOP_ID_FIELD_NAME;
+    return isFrom() ? GtfsTransfer.FROM_STOP_ID_FIELD_NAME : GtfsTransfer.TO_STOP_ID_FIELD_NAME;
   }
 
   public String stopId(GtfsTransfer transfer) {
@@ -34,9 +31,7 @@ public enum TransferDirection {
   }
 
   public String routeIdFieldName() {
-    return isFrom()
-        ? GtfsTransferTableLoader.FROM_ROUTE_ID_FIELD_NAME
-        : GtfsTransferTableLoader.TO_ROUTE_ID_FIELD_NAME;
+    return isFrom() ? GtfsTransfer.FROM_ROUTE_ID_FIELD_NAME : GtfsTransfer.TO_ROUTE_ID_FIELD_NAME;
   }
 
   public boolean hasRouteId(GtfsTransfer transfer) {
@@ -48,9 +43,7 @@ public enum TransferDirection {
   }
 
   public String tripIdFieldName() {
-    return isFrom()
-        ? GtfsTransferTableLoader.FROM_TRIP_ID_FIELD_NAME
-        : GtfsTransferTableLoader.TO_TRIP_ID_FIELD_NAME;
+    return isFrom() ? GtfsTransfer.FROM_TRIP_ID_FIELD_NAME : GtfsTransfer.TO_TRIP_ID_FIELD_NAME;
   }
 
   public boolean hasTripId(GtfsTransfer transfer) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersInSeatTransferTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersInSeatTransferTypeValidator.java
@@ -17,7 +17,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTransfer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTransferTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsTransferTableLoader;
 import org.mobilitydata.gtfsvalidator.table.GtfsTransferType;
 import org.mobilitydata.gtfsvalidator.validator.TransfersStopTypeValidator.TransferWithInvalidStopLocationTypeNotice;
 
@@ -65,7 +64,7 @@ public class TransfersInSeatTransferTypeValidator extends FileValidator {
       if (!transferDirection.hasTripId(transfer)) {
         noticeContainer.addValidationNotice(
             new MissingRequiredFieldNotice(
-                GtfsTransferTableLoader.FILENAME,
+                GtfsTransfer.FILENAME,
                 transfer.csvRowNumber(),
                 transferDirection.tripIdFieldName()));
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -28,7 +28,6 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTranslation;
 import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableLoader;
 
 /**
  * Validates that translations are provided in accordance with GTFS Specification.
@@ -54,7 +53,7 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     // The legacy Google translation format does not define `translations.table_name` field.
-    if (!translationTable.getHeader().hasColumn(GtfsTranslationTableLoader.TABLE_NAME_FIELD_NAME)) {
+    if (!translationTable.getHeader().hasColumn(GtfsTranslation.TABLE_NAME_FIELD_NAME)) {
       // Skip validation if legacy Google translation format is detected.
       return;
     }
@@ -81,25 +80,25 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
       if (!translation.hasFieldName()) {
         noticeContainer.addValidationNotice(
             new MissingRequiredFieldNotice(
-                GtfsTranslationTableLoader.FILENAME,
+                GtfsTranslation.FILENAME,
                 translation.csvRowNumber(),
-                GtfsTranslationTableLoader.FIELD_NAME_FIELD_NAME));
+                GtfsTranslation.FIELD_NAME_FIELD_NAME));
         isValid = false;
       }
       if (!translation.hasLanguage()) {
         noticeContainer.addValidationNotice(
             new MissingRequiredFieldNotice(
-                GtfsTranslationTableLoader.FILENAME,
+                GtfsTranslation.FILENAME,
                 translation.csvRowNumber(),
-                GtfsTranslationTableLoader.LANGUAGE_FIELD_NAME));
+                GtfsTranslation.LANGUAGE_FIELD_NAME));
         isValid = false;
       }
       if (!translation.hasTableName()) {
         noticeContainer.addValidationNotice(
             new MissingRequiredFieldNotice(
-                GtfsTranslationTableLoader.FILENAME,
+                GtfsTranslation.FILENAME,
                 translation.csvRowNumber(),
-                GtfsTranslationTableLoader.TABLE_NAME_FIELD_NAME));
+                GtfsTranslation.TABLE_NAME_FIELD_NAME));
         isValid = false;
       }
     }
@@ -112,16 +111,12 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
       if (translation.hasRecordId()) {
         noticeContainer.addValidationNotice(
             new TranslationUnexpectedValueNotice(
-                translation,
-                GtfsTranslationTableLoader.RECORD_ID_FIELD_NAME,
-                translation.recordId()));
+                translation, GtfsTranslation.RECORD_ID_FIELD_NAME, translation.recordId()));
       }
       if (translation.hasRecordSubId()) {
         noticeContainer.addValidationNotice(
             new TranslationUnexpectedValueNotice(
-                translation,
-                GtfsTranslationTableLoader.RECORD_SUB_ID_FIELD_NAME,
-                translation.recordSubId()));
+                translation, GtfsTranslation.RECORD_SUB_ID_FIELD_NAME, translation.recordSubId()));
       }
     }
     Optional<GtfsTableContainer<?>> parentTable =
@@ -146,14 +141,14 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
             translation,
             translation.hasRecordId(),
             keyColumnNames.size() >= 1,
-            GtfsTranslationTableLoader.RECORD_ID_FIELD_NAME,
+            GtfsTranslation.RECORD_ID_FIELD_NAME,
             translation.recordId(),
             noticeContainer)
         || isMissingOrUnexpectedField(
             translation,
             translation.hasRecordSubId(),
             keyColumnNames.size() >= 2,
-            GtfsTranslationTableLoader.RECORD_SUB_ID_FIELD_NAME,
+            GtfsTranslation.RECORD_SUB_ID_FIELD_NAME,
             translation.recordSubId(),
             noticeContainer)) {
       return;
@@ -187,7 +182,7 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
     } else {
       noticeContainer.addValidationNotice(
           new MissingRequiredFieldNotice(
-              GtfsTranslationTableLoader.FILENAME, translation.csvRowNumber(), fieldName));
+              GtfsTranslation.FILENAME, translation.csvRowNumber(), fieldName));
     }
     return true;
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAgencyIdValidator.java
@@ -23,7 +23,6 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
-import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableLoader;
 
 /**
  * Checks that agency_id field in "routes.txt" is defined for every row if there is more than 1
@@ -52,9 +51,7 @@ public class TripAgencyIdValidator extends FileValidator {
       if (!route.hasAgencyId()) {
         noticeContainer.addValidationNotice(
             new MissingRequiredFieldNotice(
-                routeTable.gtfsFilename(),
-                route.csvRowNumber(),
-                GtfsRouteTableLoader.AGENCY_ID_FIELD_NAME));
+                routeTable.gtfsFilename(), route.csvRowNumber(), GtfsRoute.AGENCY_ID_FIELD_NAME));
       }
       // No need to check reference integrity because it is done by a validator generated from
       // @ForeignKey annotation.

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidatorTest.java
@@ -17,18 +17,18 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTableLoader.STOP_ID_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.ARRIVAL_TIME_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.CONTINUOUS_DROP_OFF_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.CONTINUOUS_PICKUP_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.DEPARTURE_TIME_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.DROP_OFF_TYPE_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.PICKUP_TYPE_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.SHAPE_DIST_TRAVELED_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.STOP_HEADSIGN_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.STOP_SEQUENCE_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.TIMEPOINT_FIELD_NAME;
-import static org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableLoader.TRIP_ID_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStop.STOP_ID_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.ARRIVAL_TIME_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.CONTINUOUS_DROP_OFF_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.CONTINUOUS_PICKUP_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.DEPARTURE_TIME_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.DROP_OFF_TYPE_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.PICKUP_TYPE_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.SHAPE_DIST_TRAVELED_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.STOP_HEADSIGN_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.STOP_SEQUENCE_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.TIMEPOINT_FIELD_NAME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsStopTime.TRIP_ID_FIELD_NAME;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/CurrencyAmountValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/CurrencyAmountValidatorGenerator.java
@@ -96,7 +96,8 @@ public class CurrencyAmountValidatorGenerator {
           .addStatement("$T currency = entity.$L()", Currency.class, currencyField.name())
           .beginControlFlow("if (amount.scale() != currency.getDefaultFractionDigits())")
           .addStatement(
-              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", entity.csvRowNumber(), amount))",
+              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", entity.csvRowNumber(),"
+                  + " amount))",
               InvalidCurrencyAmountNotice.class,
               fileDescriptor.filename(),
               amountField.name())

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EndRangeValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EndRangeValidatorGenerator.java
@@ -144,19 +144,20 @@ public class EndRangeValidatorGenerator {
       GtfsFieldDescriptor startField,
       GtfsFieldDescriptor endField,
       StartEndRangeNoticeType noticeType) {
-    TypeName tableLoaderTypeName = new GtfsEntityClasses(fileDescriptor).tableLoaderTypeName();
+    TypeName gtfsEntityTypeName =
+        new GtfsEntityClasses(fileDescriptor).entityImplementationTypeName();
     CodeBlock.Builder block =
-        CodeBlock.builder().add("$T.FILENAME, entity.csvRowNumber(), ", tableLoaderTypeName);
+        CodeBlock.builder().add("$T.FILENAME, entity.csvRowNumber(), ", gtfsEntityTypeName);
     if (fileDescriptor.hasSingleColumnPrimaryKey()) {
       block.add("entity.$L(), ", fileDescriptor.getSingleColumnPrimaryKey().name());
     }
-    block.add("$T.$L, ", tableLoaderTypeName, FieldNameConverter.fieldNameField(startField.name()));
+    block.add("$T.$L, ", gtfsEntityTypeName, FieldNameConverter.fieldNameField(startField.name()));
     if (noticeType.equals(StartEndRangeNoticeType.OUT_OF_ORDER)) {
       block.add("entity.$L().toString(), ", startField.name());
     }
     block.add(
         "$T.$L, entity.$L().toString()",
-        tableLoaderTypeName,
+        gtfsEntityTypeName,
         FieldNameConverter.fieldNameField(endField.name()),
         endField.name());
     return block.build();

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/EntityImplementationGenerator.java
@@ -18,8 +18,10 @@ package org.mobilitydata.gtfsvalidator.processor;
 
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.clearMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.fieldDefaultName;
+import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.fieldNameField;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.getValueMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.getterMethodName;
+import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.gtfsColumnName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.hasMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.setterMethodName;
 import static org.mobilitydata.gtfsvalidator.processor.GtfsEntityClasses.TABLE_PACKAGE_NAME;
@@ -218,6 +220,7 @@ public class EntityImplementationGenerator {
             .addJavadoc("Use {@link Builder} class to construct an object.")
             .build());
 
+    generateFilenameAndFieldNameConstants(typeSpec);
     addEntityOrBuilderFields(typeSpec);
     addDefaultValueFields(typeSpec);
 
@@ -244,6 +247,25 @@ public class EntityImplementationGenerator {
     typeSpec.addType(generateGtfsEntityBuilderClass());
 
     return typeSpec.build();
+  }
+
+  private void generateFilenameAndFieldNameConstants(TypeSpec.Builder typeSpec) {
+    typeSpec.addField(
+        FieldSpec.builder(
+                String.class, "FILENAME", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
+            .initializer("$S", fileDescriptor.filename())
+            .build());
+    for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
+      typeSpec.addField(
+          FieldSpec.builder(
+                  String.class,
+                  fieldNameField(field.name()),
+                  Modifier.PUBLIC,
+                  Modifier.STATIC,
+                  Modifier.FINAL)
+              .initializer("$S", gtfsColumnName(field.name()))
+              .build());
+    }
   }
 
   private MethodSpec generateGetterMethod(GtfsFieldDescriptor field, ClassContext classContext) {

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/LatLonValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/LatLonValidatorGenerator.java
@@ -120,18 +120,19 @@ public class LatLonValidatorGenerator {
 
   private static CodeBlock generateNoticeContext(
       GtfsFileDescriptor fileDescriptor, LatLonDescriptor latLonDescriptor) {
-    TypeName tableLoaderTypeName = new GtfsEntityClasses(fileDescriptor).tableLoaderTypeName();
+    TypeName gtfsEntityTypeName =
+        new GtfsEntityClasses(fileDescriptor).entityImplementationTypeName();
     CodeBlock.Builder block =
-        CodeBlock.builder().add("$T.FILENAME, entity.csvRowNumber(), ", tableLoaderTypeName);
+        CodeBlock.builder().add("$T.FILENAME, entity.csvRowNumber(), ", gtfsEntityTypeName);
     if (fileDescriptor.hasSingleColumnPrimaryKey()) {
       block.add("entity.$L(), ", fileDescriptor.getSingleColumnPrimaryKey().name());
     }
     block.add(
         "$T.$L, entity.$L(), $T.$L, entity.$L()",
-        tableLoaderTypeName,
+        gtfsEntityTypeName,
         FieldNameConverter.fieldNameField(latLonDescriptor.latField()),
         latLonDescriptor.latField(),
-        tableLoaderTypeName,
+        gtfsEntityTypeName,
         FieldNameConverter.fieldNameField(latLonDescriptor.lonField()),
         latLonDescriptor.lonField());
     return block.build();

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -75,7 +75,7 @@ public class TableContainerGenerator {
             .addAnnotation(Override.class)
             .addModifiers(Modifier.PUBLIC)
             .returns(String.class)
-            .addStatement("return $T.FILENAME", classNames.tableLoaderTypeName())
+            .addStatement("return $T.FILENAME", classNames.entityImplementationTypeName())
             .build());
 
     typeSpec.addMethod(

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
@@ -191,7 +191,9 @@ class TableContainerIndexGenerator {
             .map(
                 (f) ->
                     CodeBlock.of(
-                        "$T.$L", classNames.tableLoaderTypeName(), fieldNameField(f.name())))
+                        "$T.$L",
+                        classNames.entityImplementationTypeName(),
+                        fieldNameField(f.name())))
             .collect(CodeBlock.joining(", ")));
     return field.build();
   }
@@ -323,7 +325,9 @@ class TableContainerIndexGenerator {
                   + "$L, $L))",
               DuplicateKeyNotice.class,
               fileDescriptor.primaryKeys().stream()
-                  .map((field) -> CodeBlock.of("$T.$L", loaderType, fieldNameField(field.name())))
+                  .map(
+                      (field) ->
+                          CodeBlock.of("$T.$L", gtfsEntityType, fieldNameField(field.name())))
                   .collect(CodeBlock.joining(" + \",\" + ")),
               fileDescriptor.primaryKeys().stream()
                   .map((field) -> CodeBlock.of("oldEntity.$L()", field.name()))
@@ -350,7 +354,7 @@ class TableContainerIndexGenerator {
               "noticeContainer.addValidationNotice(new $T(gtfsFilename(),"
                   + " newEntity.csvRowNumber(), oldEntity.csvRowNumber(), $T.$L, newEntity.$L()))",
               DuplicateKeyNotice.class,
-              loaderType,
+              gtfsEntityType,
               fieldNameField(primaryKey.name()),
               primaryKey.name())
           .nextControlFlow("else")

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableLoaderGenerator.java
@@ -16,10 +16,11 @@
 
 package org.mobilitydata.gtfsvalidator.processor;
 
-import static org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum.*;
+import static org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum.OPTIONAL;
+import static org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum.RECOMMENDED;
+import static org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum.REQUIRED;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.fieldColumnIndex;
 import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.fieldNameField;
-import static org.mobilitydata.gtfsvalidator.processor.FieldNameConverter.gtfsColumnName;
 import static org.mobilitydata.gtfsvalidator.processor.GtfsEntityClasses.TABLE_PACKAGE_NAME;
 
 import com.google.common.base.CaseFormat;
@@ -145,22 +146,6 @@ public class TableLoaderGenerator {
                 FluentLogger.class, "logger", Modifier.PRIVATE, Modifier.STATIC, Modifier.FINAL)
             .initializer("$T.forEnclosingClass()", FluentLogger.class)
             .build());
-    typeSpec.addField(
-        FieldSpec.builder(
-                String.class, "FILENAME", Modifier.PUBLIC, Modifier.STATIC, Modifier.FINAL)
-            .initializer("$S", fileDescriptor.filename())
-            .build());
-    for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
-      typeSpec.addField(
-          FieldSpec.builder(
-                  String.class,
-                  fieldNameField(field.name()),
-                  Modifier.PUBLIC,
-                  Modifier.STATIC,
-                  Modifier.FINAL)
-              .initializer("$S", gtfsColumnName(field.name()))
-              .build());
-    }
 
     typeSpec.addMethod(MethodSpec.constructorBuilder().addModifiers(Modifier.PUBLIC).build());
     typeSpec.addMethod(generateGtfsFilenameMethod());
@@ -175,39 +160,34 @@ public class TableLoaderGenerator {
   }
 
   private MethodSpec generateGetColumnNamesMethod() {
-    ArrayList<String> fieldNames = new ArrayList<>();
-    fieldNames.ensureCapacity(fileDescriptor.fields().size());
-    for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
-      fieldNames.add(fieldNameField(field.name()));
-    }
-
-    MethodSpec.Builder method =
-        MethodSpec.methodBuilder("getColumnNames")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .returns(ParameterizedTypeName.get(Set.class, String.class))
-            .addStatement("return $T.of($L)", ImmutableSet.class, String.join(", ", fieldNames));
-
-    return method.build();
+    TypeName gtfsEntityType = classNames.entityImplementationTypeName();
+    return MethodSpec.methodBuilder("getColumnNames")
+        .addAnnotation(Override.class)
+        .addModifiers(Modifier.PUBLIC)
+        .returns(ParameterizedTypeName.get(Set.class, String.class))
+        .addStatement(
+            "return $T.of($L)",
+            ImmutableSet.class,
+            fileDescriptor.fields().stream()
+                .map(field -> CodeBlock.of("$T.$L", gtfsEntityType, fieldNameField(field.name())))
+                .collect(CodeBlock.joining(", ")))
+        .build();
   }
 
   private MethodSpec generateGetRequiredColumnNamesMethod() {
-    ArrayList<String> fieldNames = new ArrayList<>();
-    fieldNames.ensureCapacity(fileDescriptor.fields().size());
-    for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
-      if (field.required()) {
-        fieldNames.add(fieldNameField(field.name()));
-      }
-    }
-
-    MethodSpec.Builder method =
-        MethodSpec.methodBuilder("getRequiredColumnNames")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .returns(ParameterizedTypeName.get(Set.class, String.class))
-            .addStatement("return $T.of($L)", ImmutableSet.class, String.join(", ", fieldNames));
-
-    return method.build();
+    TypeName gtfsEntityType = classNames.entityImplementationTypeName();
+    return MethodSpec.methodBuilder("getRequiredColumnNames")
+        .addAnnotation(Override.class)
+        .addModifiers(Modifier.PUBLIC)
+        .returns(ParameterizedTypeName.get(Set.class, String.class))
+        .addStatement(
+            "return $T.of($L)",
+            ImmutableSet.class,
+            fileDescriptor.fields().stream()
+                .filter(GtfsFieldDescriptor::required)
+                .map(field -> CodeBlock.of("$T.$L", gtfsEntityType, fieldNameField(field.name())))
+                .collect(CodeBlock.joining(", ")))
+        .build();
   }
 
   private MethodSpec generateLoadMethod() {
@@ -234,23 +214,23 @@ public class TableLoaderGenerator {
           "settings.setMaxCharsPerColumn($L)", fileDescriptor.maxCharsPerColumn().get());
     }
     method
-        .addStatement("csvFile = new $T(inputStream, FILENAME, settings)", CsvFile.class)
+        .addStatement("csvFile = new $T(inputStream, gtfsFilename(), settings)", CsvFile.class)
         .nextControlFlow("catch ($T e)", TextParsingException.class)
         .addStatement(
-            "noticeContainer.addValidationNotice(new $T(FILENAME, e))",
+            "noticeContainer.addValidationNotice(new $T(gtfsFilename(), e))",
             CsvParsingFailedNotice.class)
         .addStatement(
             "return new $T($T.INVALID_HEADERS)", tableContainerTypeName, TableStatus.class)
         .endControlFlow()
         .beginControlFlow("if (csvFile.isEmpty())")
         .addStatement(
-            "noticeContainer.addValidationNotice(new $T(FILENAME))", EmptyFileNotice.class)
+            "noticeContainer.addValidationNotice(new $T(gtfsFilename()))", EmptyFileNotice.class)
         .addStatement("return new $T($T.EMPTY_FILE)", tableContainerTypeName, TableStatus.class)
         .endControlFlow()
         .addStatement("$T header = csvFile.getHeader()", CsvHeader.class)
         .addStatement("$T headerNotices = new $T()", NoticeContainer.class, NoticeContainer.class)
         .addStatement(
-            "validatorProvider.getTableHeaderValidator().validate(FILENAME, header, "
+            "validatorProvider.getTableHeaderValidator().validate(gtfsFilename(), header, "
                 + "getColumnNames(), getRequiredColumnNames(), headerNotices)")
         .addStatement("noticeContainer.addAll(headerNotices)")
         .beginControlFlow("if (headerNotices.hasValidationErrors())")
@@ -260,8 +240,9 @@ public class TableLoaderGenerator {
 
     for (GtfsFieldDescriptor field : fileDescriptor.fields()) {
       method.addStatement(
-          "final int $L = header.getColumnIndex($L)",
+          "final int $L = header.getColumnIndex($T.$L)",
           fieldColumnIndex(field.name()),
+          gtfsEntityType,
           fieldNameField(field.name()));
     }
 
@@ -284,7 +265,8 @@ public class TableLoaderGenerator {
     method
         .addStatement("final $T.Builder builder = new $T.Builder()", gtfsEntityType, gtfsEntityType)
         .addStatement(
-            "final $T rowParser = new $T(FILENAME, header, validatorProvider.getFieldValidator())",
+            "final $T rowParser = new $T(gtfsFilename(), header,"
+                + " validatorProvider.getFieldValidator())",
             RowParser.class,
             RowParser.class)
         .addStatement(
@@ -305,7 +287,8 @@ public class TableLoaderGenerator {
         .beginControlFlow("try")
         .beginControlFlow("for ($T row : csvFile)", CsvRow.class)
         .beginControlFlow("if (row.getRowNumber() % $L == 0)", LOG_EVERY_N_ROWS)
-        .addStatement("logger.atInfo().log($S, FILENAME, row.getRowNumber())", "Reading %s, row %d")
+        .addStatement(
+            "logger.atInfo().log($S, gtfsFilename(), row.getRowNumber())", "Reading %s, row %d")
         .endControlFlow()
         .addStatement("$T rowNotices = new $T()", NoticeContainer.class, NoticeContainer.class)
         .addStatement("rowParser.setRow(row, rowNotices)")
@@ -354,7 +337,7 @@ public class TableLoaderGenerator {
         .endControlFlow() // end for (row)
         .nextControlFlow("catch ($T e)", TextParsingException.class)
         .addStatement(
-            "noticeContainer.addValidationNotice(new $T(FILENAME, e))",
+            "noticeContainer.addValidationNotice(new $T(gtfsFilename(), e))",
             CsvParsingFailedNotice.class)
         .addStatement(
             "return new $T($T.UNPARSABLE_ROWS)", tableContainerTypeName, TableStatus.class)
@@ -366,9 +349,10 @@ public class TableLoaderGenerator {
         final String cacheName = fieldColumnCache(field);
         method.addStatement(
             "logger.atInfo().log("
-                + "$S, gtfsFilename(), $L, $L.getCacheSize(), $L.getLookupCount(), "
+                + "$S, gtfsFilename(), $T.$L, $L.getCacheSize(), $L.getLookupCount(), "
                 + "$L.getHitRatio() * 100.0, $L.getMissRatio() * 100.0)",
             "Cache for %s %s: size = %d, lookup count = %d, hits = %.2f%%, misses = %.2f%%",
+            gtfsEntityType,
             fieldNameField(field.name()),
             cacheName,
             cacheName,
@@ -381,7 +365,8 @@ public class TableLoaderGenerator {
 
     method
         .beginControlFlow("if (hasUnparsableRows)")
-        .addStatement("logger.atSevere().log($S, FILENAME)", "Failed to parse some rows in %s")
+        .addStatement(
+            "logger.atSevere().log($S, gtfsFilename())", "Failed to parse some rows in %s")
         .addStatement(
             "return new $T($T.UNPARSABLE_ROWS)", tableContainerTypeName, TableStatus.class)
         .nextControlFlow("else")
@@ -404,7 +389,7 @@ public class TableLoaderGenerator {
         .addAnnotation(Override.class)
         .addModifiers(Modifier.PUBLIC)
         .returns(String.class)
-        .addStatement("return FILENAME")
+        .addStatement("return $T.FILENAME", classNames.entityImplementationTypeName())
         .build();
   }
 


### PR DESCRIPTION
E.g., now use `GtfsStop.STOP_ID_FIELD_NAME` instead of `GtfsStopTableLoader.STOP_ID_FIELD_NAME`.

Motivation

1. Table loader classes should be only used for loading data tables. They should not be used by validator classes.
2. Our final goal is to stop generating table loader classes and instead make them usual classes that use a GTFS schema as a parameter. GTFS field names have to be generated, so we move them to entity classes that are generated anyway.
