### PR TITLE
Do not invoke single file validators if table indices were not generated

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -121,8 +121,10 @@ public final class AnyTableLoader {
     }
     GtfsTableContainer table =
         tableDescriptor.createContainerForHeaderAndEntities(header, entities, noticeContainer);
-    ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table), noticeContainer);
+    if (!noticeContainer.hasValidationErrors()) {
+      ValidatorUtil.invokeSingleFileValidators(
+          validatorProvider.createSingleFileValidators(table), noticeContainer);
+    }
     return table;
   }
 


### PR DESCRIPTION
If a table has duplicated keys, then its indices won't be generated and the noticeContainer will contain errors. Single file validators may have undefined behaviour when called for such incomplete indices.
