### PR TITLE
Fix 1198: separate required column from required value

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/Required.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/Required.java
@@ -24,7 +24,7 @@ import java.lang.annotation.Target;
 /**
  * Adds a validation that the field or a file is required.
  *
- * <p>In the case of a field, both the column header, and a value for each row is required.
+ * <p>In the case of a field, both the column header and a value for each row is required.
  *
  * <p>Example.
  *

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/RequiredColumn.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/RequiredColumn.java
@@ -22,9 +22,8 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Adds a validation that the field or a file is required.
- *
- * <p>In the case of a field, both the column header, and a value for each row is required.
+ * Adds a validation that the column and header must be present. A value for the field may be
+ * optional.
  *
  * <p>Example.
  *
@@ -35,10 +34,10 @@ import java.lang.annotation.Target;
  *       {@literal @}PrimaryKey
  *       String agencyId();
  *
- *       {@literal @}Required String agencyName();
+ *       {@literal @}RequiredColumn String agencyName();
  *   }
  * </pre>
  */
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.SOURCE)
-public @interface Required {}
+public @interface RequiredColumn {}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/RequiredColumn.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/annotation/RequiredColumn.java
@@ -28,14 +28,23 @@ import java.lang.annotation.Target;
  * <p>Example.
  *
  * <pre>
- *   {@literal @}GtfsTable("agency.txt")
- *   public interface GtfsAgencySchema extends GtfsEntity {
- *       {@literal @}FieldType(FieldTypeEnum.ID)
- *       {@literal @}PrimaryKey
- *       String agencyId();
+ *    {@literal @}GtfsTable("transfers.txt")
+ *    public interface GtfsTransferSchema extends GtfsEntity {
+ *        {@literal @}FieldType(FieldTypeEnum.ID)
+ *        {@literal @}Required
+ *        {@literal @}ForeignKey(table = "stops.txt", field = "stop_id")
+ *        {@literal @}PrimaryKey(translationRecordIdType = RECORD_ID)
+ *        String fromStopId();
  *
- *       {@literal @}RequiredColumn String agencyName();
- *   }
+ *        {@literal @}FieldType(FieldTypeEnum.ID)
+ *        {@literal @}Required
+ *        {@literal @}ForeignKey(table = "stops.txt", field = "stop_id")
+ *        {@literal @}PrimaryKey(translationRecordIdType = RECORD_SUB_ID)
+ *        String toStopId();
+ *
+ *        {@literal @}RequiredColumn
+ *        GtfsTransferType transferType();
+ *    }
  * </pre>
  */
 @Target({ElementType.METHOD, ElementType.TYPE})

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -141,7 +141,7 @@ public final class AnyTableLoader {
                 .map(GtfsColumnDescriptor::columnName)
                 .collect(Collectors.toSet()),
             columnDescriptors.stream()
-                .filter(GtfsColumnDescriptor::isRequired)
+                .filter(GtfsColumnDescriptor::headerRequired)
                 .map(GtfsColumnDescriptor::columnName)
                 .collect(Collectors.toSet()),
             headerNotices);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsColumnDescriptor.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsColumnDescriptor.java
