### PR TITLE
Fix: Fix bug triage workflow

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create card
-        uses: alex-page/github-project-automation-plus@v0.8.1
+        uses: alex-page/github-project-automation-plus@v0.8.2
         with:
           project: Bug triage
           column: Requires investigation


### PR DESCRIPTION
**Summary:**

Attempt to fix the bug triage workflow, which is broken. Related issue: #1298 
<img width="617" alt="Screenshot 2023-02-14 at 11 04 01 AM" src="https://user-images.githubusercontent.com/63653518/218791901-866b6ca2-ce1c-4e66-b862-589bbded87ec.png">

This solution came from this thread: https://github.com/alex-page/github-project-automation-plus/issues/81

**Expected behavior:** 

When an issue is opened with a "bug" label, the workflow runs properly and a card is added to the repo project "Bug triage".

Please make sure these boxes are checked before submitting your pull request - thanks!

- ~~[ ] Run the unit tests with `gradle test` to make sure you didn't break anything~~
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- ~~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~~
