### PR TITLE
feat: Add unit test to verify that every Notice has an entry in RULES.md

### DIFF
--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -3,12 +3,8 @@ name: Test Package Document
 on:
   push:
     branches: [ master ]
-    paths-ignore:
-      - '**.md'
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - '**.md'
   release:
     types: [ prereleased, released ]
 

--- a/RULES.md
+++ b/RULES.md
@@ -101,9 +101,9 @@ Each Notice is associated with a severity: `INFO`, `WARNING`, `ERROR`.
 | [`equal_shape_distance_same_coordinates`](#equal_shape_distance_same_coordinates)             | Two consecutive points have equal `shape_dist_traveled` and the same lat/lon coordinates in `shapes.txt`.                                                     |
 | [`fast_travel_between_consecutive_stops`](#fast_travel_between_consecutive_stops)             | A transit vehicle moves too fast between two consecutive stops.                                                                                               |
 | [`fast_travel_between_far_stops`](#fast_travel_between_far_stops)                             | A transit vehicle moves too fast between two far stops.                                                                                                       |
-| [`feed_expiration_date7_days`](#feed_expiration_date7_days)                                 | Dataset should be valid for at least the next 7 days.                                                                                                         |
-| [`feed_expiration_date30_days`](#feed_expiration_date30_days)                               | Dataset should cover at least the next 30 days of service.                                                                                                    |
-| [`feed_info_lang_and_agency_mismatch`](#feed_info_lang_and_agency_mismatch)                   | Mismatching feed and agency language fields.                                                                                                                  |
+| [`feed_expiration_date7_days`](#feed_expiration_date7_days)                                   | Dataset should be valid for at least the next 7 days.                                                                                                         |
+| [`feed_expiration_date30_days`](#feed_expiration_date30_days)                                 | Dataset should cover at least the next 30 days of service.                                                                                                    |
+| [`feed_info_lang_and_agency_lang_mismatch`](#feed_info_lang_and_agency_lang_mismatch)         | Mismatching feed and agency language fields.                                                                                                                  |
 | [`inconsistent_agency_lang`](#inconsistent_agency_lang)                                       | Inconsistent language among agencies.                                                                                                                         |
 | [`leading_or_trailing_whitespaces`](#leading_or_trailing_whitespaces)                         | The value in CSV file has leading or trailing whitespaces.                                                                                                    |
 | [`missing_feed_info_date`](#missing_feed_info_date)                                           | `feed_end_date` should be provided if `feed_start_date` is provided. `feed_start_date` should be provided if `feed_end_date` is provided.                     |
@@ -408,7 +408,7 @@ A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit_typ
 
 <a name="FareTransferRuleDurationLimitWithoutTypeNotice"/>
 
-### fare_transfer_rule_duration_limit_without_type 
+### fare_transfer_rule_duration_limit_without_type
 
 A row from GTFS file `fare_transfer_rules.txt` has a defined `duration_limit` field but no `duration_limit_type` specified.
 
@@ -1870,7 +1870,7 @@ At any time, the GTFS dataset should cover at least the next 30 days of service,
 
 <a name="FeedInfoLangAndAgencyLangMismatchNotice"/>
 
-### feed_info_lang_and_agency_mismatch
+### feed_info_lang_and_agency_lang_mismatch
 1. Files `agency.txt` and `feed_info.txt` should define matching `agency.agency_lang` and `feed_info.feed_lang`.
   The default language may be multilingual for datasets with the original text in multiple languages. In such cases, the feed_lang field should contain the language code mul defined by the norm ISO 639-2.
   * If `feed_lang` is not `mul` and does not match with `agency_lang`, that's an error
@@ -1964,7 +1964,7 @@ Even though `feed_info.start_date` and `feed_info.end_date` are optional, if one
 
 </details>
 
-<a name="MissingTimepointColumnNotice"/>
+<a name="MissingRecommendedFileNotice"/>
 
 ### missing_recommended_file
 
@@ -1983,6 +1983,8 @@ A recommended file is missing.
 * [`feed_info.txt`](http://gtfs.org/reference/static#feed_infotxt)
 
 </details>
+
+<a name="MissingRecommendedFieldNotice"/>
 
 ### missing_recommended_field
 
@@ -2003,6 +2005,8 @@ The given field has no value in some input row, even though values are recommend
 * [`feed_info.txt`](http://gtfs.org/reference/static#feed_infotxt)
 
 </details>
+
+<a name="MissingTimepointColumnNotice"/>
 
 ### missing_timepoint_column
 
@@ -2159,7 +2163,7 @@ A platform has no `parent_station` field set.
 
 <a name="RouteColorContrastNotice"/>
 
-#### route_color_contrast
+### route_color_contrast
 
 A route's color and `route_text_color` should be contrasting.
 
@@ -2676,6 +2680,7 @@ Error in IO operation.
 | `exception`  	| The name of the exception.                                    	| String 	|
 | `message`    	| The error message that explains the reason for the exception. 	| String  |
 </details>
+
 <a name="RuntimeExceptionInLoaderError"/>
 
 ### runtime_exception_in_loader_error

--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Main.java
@@ -28,6 +28,7 @@ import java.nio.file.Paths;
 import org.mobilitydata.gtfsvalidator.notice.NoticeSchemaGenerator;
 import org.mobilitydata.gtfsvalidator.runner.ValidationRunner;
 import org.mobilitydata.gtfsvalidator.util.VersionResolver;
+import org.mobilitydata.gtfsvalidator.validator.ClassGraphDiscovery;
 
 /** The main entry point for GTFS Validator CLI. */
 public class Main {
@@ -85,7 +86,7 @@ public class Main {
           Paths.get(args.getOutputBase(), NOTICE_SCHEMA_JSON),
           gson.toJson(
                   NoticeSchemaGenerator.jsonSchemaForPackages(
-                      NoticeSchemaGenerator.DEFAULT_NOTICE_PACKAGES))
+                      ClassGraphDiscovery.DEFAULT_NOTICE_PACKAGES))
               .getBytes(StandardCharsets.UTF_8));
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot store notice schema file");

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -68,17 +68,18 @@ public abstract class Notice {
    * @return notice code, e.g., "foreign_key_violation".
    */
   public String getCode() {
-    return getCode(getClass().getSimpleName());
+    return getCode(getClass());
   }
 
   /**
-   * Returns a descriptive type-specific name for this notice class simple name.
+   * Returns a descriptive type-specific name for this notice class.
    *
    * @return notice code, e.g., "foreign_key_violation".
    */
-  static String getCode(String className) {
+  public static String getCode(Class<?> noticeClass) {
     return CaseFormat.UPPER_CAMEL.to(
-        CaseFormat.LOWER_UNDERSCORE, StringUtils.removeEnd(className, NOTICE_SUFFIX));
+        CaseFormat.LOWER_UNDERSCORE,
+        StringUtils.removeEnd(noticeClass.getSimpleName(), NOTICE_SUFFIX));
   }
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGenerator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGenerator.java
@@ -98,7 +98,7 @@ public class NoticeSchemaGenerator {
    *
    * <pre>{@code
    * {
-   *   "AttributionWithoutRoleNotice": {
+   *   "attribution_without_role": {
    *     "attributionId": String.class,
    *     "csvRowNumber": Long.class,
    *   }
@@ -106,20 +106,21 @@ public class NoticeSchemaGenerator {
    * }</pre>
    *
    * @param packages List of packages where notices are declared
-   * @return a map describing all notices in given packages (see above)
+   * @return a map describing all notices in given packages, keyed by notice code (see above)
    * @throws IOException
    */
   @VisibleForTesting
   static Map<String, Map<String, Class<?>>> contextFieldsInPackages(List<String> packages)
       throws IOException {
     // Return a sorted TreeMap for stable results.
-    Map<String, Map<String, Class<?>>> contextFieldsByNotice = new TreeMap<>();
+    Map<String, Map<String, Class<?>>> contextFieldsByNoticeCode = new TreeMap<>();
 
     for (Class<Notice> noticeClass : ClassGraphDiscovery.discoverNoticeSubclasses(packages)) {
-      contextFieldsByNotice.put(Notice.getCode(noticeClass), contextFieldsForNotice(noticeClass));
+      contextFieldsByNoticeCode.put(
+          Notice.getCode(noticeClass), contextFieldsForNotice(noticeClass));
     }
 
-    return contextFieldsByNotice;
+    return contextFieldsByNoticeCode;
   }
 
   @VisibleForTesting

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeSchemaGeneratorTest.java
@@ -25,11 +25,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import java.io.IOException;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
-import org.mobilitydata.gtfsvalidator.notice.testnotices.GtfsTypesValidationNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.S2LatLngNotice;
-import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
-import org.mobilitydata.gtfsvalidator.notice.testnotices.TestValidator.TestInnerNotice;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
@@ -38,17 +34,6 @@ public class NoticeSchemaGeneratorTest {
   private static final String OPEN_SOURCE_NOTICES_PACKAGE = "org.mobilitydata.gtfsvalidator";
   private static final String TEST_NOTICES_PACKAGE =
       "org.mobilitydata.gtfsvalidator.notice.testnotices";
-
-  @Test
-  public void findNoticeSubclasses() throws IOException {
-    assertThat(NoticeSchemaGenerator.findNoticeSubclasses(ImmutableList.of(TEST_NOTICES_PACKAGE)))
-        .containsExactly(
-            DoubleFieldNotice.class,
-            TestInnerNotice.class,
-            GtfsTypesValidationNotice.class,
-            S2LatLngNotice.class,
-            StringFieldNotice.class);
-  }
 
   @Test
   public void jsonSchemaForPackages_succeeds() throws IOException {
@@ -64,16 +49,16 @@ public class NoticeSchemaGeneratorTest {
             NoticeSchemaGenerator.contextFieldsInPackages(ImmutableList.of(TEST_NOTICES_PACKAGE)))
         .isEqualTo(
             ImmutableMap.of(
-                "DoubleFieldNotice",
+                "double_field",
                 ImmutableMap.of("doubleField", double.class),
-                "TestInnerNotice",
+                "test_inner",
                 ImmutableMap.of("intField", int.class),
-                "GtfsTypesValidationNotice",
+                "gtfs_types_validation",
                 ImmutableMap.of(
                     "color", GtfsColor.class, "date", GtfsDate.class, "time", GtfsTime.class),
-                "S2LatLngNotice",
+                "s2_lat_lng",
                 ImmutableMap.of("point", S2LatLng.class),
-                "StringFieldNotice",
+                "string_field",
                 ImmutableMap.of("someField", String.class)));
   }
 

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ClassGraphDiscoveryTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ClassGraphDiscoveryTest.java
@@ -1,0 +1,27 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.DoubleFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.GtfsTypesValidationNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.S2LatLngNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.TestValidator.TestInnerNotice;
+
+public class ClassGraphDiscoveryTest {
+  private static final String TEST_NOTICES_PACKAGE =
+      "org.mobilitydata.gtfsvalidator.notice.testnotices";
+
+  @Test
+  public void discoverNoticeSubclasses() {
+    assertThat(ClassGraphDiscovery.discoverNoticeSubclasses(ImmutableList.of(TEST_NOTICES_PACKAGE)))
+        .containsExactly(
+            DoubleFieldNotice.class,
+            TestInnerNotice.class,
+            GtfsTypesValidationNotice.class,
+            S2LatLngNotice.class,
+            StringFieldNotice.class);
+  }
+}

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -58,9 +58,16 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:4.5.1'
 }
 
+// A custom task to copy RULES.md into the test resource directory so that we can reference it in
+// unit tests.  See NoticeDocumentationTest for more details.
+tasks.register('copyRulesMarkdown', Copy) {
+    from "$rootDir/RULES.md"
+    into "$projectDir/build/resources/test"
+}
+
 test {
     // Always run tests, even when nothing changed.
-    dependsOn 'cleanTest'
+    dependsOn 'cleanTest', 'copyRulesMarkdown'
 
     // Show test results.
     testLogging {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeDocumentationTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeDocumentationTest.java
@@ -1,0 +1,89 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.Notice;
+
+@RunWith(JUnit4.class)
+public class NoticeDocumentationTest {
+  private static Pattern MARKDOWN_NOTICE_SIMPLE_CLASS_NAME_ANCHOR_PATTERN =
+      Pattern.compile("^<a name=\"(\\w+(Error|Notice))\"/>");
+
+  private static Pattern MARKDOWN_NOTICE_CODE_HEADER_PATTERN =
+      Pattern.compile("^### (([a-z0-9]+_)*[a-z0-9]+)");
+
+  /**
+   * If this test is failing, it likely means you need to update RULES.md in the project root
+   * directory to include an entry for a new notice.
+   */
+  @Test
+  public void testThatRulesMarkdownContainsAnchorsForAllValidationNotices() throws IOException {
+    Set<String> fromMarkdown = readNoticeSimpleClassNamesFromRulesMarkdown();
+    Set<String> fromSource =
+        discoverValidationNoticeClasses().map(Class::getSimpleName).collect(Collectors.toSet());
+
+    assertThat(fromMarkdown).isEqualTo(fromSource);
+  }
+
+  /**
+   * If this test is failing, it likely means you need to update RULES.md in the project root
+   * directory to include an entry for a new notice.
+   */
+  @Test
+  public void testThatRulesMarkdownContainsHeadersForAllValidationNotices() throws IOException {
+    Set<String> fromMarkdown = readNoticeCodesFromRulesMarkdown();
+    Set<String> fromSource =
+        discoverValidationNoticeClasses().map(Notice::getCode).collect(Collectors.toSet());
+
+    assertThat(fromMarkdown).isEqualTo(fromSource);
+  }
+
+  private static Stream<Class<Notice>> discoverValidationNoticeClasses() {
+    return ClassGraphDiscovery.discoverNoticeSubclasses(ClassGraphDiscovery.DEFAULT_NOTICE_PACKAGES)
+        .stream();
+  }
+
+  private static Set<String> readNoticeSimpleClassNamesFromRulesMarkdown() throws IOException {
+    return readValuesFromRulesMarkdown(MARKDOWN_NOTICE_SIMPLE_CLASS_NAME_ANCHOR_PATTERN);
+  }
+
+  private static Set<String> readNoticeCodesFromRulesMarkdown() throws IOException {
+    return readValuesFromRulesMarkdown(MARKDOWN_NOTICE_CODE_HEADER_PATTERN);
+  }
+
+  private static Set<String> readValuesFromRulesMarkdown(Pattern pattern) throws IOException {
+    // RULES.md is copied into the main/build/resources/test resource directory by a custom copy
+    // rule in the main/build.gradle file.
+    try (InputStream in = NoticeDocumentationTest.class.getResourceAsStream("/RULES.md")) {
+      // Scan lines from the markdown file, find those that match our regex pattern, and pull out
+      // the matching group.
+      return new BufferedReader(new InputStreamReader(in))
+          .lines()
+          .map(line -> maybeMatchAndExtract(pattern, line))
+          .flatMap(Optional::stream)
+          .collect(Collectors.toSet());
+    }
+  }
+
+  private static Optional<String> maybeMatchAndExtract(Pattern p, String line) {
+    Matcher m = p.matcher(line);
+    if (m.matches()) {
+      return Optional.of(m.group(1));
+    } else {
+      return Optional.empty();
+    }
+  }
+}


### PR DESCRIPTION
**Summary:**

When writing new validation rules, we often forget to update `RULES.md` with updated documentation.  While #1324 has some ideas on addressing that in the long term, in the short term, we can add a unit-test that will fail if there is an entry in `RULES.md` for a newly added notice.

For example, this test should fail initially because `StopWithoutLocationNotice` is missing from `RULES.md` per #1330.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
