### PR TITLE
Initialize one field per line in the generated code

### DIFF
--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
@@ -191,7 +191,7 @@ class TableContainerIndexGenerator {
                         "$T.$L",
                         classNames.entityImplementationTypeName(),
                         fieldNameField(f.name())))
-            .collect(CodeBlock.joining(", ")));
+            .collect(CodeBlock.joining(",\n")));
     return field.build();
   }
 
@@ -255,9 +255,9 @@ class TableContainerIndexGenerator {
       method
           .beginControlFlow("try")
           .addStatement(
-              "return Optional.ofNullable($L.getOrDefault(CompositeKey.builder()$L.build(), null))",
+              "return Optional.ofNullable($L.getOrDefault(CompositeKey.builder()\n$L.\nbuild(), null))",
               BY_COMPOSITE_KEY_MAP_FIELD_NAME,
-              CodeBlock.join(keyBuilderSetters, ""))
+              CodeBlock.join(keyBuilderSetters, "\n"))
           .nextControlFlow("catch (NumberFormatException ex)")
           .addStatement("return Optional.empty()")
           .endControlFlow();
@@ -305,7 +305,7 @@ class TableContainerIndexGenerator {
       method
           .beginControlFlow("for ($T newEntity : entities)", gtfsEntityType)
           .addStatement(
-              "CompositeKey key = CompositeKey.builder()$L.build()",
+              "CompositeKey key = CompositeKey.builder()\n$L\n.build()",
               fileDescriptor.primaryKeys().stream()
                   .map(
                       (field) ->
@@ -313,26 +313,26 @@ class TableContainerIndexGenerator {
                               ".$L(newEntity.$L())",
                               FieldNameConverter.setterMethodName(field.name()),
                               field.name()))
-                  .collect(CodeBlock.joining("")))
+                  .collect(CodeBlock.joining("\n")))
           .addStatement(
               "$T oldEntity = $L.getOrDefault(key, null)",
               classNames.entityImplementationTypeName(),
               BY_COMPOSITE_KEY_MAP_FIELD_NAME)
           .beginControlFlow("if (oldEntity != null)")
           .addStatement(
-              "noticeContainer.addValidationNotice(new $T("
+              "noticeContainer.addValidationNotice(new $T(\n"
                   + "gtfsFilename(), newEntity.csvRowNumber(), "
-                  + "oldEntity.csvRowNumber(), "
-                  + "$L, $L))",
+                  + "oldEntity.csvRowNumber(),\n"
+                  + "$L,\n$L))",
               DuplicateKeyNotice.class,
               fileDescriptor.primaryKeys().stream()
                   .map(
                       (field) ->
                           CodeBlock.of("$T.$L", gtfsEntityType, fieldNameField(field.name())))
-                  .collect(CodeBlock.joining(" + \",\" + ")),
+                  .collect(CodeBlock.joining(" + \",\" + \n")),
               fileDescriptor.primaryKeys().stream()
                   .map((field) -> CodeBlock.of("oldEntity.$L()", field.name()))
-                  .collect(CodeBlock.joining(" + \",\" + ")))
+                  .collect(CodeBlock.joining(" + \",\" + \n")))
           .nextControlFlow("else")
           .addStatement("$L.put(key, newEntity)", BY_COMPOSITE_KEY_MAP_FIELD_NAME)
           .endControlFlow()


### PR DESCRIPTION
The generated code may be analysed by engineers, so it should be readable.

Example of the new code.

```
      CompositeKey key = CompositeKey.builder()
          .setFromStopId(newEntity.fromStopId())
          .setToStopId(newEntity.toStopId())
          .setFromTripId(newEntity.fromTripId())
          .setToTripId(newEntity.toTripId())
          .setFromRouteId(newEntity.fromRouteId())
          .setToRouteId(newEntity.toRouteId())
          .build();
```
