### PR TITLE
Docs: Fix RULES.md notice name for 2 notices

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -101,8 +101,8 @@ Each Notice is associated with a severity: `INFO`, `WARNING`, `ERROR`.
 | [`equal_shape_distance_same_coordinates`](#equal_shape_distance_same_coordinates)             | Two consecutive points have equal `shape_dist_traveled` and the same lat/lon coordinates in `shapes.txt`.                                                     |
 | [`fast_travel_between_consecutive_stops`](#fast_travel_between_consecutive_stops)             | A transit vehicle moves too fast between two consecutive stops.                                                                                               |
 | [`fast_travel_between_far_stops`](#fast_travel_between_far_stops)                             | A transit vehicle moves too fast between two far stops.                                                                                                       |
-| [`feed_expiration_date_7_days`](#feed_expiration_date_7_days)                                 | Dataset should be valid for at least the next 7 days.                                                                                                         |
-| [`feed_expiration_date_30_days`](#feed_expiration_date_30_days)                               | Dataset should cover at least the next 30 days of service.                                                                                                    |
+| [`feed_expiration_date7_days`](#feed_expiration_date7_days)                                 | Dataset should be valid for at least the next 7 days.                                                                                                         |
+| [`feed_expiration_date30_days`](#feed_expiration_date30_days)                               | Dataset should cover at least the next 30 days of service.                                                                                                    |
 | [`feed_info_lang_and_agency_mismatch`](#feed_info_lang_and_agency_mismatch)                   | Mismatching feed and agency language fields.                                                                                                                  |
 | [`inconsistent_agency_lang`](#inconsistent_agency_lang)                                       | Inconsistent language among agencies.                                                                                                                         |
 | [`leading_or_trailing_whitespaces`](#leading_or_trailing_whitespaces)                         | The value in CSV file has leading or trailing whitespaces.                                                                                                    |
@@ -1823,7 +1823,7 @@ Same as for [`fast_travel_between_consecutive_stops`](#fast_travel_between_conse
 
 <a name="FeedExpirationDate7DaysNotice"/>
 
-### feed_expiration_date_7_days
+### feed_expiration_date7_days
 
 The dataset expiration date defined in `feed_info.txt` is in seven days or less. At any time, the published GTFS dataset should be valid for at least the next 7 days.
 
@@ -1847,7 +1847,7 @@ The dataset expiration date defined in `feed_info.txt` is in seven days or less.
 
 <a name="FeedExpirationDate30DaysNotice"/>
 
-### feed_expiration_date_30_days
+### feed_expiration_date30_days
 
 At any time, the GTFS dataset should cover at least the next 30 days of service, and ideally for as long as the operator is confident that the schedule will continue to be operated.
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/model/NoticeReport.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/model/NoticeReport.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
+ */ 
 
 package org.mobilitydata.gtfsvalidator.model;
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/model/NoticeReport.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/model/NoticeReport.java
@@ -12,7 +12,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */ 
+ */
 
 package org.mobilitydata.gtfsvalidator.model;
 


### PR DESCRIPTION
**Summary:**

Closes #1322 

**Expected behavior:** 

~~When either `feed_expiration_date7_days` or `feed_expiration_date30_days` is triggered, the link in the HTML report isn't broken. ~~
EDIT: the notice name in the validation report is the same than the notice name in RULES.md for these two notices.

Please make sure these boxes are checked before submitting your pull request - thanks!

- ~~[ ] Run the unit tests with `gradle test` to make sure you didn't break anything~~
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~~