@@ -9,15 +9,13 @@ import org.mobilitydata.gtfsvalidator.parsing.RowParser;
 public abstract class GtfsColumnDescriptor {
   public abstract String columnName();
 
+  public abstract boolean headerRequired();
+
   public abstract FieldLevelEnum fieldLevel();
 
   public abstract Optional<RowParser.NumberBounds> numberBounds();
 
   public abstract boolean isCached();
-
-  public boolean isRequired() {
-    return FieldLevelEnum.REQUIRED.equals(fieldLevel());
-  }
 
   public static GtfsColumnDescriptor.Builder builder() {
     return new AutoValue_GtfsColumnDescriptor.Builder();
@@ -26,6 +24,8 @@ public abstract class GtfsColumnDescriptor {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setColumnName(String value);
+
+    public abstract Builder setHeaderRequired(boolean value);
 
     public abstract Builder setFieldLevel(FieldLevelEnum value);
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
@@ -34,8 +34,8 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
   public void validate(
       String filename,
       CsvHeader actualHeader,
-      Set<String> supportedHeaders,
-      Set<String> requiredHeaders,
+      Set<String> supportedColumns,
+      Set<String> requiredColumns,
       NoticeContainer noticeContainer) {
     if (actualHeader.getColumnCount() == 0) {
       // This is an empty file.
@@ -43,7 +43,7 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
     }
     Map<String, Integer> columnIndices = new HashMap<>();
     // Sorted tree set for stable order of notices.
-    TreeSet<String> missingColumns = new TreeSet<>(requiredHeaders);
+    TreeSet<String> missingColumns = new TreeSet<>(requiredColumns);
     for (int i = 0; i < actualHeader.getColumnCount(); ++i) {
       String column = actualHeader.getColumnName(i);
       // Column indices are zero-based. We add 1 to make them 1-based.
@@ -56,7 +56,7 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
         noticeContainer.addValidationNotice(
             new DuplicatedColumnNotice(filename, column, prev + 1, i + 1));
       }
-      if (!supportedHeaders.contains(column)) {
+      if (!supportedColumns.contains(column)) {
         noticeContainer.addValidationNotice(new UnknownColumnNotice(filename, column, i + 1));
       }
       missingColumns.remove(column);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultTableHeaderValidator.java
@@ -34,8 +34,8 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
   public void validate(
       String filename,
       CsvHeader actualHeader,
-      Set<String> supportedColumns,
-      Set<String> requiredColumns,
+      Set<String> supportedHeaders,
+      Set<String> requiredHeaders,
       NoticeContainer noticeContainer) {
     if (actualHeader.getColumnCount() == 0) {
       // This is an empty file.
@@ -43,7 +43,7 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
     }
     Map<String, Integer> columnIndices = new HashMap<>();
     // Sorted tree set for stable order of notices.
-    TreeSet<String> missingColumns = new TreeSet<>(requiredColumns);
+    TreeSet<String> missingColumns = new TreeSet<>(requiredHeaders);
     for (int i = 0; i < actualHeader.getColumnCount(); ++i) {
       String column = actualHeader.getColumnName(i);
       // Column indices are zero-based. We add 1 to make them 1-based.
@@ -56,7 +56,7 @@ public class DefaultTableHeaderValidator implements TableHeaderValidator {
         noticeContainer.addValidationNotice(
             new DuplicatedColumnNotice(filename, column, prev + 1, i + 1));
       }
-      if (!supportedColumns.contains(column)) {
+      if (!supportedHeaders.contains(column)) {
         noticeContainer.addValidationNotice(new UnknownColumnNotice(filename, column, i + 1));
       }
       missingColumns.remove(column);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/TableHeaderValidator.java
@@ -26,7 +26,7 @@ public interface TableHeaderValidator {
   void validate(
       String filename,
       CsvHeader actualHeader,
-      Set<String> supportedColumns,
-      Set<String> requiredColumns,
+      Set<String> supportedHeaders,
+      Set<String> requiredHeaders,
       NoticeContainer noticeContainer);
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTransferSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTransferSchema.java
@@ -18,14 +18,7 @@ package org.mobilitydata.gtfsvalidator.table;
 
 import static org.mobilitydata.gtfsvalidator.annotation.TranslationRecordIdType.*;
 
-import org.mobilitydata.gtfsvalidator.annotation.ConditionallyRequired;
-import org.mobilitydata.gtfsvalidator.annotation.FieldType;
-import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
-import org.mobilitydata.gtfsvalidator.annotation.ForeignKey;
-import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
-import org.mobilitydata.gtfsvalidator.annotation.NonNegative;
-import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
-import org.mobilitydata.gtfsvalidator.annotation.Required;
+import org.mobilitydata.gtfsvalidator.annotation.*;
 
 @GtfsTable("transfers.txt")
 public interface GtfsTransferSchema extends GtfsEntity {
@@ -41,7 +34,7 @@ public interface GtfsTransferSchema extends GtfsEntity {
   @PrimaryKey(translationRecordIdType = RECORD_SUB_ID)
   String toStopId();
 
-  @Required
+  @RequiredColumn
   GtfsTransferType transferType();
 
   @NonNegative

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/Analyser.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/Analyser.java
@@ -30,23 +30,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.SimpleTypeVisitor8;
-import org.mobilitydata.gtfsvalidator.annotation.CachedField;
-import org.mobilitydata.gtfsvalidator.annotation.CurrencyAmount;
-import org.mobilitydata.gtfsvalidator.annotation.DefaultValue;
-import org.mobilitydata.gtfsvalidator.annotation.EndRange;
-import org.mobilitydata.gtfsvalidator.annotation.FieldType;
-import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
-import org.mobilitydata.gtfsvalidator.annotation.ForeignKey;
-import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValue;
-import org.mobilitydata.gtfsvalidator.annotation.GtfsEnumValues;
-import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
-import org.mobilitydata.gtfsvalidator.annotation.Index;
-import org.mobilitydata.gtfsvalidator.annotation.NonNegative;
-import org.mobilitydata.gtfsvalidator.annotation.NonZero;
-import org.mobilitydata.gtfsvalidator.annotation.Positive;
-import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
-import org.mobilitydata.gtfsvalidator.annotation.Recommended;
-import org.mobilitydata.gtfsvalidator.annotation.Required;
+import org.mobilitydata.gtfsvalidator.annotation.*;
 import org.mobilitydata.gtfsvalidator.parsing.RowParser.NumberBounds;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -85,7 +69,8 @@ public class Analyser {
               ? fieldTypeAnnotation.value()
               : javaTypeToGtfsType(method.getReturnType()));
       fieldBuilder.setRecommended(method.getAnnotation(Recommended.class) != null);
-      fieldBuilder.setRequired(method.getAnnotation(Required.class) != null);
+      fieldBuilder.setColumnRequired(method.getAnnotation(RequiredColumn.class) != null);
+      fieldBuilder.setValueRequired(method.getAnnotation(Required.class) != null);
       PrimaryKey primaryKey = method.getAnnotation(PrimaryKey.class);
       if (primaryKey != null) {
         fieldBuilder.setPrimaryKey(primaryKey);

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsFieldDescriptor.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/GtfsFieldDescriptor.java
@@ -54,7 +54,13 @@ public abstract class GtfsFieldDescriptor {
   // Dynamic properties.
   public abstract boolean recommended();
 
-  public abstract boolean required();
+  public abstract boolean valueRequired();
+
+  public abstract boolean columnRequired();
+
+  public boolean isHeaderRequired() {
+    return columnRequired() || valueRequired();
+  }
 
   public abstract Optional<RowParser.NumberBounds> numberBounds();
 
@@ -68,7 +74,9 @@ public abstract class GtfsFieldDescriptor {
 
     public abstract Builder setRecommended(boolean value);
 
-    public abstract Builder setRequired(boolean value);
+    public abstract Builder setValueRequired(boolean value);
+
+    public abstract Builder setColumnRequired(boolean value);
 
     public abstract Builder setPrimaryKey(PrimaryKey annotation);
 

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableDescriptorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableDescriptorGenerator.java
@@ -183,10 +183,12 @@ public class TableDescriptorGenerator {
               .add(
                   "GtfsColumnDescriptor.builder()\n"
                       + ".setColumnName($T.$L)\n"
+                      + ".setHeaderRequired($L)\n"
                       + ".setFieldLevel($T.$L)\n"
                       + ".setIsCached($L)\n",
                   gtfsEntityType,
                   fieldNameField(field.name()),
+                  field.isHeaderRequired(),
                   FieldLevelEnum.class,
                   getFieldLevel(field),
                   cachingEnabled(field));
@@ -274,7 +276,7 @@ public class TableDescriptorGenerator {
   }
 
   static FieldLevelEnum getFieldLevel(GtfsFieldDescriptor field) {
-    return field.required() ? REQUIRED : field.recommended() ? RECOMMENDED : OPTIONAL;
+    return field.valueRequired() ? REQUIRED : field.recommended() ? RECOMMENDED : OPTIONAL;
   }
 
   private MethodSpec generateGtfsFilenameMethod() {

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredAnnotationSchema.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredAnnotationSchema.java
@@ -1,0 +1,13 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.Required;
+
+@GtfsTable("required.txt")
+public interface RequiredAnnotationSchema {
+
+  @Required
+  String valueRequired();
+
+  String valueNotRequired();
+}

--- a/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredColumnAnnotationSchema.java
+++ b/processor/tests/src/main/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredColumnAnnotationSchema.java
@@ -1,0 +1,15 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
+import org.mobilitydata.gtfsvalidator.annotation.Required;
+import org.mobilitydata.gtfsvalidator.annotation.RequiredColumn;
+
+@GtfsTable("required_column.txt")
+public interface RequiredColumnAnnotationSchema {
+
+  @Required
+  String valueRequired();
+
+  @RequiredColumn
+  String columnRequired();
+}

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredAnnotationSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredAnnotationSchemaTest.java
@@ -1,0 +1,53 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnNotice;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.table.RequiredAnnotationTableDescriptor;
+import org.mobilitydata.gtfsvalidator.testing.LoadingHelper;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
+
+@RunWith(JUnit4.class)
+public class RequiredAnnotationSchemaTest {
+
+  private RequiredAnnotationTableDescriptor tableDescriptor;
+  private LoadingHelper helper;
+
+  @Before
+  public void setup() throws ValidatorLoaderException {
+    tableDescriptor = new RequiredAnnotationTableDescriptor();
+    helper = new LoadingHelper();
+  }
+
+  @Test
+  public void includingRequiredColumnHeaderWithValueShouldNotGenerateNotice()
+      throws ValidatorLoaderException {
+
+    helper.load(tableDescriptor, "value_required,value_not_required", "value1,value2");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void includingRequiredColumnHeaderWithoutValueShouldGenerateNotice()
+      throws ValidatorLoaderException {
+
+    helper.load(tableDescriptor, "value_required,value_not_required", ",value2");
+    assertThat(helper.getValidationNotices())
+        .containsExactly(new MissingRequiredFieldNotice("required.txt", 2, "value_required"));
+  }
+
+  @Test
+  public void missingColumnHeaderForRequiredColumnShouldGenerateNotice()
+      throws ValidatorLoaderException {
+
+    helper.load(tableDescriptor, "value_not_required", "value2");
+    assertThat(helper.getValidationNotices())
+        .containsExactly(new MissingRequiredColumnNotice("required.txt", "value_required"));
+  }
+}

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredColumnAnnotationSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/RequiredColumnAnnotationSchemaTest.java
@@ -1,0 +1,50 @@
+package org.mobilitydata.gtfsvalidator.processor.tests;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredColumnNotice;
+import org.mobilitydata.gtfsvalidator.table.RequiredColumnAnnotationTableDescriptor;
+import org.mobilitydata.gtfsvalidator.testing.LoadingHelper;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
+
+@RunWith(JUnit4.class)
+public class RequiredColumnAnnotationSchemaTest {
+  private RequiredColumnAnnotationTableDescriptor tableDescriptor;
+  private LoadingHelper helper;
+
+  @Before
+  public void setup() throws ValidatorLoaderException {
+    tableDescriptor = new RequiredColumnAnnotationTableDescriptor();
+    helper = new LoadingHelper();
+  }
+
+  @Test
+  public void includingRequiredColumnHeaderWithValueShouldNotGenerateNotice()
+      throws ValidatorLoaderException {
+
+    helper.load(tableDescriptor, "value_required,column_required", "value,value2");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void includingRequiredColumnHeaderWithoutValueShouldNotGenerateNotice()
+      throws ValidatorLoaderException {
+
+    helper.load(tableDescriptor, "value_required,column_required", "value,");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void missingRequiredColumnHeaderShouldGenerateNotice() throws ValidatorLoaderException {
+
+    helper.load(tableDescriptor, "value_required", "value");
+    assertThat(helper.getValidationNotices())
+        .containsExactly(new MissingRequiredColumnNotice("required_column.txt", "column_required"));
+  }
+}


### PR DESCRIPTION
**Summary:**

Closes #1198. Added a new annotation `@RequiredColumn` to allow for scenario where a column must exist in the file, but values for that column may be empty.

It may be useful in the future to separate the existing `@Required` annotation into `@RequiredFile` and `@RequiredValue` annotations. I've opened #1343 for discussion of that topic.


**Expected behavior:** 

Given the following `transfers.txt` file, the following should not throw an error:

```
from_stop_id,to_stop_id,transfer_type,min_transfer_time
1,2,,
```

This is a valid use case [according to the spec](https://gtfs.org/schedule/reference/#:~:text=recommended%20transfer%20point%20between%20routes) in that the transfer_type value is empty which indicates a "Recommended transfer point between routes".

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- (N/A) Include screenshot(s) showing how this pull request works and fixes the issue(s)
