### PR TITLE
fix: Bump validation workflows to use large machine instances

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -127,10 +127,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   get-reports:
     needs: [ fetch-urls, pack-master, pack-snapshot ]
-    runs-on: 
-      # We use machines with more memory to run validation, as large feeds
-      # can consume too much heap for default machine instances (see #1304).
-      labels: ubuntu-latest-4-cores
+    # We use machines with more memory to run validation, as large feeds
+    # can consume too much heap for default machine instances (see #1304).
+    runs-on: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: 
       # We use machines with more memory to run validation, as large feeds
       # can consume too much heap for default machine instances (see #1304).
-      group: ubuntu-latest-4-cores
+      label: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -127,7 +127,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   get-reports:
     needs: [ fetch-urls, pack-master, pack-snapshot ]
-    runs-on: ubuntu-latest
+    runs-on: 
+      # We use machines with more memory to run validation, as large feeds
+      # can consume too much heap for default machine instances (see #1304).
+      group: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -130,7 +130,7 @@ jobs:
     runs-on: 
       # We use machines with more memory to run validation, as large feeds
       # can consume too much heap for default machine instances (see #1304).
-      label: ubuntu-latest-4-cores
+      labels: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -82,10 +82,9 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   run-on-data:
     needs: [ fetch-urls, pack-snapshot ]
-    runs-on: 
-      # We use machines with more memory to run validation, as large feeds
-      # can consume too much heap for default machine instances (see #1304).
-      labels: ubuntu-latest-4-cores
+    # We use machines with more memory to run validation, as large feeds
+    # can consume too much heap for default machine instances (see #1304).
+    runs-on: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: 
       # We use machines with more memory to run validation, as large feeds
       # can consume too much heap for default machine instances (see #1304).
-      label: ubuntu-latest-4-cores
+      labels: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -85,7 +85,7 @@ jobs:
     runs-on: 
       # We use machines with more memory to run validation, as large feeds
       # can consume too much heap for default machine instances (see #1304).
-      group: ubuntu-latest-4-cores
+      label: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -82,7 +82,10 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
   run-on-data:
     needs: [ fetch-urls, pack-snapshot ]
-    runs-on: ubuntu-latest
+    runs-on: 
+      # We use machines with more memory to run validation, as large feeds
+      # can consume too much heap for default machine instances (see #1304).
+      group: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:


### PR DESCRIPTION
We want to avoid running out of heap memory when processing large feeds.

Closes #1304.