### PR TITLE
fix: add log message when multi-file validators are not triggered

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -139,6 +139,7 @@ public class GtfsFeedLoader {
         // Consider we failed to parse a row trip.txt but there is another row in stop_times.txt
         // that references a trip. Then foreign key validator may notify about a missing trip_id
         // which would be wrong.
+        logger.atSevere().log("Multi-file validators were not executed due to file parsing errors.");
         return feed;
       }
       List<Callable<NoticeContainer>> validatorCallables = new ArrayList<>();

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -139,7 +139,8 @@ public class GtfsFeedLoader {
         // Consider we failed to parse a row trip.txt but there is another row in stop_times.txt
         // that references a trip. Then foreign key validator may notify about a missing trip_id
         // which would be wrong.
-        logger.atSevere().log("Multi-file validators were not executed due to file parsing errors.");
+        logger.atSevere().log(
+            "Multi-file validators were not executed due to file parsing errors.");
         return feed;
       }
       List<Callable<NoticeContainer>> validatorCallables = new ArrayList<>();


### PR DESCRIPTION
**Summary:**

Fixes #1308.  Multi-file validators are not triggered due to parsing errors. This change adds a log line alerting that multi-file validators were not triggered. 
More detailed information regarding the validators that were ignored/executed will be addressed as part of #1097

**Expected behavior:** 

Alert via console log when multi-files validators are not triggered.  

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
