### PR TITLE
fix: add field value to mixed case notice

### DIFF
--- a/RULES.md
+++ b/RULES.md
@@ -2189,11 +2189,12 @@ This field contains customer-facing text and should use Mixed Case (upper and lo
 
 
 #### Notice fields description
-| Field name     	| Description                           	| Type   	|
-|----------------	|---------------------------------------	|--------	|
-| `csvRowNumber` 	| The row number of the faulty record.  	| Long   	|
-| `filename`    	| Name of the faulty file.              	| String 	|
-| `fieldName`    	| Name of the faulty field.              	| String 	|
+| Field name     	 | Description                           	| Type   	|
+|------------------|---------------------------------------	|--------	|
+| `csvRowNumber`   | The row number of the faulty record.  	| Long   	|
+| `filename`       | Name of the faulty file.              	| String 	|
+| `fieldName`      | Name of the faulty field.              	| String 	|
+| `fieldValue`     | Name of the faulty field.              	| String 	|
 
 #### Affected files & fields
 * [`agency.agency_name`](https://gtfs.org/schedule/reference/#agencytxt)

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
@@ -12,12 +12,15 @@ public class MixedCaseRecommendedFieldNotice extends ValidationNotice {
 
   private final String fieldName;
 
+  private final String fieldValue;
   private final int csvRowNumber;
 
-  public MixedCaseRecommendedFieldNotice(String filename, String fieldName, int csvRowNumber) {
+  public MixedCaseRecommendedFieldNotice(
+      String filename, String fieldName, String fieldValue, int csvRowNumber) {
     super(SeverityLevel.WARNING);
     this.filename = filename;
     this.fieldName = fieldName;
+    this.fieldValue = fieldValue;
     this.csvRowNumber = csvRowNumber;
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -76,7 +76,7 @@ public class MixedCaseValidatorGenerator {
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
           .beginControlFlow("if (!(value.matches(\".*[a-z].*\") && value.matches(\".*[A-Z].*\")))")
           .addStatement(
-              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", entity.csvRowNumber()))",
+              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
               MixedCaseRecommendedFieldNotice.class,
               fileDescriptor.filename(),
               FieldNameConverter.gtfsColumnName(mixedCaseField.name()))

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MixedCaseSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MixedCaseSchemaTest.java
@@ -47,62 +47,30 @@ public class MixedCaseSchemaTest {
   @Test
   public void testValidMixedCase() throws ValidatorLoaderException {
 
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "MixedCaseValue");
+    String[] validValues = {
+      "MixedCase", "Mixed-Case", "Mixed_Case", "Mixed Case", "Another good value"
+    };
 
-    assertThat(helper.getValidationNotices()).isEmpty();
+    for (String value : validValues) {
+      helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, value);
 
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "Mixed Case Value");
-
-    assertThat(helper.getValidationNotices()).isEmpty();
-
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "Another good value");
-
-    assertThat(helper.getValidationNotices()).isEmpty();
+      assertThat(helper.getValidationNotices()).isEmpty();
+    }
   }
 
   @Test
   public void testInvalidMixedCases() throws ValidatorLoaderException {
+    String[] invalidValues = {
+      "lowercase", "UPPERCASE", "snake_case", "kebab-case", "UPPER-CASE", "lower case space"
+    };
 
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "lowercase");
+    for (String value : invalidValues) {
+      helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, value);
 
-    assertThat(helper.getValidationNotices())
-        .containsExactly(
-            new MixedCaseRecommendedFieldNotice(
-                MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, 2));
-
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "UPPERCASE");
-
-    assertThat(helper.getValidationNotices())
-        .containsExactly(
-            new MixedCaseRecommendedFieldNotice(
-                MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, 2));
-
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "snake_case");
-
-    assertThat(helper.getValidationNotices())
-        .containsExactly(
-            new MixedCaseRecommendedFieldNotice(
-                MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, 2));
-
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "kebab-case");
-
-    assertThat(helper.getValidationNotices())
-        .containsExactly(
-            new MixedCaseRecommendedFieldNotice(
-                MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, 2));
-
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "UPPER-CASE");
-
-    assertThat(helper.getValidationNotices())
-        .containsExactly(
-            new MixedCaseRecommendedFieldNotice(
-                MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, 2));
-
-    helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, "lower case space");
-
-    assertThat(helper.getValidationNotices())
-        .containsExactly(
-            new MixedCaseRecommendedFieldNotice(
-                MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, 2));
+      assertThat(helper.getValidationNotices())
+          .containsExactly(
+              new MixedCaseRecommendedFieldNotice(
+                  MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, value, 2));
+    }
   }
 }


### PR DESCRIPTION
**Summary:**

Closes #1392

Add field value to notice.  Note, does not change casing of `filename` field as everywhere else is using the lowercase version.  

**Expected behavior:** 

Should show the offending value.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
