### PR TITLE
ci: build & publish linux/arm64 Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,10 @@ name: Docker image
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      # todo: revert
+      - docker-arm64
   release:
     types: [ prereleased, released ]
 
@@ -114,7 +117,8 @@ jobs:
           file: ./Dockerfile
           build-args: |
             VERSION_TAG=${{ steps.prep.outputs.version }}
-          push: true
+          # todo: revert
+          push: false
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.prep.outputs.tags }}
           labels: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -98,6 +98,7 @@ jobs:
           build-args: |
             VERSION_TAG=${{ steps.prep.outputs.version }}
           load: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY,,}.git
@@ -114,6 +115,7 @@ jobs:
           build-args: |
             VERSION_TAG=${{ steps.prep.outputs.version }}
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.prep.outputs.tags }}
           labels: |
             org.opencontainers.image.source=https://github.com/${GITHUB_REPOSITORY,,}.git


### PR DESCRIPTION
On an ARM64 system, I would like to use native Docker images in order not to run an emulation layer.

This PR extends the Docker build & publishing CI workflow to also build `linux/arm64` images in addition to `linux/amd64` images (implicit default).

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
