### PR TITLE
fix: byTranslationKey() for multi-key schemas without translations.txt support

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
@@ -208,6 +208,11 @@ class TableContainerIndexGenerator {
         .build();
   }
 
+  private boolean hasTranslationRecordId() {
+    return fileDescriptor.primaryKeys().stream()
+        .anyMatch((f) -> f.primaryKey().get().translationRecordIdType() == RECORD_ID);
+  }
+
   private MethodSpec generateByTranslationKeyMethod() {
     MethodSpec.Builder method =
         MethodSpec.methodBuilder("byTranslationKey")
@@ -222,7 +227,7 @@ class TableContainerIndexGenerator {
       method.addStatement(
           "return Optional.ofNullable($L.getOrDefault(recordId, null))",
           byKeyMapName(fileDescriptor.getSingleColumnPrimaryKey().name()));
-    } else if (fileDescriptor.hasMultiColumnPrimaryKey()) {
+    } else if (fileDescriptor.hasMultiColumnPrimaryKey() && hasTranslationRecordId()) {
       ImmutableMap<TranslationRecordIdType, String> recordIdTypes =
           ImmutableMap.of(RECORD_ID, "recordId", RECORD_SUB_ID, "recordSubId");
       List<CodeBlock> keyBuilderSetters = new ArrayList<>();

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/MultiColumnUnsupportedTranslationsPrimaryKeySchema.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/MultiColumnUnsupportedTranslationsPrimaryKeySchema.java
@@ -1,0 +1,18 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import static org.mobilitydata.gtfsvalidator.annotation.TranslationRecordIdType.UNSUPPORTED;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
+
+@GtfsTable("multi_column_unsupported_translations_primary_key.txt")
+public interface MultiColumnUnsupportedTranslationsPrimaryKeySchema {
+  @PrimaryKey(translationRecordIdType = UNSUPPORTED)
+  String idA();
+
+  @PrimaryKey(translationRecordIdType = UNSUPPORTED)
+  String idB();
+
+  @PrimaryKey(translationRecordIdType = UNSUPPORTED)
+  String idC();
+}

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MultiColumnUnsupportedTranslationsPrimaryKeySchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MultiColumnUnsupportedTranslationsPrimaryKeySchemaTest.java
@@ -1,0 +1,36 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import static com.google.common.truth.Truth8.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.table.MultiColumnUnsupportedTranslationsPrimaryKeyTableContainer;
+import org.mobilitydata.gtfsvalidator.table.MultiColumnUnsupportedTranslationsPrimaryKeyTableDescriptor;
+import org.mobilitydata.gtfsvalidator.testing.LoadingHelper;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
+
+@RunWith(JUnit4.class)
+public class MultiColumnUnsupportedTranslationsPrimaryKeySchemaTest {
+  private MultiColumnUnsupportedTranslationsPrimaryKeyTableDescriptor tableDescriptor;
+
+  private LoadingHelper helper;
+
+  @Before
+  public void setup() {
+    tableDescriptor = new MultiColumnUnsupportedTranslationsPrimaryKeyTableDescriptor();
+    helper = new LoadingHelper();
+  }
+
+  @Test
+  public void testNoTranslationSupport() throws ValidatorLoaderException {
+    MultiColumnUnsupportedTranslationsPrimaryKeyTableContainer container =
+        helper.load(tableDescriptor, "id_a,id_b,id_c", "a1,b1,c1", ",,");
+
+    // byTranslationKey should return empty for all these calls because none of the primary keys
+    // have translation record id annotations.
+    assertThat(container.byTranslationKey("a1", "b1")).isEmpty();
+    assertThat(container.byTranslationKey("", "")).isEmpty();
+  }
+}


### PR DESCRIPTION
The `@PrimaryKey(translationRecordIdType)` field is used to indicated which keys, if any, for a given GTFS entity can be used for performing `translations.txt` lookups via `byTranslationKey()` methods generated in the table container.  Currently, code in `TableContainerIndexGenerator` will generate an implementation for `byTranslationKey()` even if none of the @PrimaryKey fields have been marked as the translation RECORD_ID.  This can lead to some weird behavior where the method will return a value even if none should be returned or generate code that does not actually compile.

This PR fixes this behavior by no longer generating a `byTranslationKey()` implementation if the entity type does not support.  Instead, empty is returned.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
