### PR TITLE
fix: Don't ignore invalid language codes in RowParser.asLanguageCode

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -185,26 +185,26 @@ public class RowParser {
   @Nullable
   /**
    * Reads the value at the specified {@code columnIndex} and parses it as {@code Locale}.
-   * 
+   *
    * @param columnIndex the column index
    * @param level whether the value is required, recommended or optional according to GTFS
    * @return If parsing was successful returns {@code Locale}, otherwise, {@code null} is returned.
    */
   public Locale asLanguageCode(int columnIndex, FieldLevelEnum level) {
-    return parseAsType(columnIndex, level, this::parseLocale, InvalidLanguageCodeNotice::new);
+    return parseAsType(columnIndex, level, RowParser::parseLocale, InvalidLanguageCodeNotice::new);
   }
 
   /**
    * Returns a well-formed IETF BCP 47 language tag representing this locale.
    *
    * @return a BCP47 locale representing the {@code languageTag}.
-   * @throws IllformedLocaleException if the {@code languageTag} doesn't match with IETF BCP 47
-   *     standard.
+   * @throws java.util.IllformedLocaleException if the {@code languageTag} doesn't match with IETF
+   *     BCP 47 standard.
    * @see java.util.Locale.Builder#setLanguageTag(String) and check how <a
    *     href="https://docs.oracle.com/javase/tutorial/i18n/locale/extensions.html">BCP 47
    *     Extensions</a> implemented in java.
    */
-  private Locale parseLocale(String languageTag) {
+  private static Locale parseLocale(String languageTag) {
     return new Locale.Builder().setLanguageTag(languageTag).build();
   }
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -183,8 +183,29 @@ public class RowParser {
   }
 
   @Nullable
+  /**
+   * Reads the value at the specified {@code columnIndex} and parses it as {@code Locale}.
+   * 
+   * @param columnIndex the column index
+   * @param level whether the value is required, recommended or optional according to GTFS
+   * @return If parsing was successful returns {@code Locale}, otherwise, {@code null} is returned.
+   */
   public Locale asLanguageCode(int columnIndex, FieldLevelEnum level) {
-    return parseAsType(columnIndex, level, Locale::forLanguageTag, InvalidLanguageCodeNotice::new);
+    return parseAsType(columnIndex, level, this::parseLocale, InvalidLanguageCodeNotice::new);
+  }
+
+  /**
+   * Returns a well-formed IETF BCP 47 language tag representing this locale.
+   *
+   * @return a BCP47 locale representing the {@code languageTag}.
+   * @throws IllformedLocaleException if the {@code languageTag} doesn't match with IETF BCP 47
+   *     standard.
+   * @see java.util.Locale.Builder#setLanguageTag(String) and check how <a
+   *     href="https://docs.oracle.com/javase/tutorial/i18n/locale/extensions.html">BCP 47
+   *     Extensions</a> implemented in java.
+   */
+  private Locale parseLocale(String languageTag) {
+    return new Locale.Builder().setLanguageTag(languageTag).build();
   }
 
   @Nullable

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -248,6 +248,13 @@ public class RowParserTest {
   }
 
   @Test
+  public void asLanguageCode_invalid() {
+    // Underscore is invalid delimiter.
+    assertThat(createParser("en_EN").asLanguageCode(0, FieldLevelEnum.REQUIRED))
+        .isNull();
+  }
+
+  @Test
   public void asLanguageCode() {
     // Russian of Russia.
     assertThat(createParser("ru-RU").asLanguageCode(0, FieldLevelEnum.REQUIRED).toLanguageTag())

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -250,8 +250,7 @@ public class RowParserTest {
   @Test
   public void asLanguageCode_invalid() {
     // Underscore is invalid delimiter.
-    assertThat(createParser("en_EN").asLanguageCode(0, FieldLevelEnum.REQUIRED))
-        .isNull();
+    assertThat(createParser("en_EN").asLanguageCode(0, FieldLevelEnum.REQUIRED)).isNull();
   }
 
   @Test


### PR DESCRIPTION

**Summary:**

Don't ignore invalid language codes in RowParser.asLanguageCode. Locale::forLanguageTag ignores invalid language codes and no notices are created. 

**Expected behavior:** 

Invalid language detected

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
