### PR TITLE
fix: Inconsistencies in RULES.md against underlying source

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -207,7 +207,7 @@ Parsing of a CSV file failed. One common case of the problem is when a cell valu
 | `columnIndex` 	| The column index where the exception occurred.                                          	| Integer 	|
 | `lineIndex`   	| The line number where the exception occurred.                                           	| Long    	|
 | `message`     	| The detailed message describing the error, and the internal state of the parser/writer. 	| String  	|
-| `content`     	| The record number when the exception occurred.                                          	| String  	|
+| `parsedContent`     	| The record number when the exception occurred.                                          	| String  	|
 
 #### Affected files
 [All GTFS files supported by the specification.](http://gtfs.org/reference/static#dataset-files)
@@ -374,11 +374,12 @@ When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` m
 |-----------------------	  |-------------------------------------------------------------------------------------------------	|---------	|
 | `shapeId`               	| The id of the faulty shape.                                                                      	| String  	|
 | `csvRowNumber`          	| The row number from `shapes.txt`.                                                                	| Long    	|
-| `shapeDistTraveled`     	| Actual distance traveled along the shape from the first shape point to the faulty record.        	| Double  	|
+| `shapeDistTraveled`     	| The faulty record's `shape_dist_traveled` value.							| Double  	|
 | `shapePtSequence`       	| The faulty record's `shapes.shape_pt_sequence`.                                                  	| Integer 	|
 | `prevCsvRowNumber`      	| The row number from `shapes.txt` of the previous shape point.                                    	| Long    	|
-| `prevShapeDistTraveled` 	| Actual distance traveled along the shape from the first shape point to the previous shape point. 	| Double  	|
+| `prevShapeDistTraveled`     	| The previous shape point's `shape_dist_traveled` value.						| Double  	|
 | `prevShapePtSequence`   	| The previous record's `shapes.shape_pt_sequence`.                                                	| Integer 	|
+| `actualDistanceBetweenShapePoints` 	| Actual distance traveled along the shape from the first shape point to the previous shape point. 	| Double  	|
 
 #### Affected files
 * [`stops.txt`](http://gtfs.org/reference/static#stopstxt)
@@ -961,7 +962,8 @@ GTFS file `levels.txt` is required for elevator (`pathway_mode=5`). A row from `
 | Field name    	| Description                                                      	 | Type   	|
 |---------------	|------------------------------------------------------------------- |--------	|
 | `csvRowNumber`  | The row number of the faulty record. 	                             | Long   	|
-| `stopId`   	  | The id of the faulty from `stops.txt`.                               | String   |
+| `stopId`   	  | The id of the faulty stop from `stops.txt`.                               | String   |
+| `stopName`   	  | The name of the faulty stop from `stops.txt`.                               | String   |
 
 #### Affected files
 * [`levels.txt`](http://gtfs.org/reference/static#levelstxt)
@@ -1140,6 +1142,18 @@ assigned - instead, pathways must be assigned to its boarding areas.
 #### References
 * [pathways.txt specification](http://gtfs.org/reference/static/#pathwaystxt)
 
+<details>
+
+#### Notice fields description
+| Field name      	| Description                                      	| Type    	|
+|-----------------	|--------------------------------------------------	|---------	|
+| `csvRowNumber`  	| The row of the faulty row.                       	| Integer 	|
+| `pathwayId`   	| The id of the faulty pathway.                       	| String	|
+| `fieldName`   	| The platform id field name.                       	| String	|
+| `stopId`	   	| The id of the endpoint platform.                     	| String	|
+
+</details>
+
 <a name="PathwayToWrongLocationTypeNotice"/>
 
 ### pathway_to_wrong_location_type
@@ -1149,6 +1163,18 @@ entrances/exits, generic nodes or boarding areas.
 
 #### References
 * [pathways.txt specification](http://gtfs.org/reference/static/#pathwaystxt)
+
+<details>
+
+#### Notice fields description
+| Field name      	| Description                                      	| Type    	|
+|-----------------	|--------------------------------------------------	|---------	|
+| `csvRowNumber`  	| The row of the faulty row.                       	| Integer 	|
+| `pathwayId`   	| The id of the faulty pathway.                       	| String	|
+| `fieldName`   	| The station id field name.                       	| String	|
+| `stopId`	   	| The id of the endpoint station.                      	| String	|
+
+</details>
 
 <a name="PathwayUnreachableLocationNotice"/>
 
@@ -1199,6 +1225,7 @@ A point is too close to origin `(0, 0)`.
 |-----------------	|--------------------------------------------------	|---------	|
 | `filename`      	| The name of the affected GTFS file.              	| String  	|
 | `csvRowNumber`  	| The row of the faulty row.                       	| Integer 	|
+| `entityId`  		| The id of the faulty entity.                       	| String	|
 | `latFieldName`  	| The name of the field that uses latitude value.  	| String  	|
 | `latFieldValue` 	| The latitude of the faulty row.                  	| Double  	|
 | `lonFieldName`  	| The name of the field that uses longitude value. 	| String  	|
@@ -1225,6 +1252,7 @@ A point is too close to the North or South Pole.
 |-----------------	|--------------------------------------------------	|---------	|
 | `filename`      	| The name of the affected GTFS file.              	| String  	|
 | `csvRowNumber`  	| The row of the faulty row.                       	| Integer 	|
+| `entityId`		| The id of the faulty entity.				| String	|
 | `latFieldName`  	| The name of the field that uses latitude value.  	| String  	|
 | `latFieldValue` 	| The latitude of the faulty row.                  	| Double  	|
 | `lonFieldName`  	| The name of the field that uses longitude value. 	| String  	|
@@ -1273,6 +1301,7 @@ The fields `frequencies.start_date` and `frequencies.end_date` have been found e
 |-----------------	|-------------------------------------- |--------	|
 | `filename`       	| The name of the faulty file.         	| String 	|
 | `csvRowNumber`   	| The row number of the faulty record. 	| Long   	|
+| `entityId`		| The id of the faulty entity.		| String	|
 | `startFieldName` 	| The start value's field name.        	| String 	|
 | `endFieldName`   	| The end value's field name.          	| String 	|
 | `value`          	| The faulty value.                    	| String 	|
@@ -1685,14 +1714,14 @@ Example of bad data:
 #### Notice fields description
 | Field name     	| Description                             	| Type   	|
 |----------------	|-----------------------------------------	|--------	|
-| csvRowNumber1  	| The row number of the first occurrence. 	| Long   	|
-| routeId1       	| The id of the the first occurrence.     	| String 	|
-| csvRowNumber2  	| The row number of the other occurrence. 	| Long   	|
-| routeId2       	| The id of the the other occurrence.     	| String 	|
-| routeShortName 	| Common `routes.route_short_name`.       	| String 	|
-| routeLongName  	| Common `routes.route_long_name`.        	| String 	|
-| routeType      	| Common `routes.route_type`.             	| String 	|
-| agencyId       	| Common `routes.agency_id`.              	| String 	|
+| `csvRowNumber1`  	| The row number of the first occurrence. 	| Long   	|
+| `routeId1`       	| The id of the the first occurrence.     	| String 	|
+| `csvRowNumber2`  	| The row number of the other occurrence. 	| Long   	|
+| `routeId2`       	| The id of the the other occurrence.     	| String 	|
+| `routeShortName` 	| Common `routes.route_short_name`.       	| String 	|
+| `routeLongName`  	| Common `routes.route_long_name`.        	| String 	|
+| `routeTypeValue`     	| Common `routes.route_type`.             	| String 	|
+| `agencyId`       	| Common `routes.agency_id`.              	| String 	|
 
 #### Affected files
 * [`routes.txt`](http://gtfs.org/reference/static#routestxt)
@@ -2328,6 +2357,7 @@ A route should not have the same `routes.route_url` as a record from `agency.txt
 | `routeCsvRowNumber`    | The row number of the faulty record from `routes.txt`.       	| Long   	|
 | `routeId`         | The faulty record's id.                    	| String 	|
 | `agencyId`    	| The faulty record's `routes.agency_id`.    	| String 	|
+| `agencyName`    	| The faulty record's referenced agency name.  	| String 	|
 | `routeUrl`     	| The duplicate URL value                    	| String 	|
 | `agencyCsvRowNumber`    | The row number of the faulty record from `agency.txt`.       	| Long   	|
 
@@ -2375,7 +2405,7 @@ A stop should not have the same `stop.stop_url` as a record from `routes.txt`.
 #### Notice fields description
 | Field name          	| Description                                            	| Type   	|
 |---------------------	|--------------------------------------------------------	|--------	|
-| `stopsvRowNumber`     | The row number of the faulty record from `stops.txt`.    	| Long   	|
+| `stopCsvRowNumber`    | The row number of the faulty record from `stops.txt`.    	| Long   	|
 | `stopId`            	| The faulty record's id.                                	| String 	|
 | `stopUrl`           	| The duplicate URL value.                                | String 	|
 | `routeId`           	| The faulty record's id from `routes.txt.               	| String 	|
@@ -2521,6 +2551,17 @@ Such stops normally do not provide user value. This notice may indicate a typo i
 * [stops_times.txt specification](https://gtfs.org/schedule/reference/#stop_timestxt)
 * [stops.txt specification](http://gtfs.org/reference/static/#stopstxt)
 
+<details>
+
+#### Notice fields description
+| Field name       | Description                            | Type    	|
+|------------------|----------------------------------------|-------	|
+| `csvRowNumber`   | The row number of the faulty record.   | Long    	|
+| `stopId`         | The id of the faulty stop.             | String  	|
+| `stopName`       | The name of the faulty stop.           | String  	|
+
+</details>
+
 <a name="TranslationUnknownTableNameNotice"/>
 
 ### translation_unknown_table_name
@@ -2614,7 +2655,7 @@ All records defined by GTFS `shapes.txt` should be used in `trips.txt`.
 | Field name   	| Description                          	| Type   	|
 |--------------	|--------------------------------------	|--------	|
 | `csvRowNumber`| The row number of the faulty record. 	| Long   	|
-| `shapeId     	| The faulty record's id.              	| String 	|
+| `shapeId`    	| The faulty record's id.              	| String 	|
 
 #### Affected files
 * [`shapes.txt`](http://gtfs.org/reference/static#shapestxt)

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyAmountNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyAmountNotice.java
@@ -12,7 +12,7 @@ import java.math.BigDecimal;
  */
 public class InvalidCurrencyAmountNotice extends ValidationNotice {
 
-  private final String fileName;
+  private final String filename;
 
   private final String fieldName;
 
@@ -21,9 +21,9 @@ public class InvalidCurrencyAmountNotice extends ValidationNotice {
   private final String amount;
 
   public InvalidCurrencyAmountNotice(
-      String fileName, String fieldName, int csvRowNumber, BigDecimal amount) {
+      String filename, String fieldName, int csvRowNumber, BigDecimal amount) {
     super(SeverityLevel.ERROR);
-    this.fileName = fileName;
+    this.filename = filename;
     this.fieldName = fieldName;
     this.csvRowNumber = csvRowNumber;
     this.amount = amount.toPlainString();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -63,13 +63,13 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
 
     private final int csvRowNumber;
     private final String stopId;
-    private final String routeDesc;
+    private final String stopDesc;
 
-    SameNameAndDescriptionForStopNotice(int csvRowNumber, String stopId, String routeDesc) {
+    SameNameAndDescriptionForStopNotice(int csvRowNumber, String stopId, String stopDesc) {
       super(SeverityLevel.WARNING);
       this.stopId = stopId;
       this.csvRowNumber = csvRowNumber;
-      this.routeDesc = routeDesc;
+      this.stopDesc = stopDesc;
     }
   }
 }


### PR DESCRIPTION
Specifically, this PR updates `RULES.md` to:
* Fix incorrectly named fields: docs should match underlying field names in Java source / JSON schema
* Add missing fields: docs should contain all fields from Java source / JSON schema
* Fix inconsistent formatting
* Fix two incorrectly-named fields in the Java source

This is an intermediate PR that brings us one step closer to alignment and generation of Notice documentation from the source code itself per #1324.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
