### PR TITLE
chore: add web validator information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ A [General Transit Feed Specification (GTFS) Schedule](https://gtfs.mobilitydata
 
 ---
 <p align="center">
-<a href="#running-the-app">Using the Desktop app</a>
+<a href="#using-the-web-based-validator">Web version</a>
 ●
-<a href="#run-the-app-via-command-line">Using the command line</a>
+<a href="#using-the-desktop-app">Desktop version</a>
 ●
-<a href="#run-the-app-using-docker">Using Docker</a>
+<a href="#using-the-command-line">Command line</a>
+●
+<a href="#using-docker">Docker</a>
 </p>
 
 
@@ -37,9 +39,9 @@ This is a cross-platform application written in Java that performs the following
 </video>
 
 # Using the web-based validator
-
-The GTFS Web Validator can be accessed from [https://gtfs-validator.mobilitydata.org/](https://gtfs-validator.mobilitydata.org/).
-The GTFS Web Validator accepts locally saved datasets and datasets available via the Web. Validation reports are available 30 days after creation and can be shared with their unique link.
+The GTFS Web Validator can be accessed at [https://gtfs-validator.mobilitydata.org/](https://gtfs-validator.mobilitydata.org/).
+The GTFS Web Validator accepts locally saved datasets in a zip format and datasets available via the Web in an URL format. 
+Validation reports have a unique URL link that can be shared and are available 30 days after creation.
 
 The GTFS Web Validator contains two main components: the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This is a cross-platform application written in Java that performs the following
 3. Performs complete validation against the [GTFS Schedule standard](https://gtfs.org/schedule/reference/#h.hc443y62gb8c).
 4. Provides an easy-to-use validation report in HTML format that can be opened in the browser and shared with other parties. See an [example of a validation report](https://htmlpreview.github.io/?https://github.com/MobilityData/gtfs-validator/blob/master/docs/report.html). The report is also available in JSON format that can be used for parsing and running additional analyses.
 
-<video src="https://user-images.githubusercontent.com/1192523/234676530-659918ef-7e37-4dd3-a7da-9762b69f1328.mp4" controls="controls" style="max-width: 730px;">
+<video src="https://user-images.githubusercontent.com/63653518/234697111-59cbc5de-5bf2-4c49-8474-fd41ac51a745.mp4" controls="controls" style="max-width: 730px;">
 </video>
 
 # Using the web-based validator

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The GTFS Web Validator can be accessed at [https://gtfs-validator.mobilitydata.o
 The GTFS Web Validator accepts locally saved datasets in a zip format and datasets available via the Web in an URL format. 
 Validation reports have a unique URL link that can be shared and are available 30 days after creation.
 
-The GTFS Web Validator contains two main components: the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
+The GTFS Web Validator contains two main components: the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md).
 
 # Using the Desktop app
 ### Setup

--- a/README.md
+++ b/README.md
@@ -129,7 +129,12 @@ where:
 
 `... c:/myDirectory:/work ...`
 
-The validator can then be executed via bash commands. See the [preceeding instructions for command line usage](#run-the-app-via-command-line).
+# GTFS Web Validator
+
+The GTFS Web Validator can be accessed from [https://gtfs-validator.mobilitydata.org/](https://gtfs-validator.mobilitydata.org/).
+The GTFS Web Validator accepts locally saved datasets and datasets available via the Web. Validation reports are available 30 days after creation and can be shared with their unique link.
+
+The GTFS Web Validator contains two main components the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
 
 ### Visualize the results
 In the output directory, the reports will be created as described [here](#visualize-the-results).

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This is a cross-platform application written in Java that performs the following
 3. Performs complete validation against the [GTFS Schedule standard](https://gtfs.org/schedule/reference/#h.hc443y62gb8c).
 4. Provides an easy-to-use validation report in HTML format that can be opened in the browser and shared with other parties. See an [example of a validation report](https://htmlpreview.github.io/?https://github.com/MobilityData/gtfs-validator/blob/master/docs/report.html). The report is also available in JSON format that can be used for parsing and running additional analyses.
 
-<video src="https://user-images.githubusercontent.com/63653518/191132078-5cd1e34c-bc99-4193-b4da-74ccdc2d35b6.mp4" controls="controls" style="max-width: 730px;">
+<video src="https://user-images.githubusercontent.com/1192523/234676530-659918ef-7e37-4dd3-a7da-9762b69f1328.mp4" controls="controls" style="max-width: 730px;">
 </video>
 
 # Using the web-based validator
@@ -42,9 +42,6 @@ The GTFS Web Validator can be accessed from [https://gtfs-validator.mobilitydata
 The GTFS Web Validator accepts locally saved datasets and datasets available via the Web. Validation reports are available 30 days after creation and can be shared with their unique link.
 
 The GTFS Web Validator contains two main components: the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
-
-<video src="https://user-images.githubusercontent.com/1192523/234625823-6ea6beb3-3449-4bb9-8195-274c75c6da4a.mov" controls="controls" style="max-width: 730px;">
-</video>
 
 # Using the Desktop app
 ### Setup

--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ where:
 
 `... c:/myDirectory:/work ...`
 
+### Visualize the results
+In the output directory, the reports will be created as described [here](#visualize-the-results).
+
 # GTFS Web Validator
 
 The GTFS Web Validator can be accessed from [https://gtfs-validator.mobilitydata.org/](https://gtfs-validator.mobilitydata.org/).
@@ -136,8 +139,8 @@ The GTFS Web Validator accepts locally saved datasets and datasets available via
 
 The GTFS Web Validator contains two main components the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
 
-### Visualize the results
-In the output directory, the reports will be created as described [here](#visualize-the-results).
+<video src="https://user-images.githubusercontent.com/1192523/234625823-6ea6beb3-3449-4bb9-8195-274c75c6da4a.mov" controls="controls" style="max-width: 730px;">
+</video>
 
 # Validation rules
 * See the list of all the noticed emitted by this validator in [RULES.md](/RULES.md).

--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ where:
 
 `... c:/myDirectory:/work ...`
 
+The validator can then be executed via bash commands. See the [preceeding instructions for command line usage](#run-the-app-via-command-line).
+
 ### Visualize the results
 In the output directory, the reports will be created as described [here](#visualize-the-results).
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,17 @@ This is a cross-platform application written in Java that performs the following
 <video src="https://user-images.githubusercontent.com/63653518/191132078-5cd1e34c-bc99-4193-b4da-74ccdc2d35b6.mp4" controls="controls" style="max-width: 730px;">
 </video>
 
-# Running the app
+# Using the web-based validator
+
+The GTFS Web Validator can be accessed from [https://gtfs-validator.mobilitydata.org/](https://gtfs-validator.mobilitydata.org/).
+The GTFS Web Validator accepts locally saved datasets and datasets available via the Web. Validation reports are available 30 days after creation and can be shared with their unique link.
+
+The GTFS Web Validator contains two main components: the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
+
+<video src="https://user-images.githubusercontent.com/1192523/234625823-6ea6beb3-3449-4bb9-8195-274c75c6da4a.mov" controls="controls" style="max-width: 730px;">
+</video>
+
+# Using the Desktop app
 ### Setup
 1. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` installer for your operating system:
     * Windows => `.msi`
@@ -68,7 +78,7 @@ Before running validation, tap the `Advanced` button to configure other aspects 
 * Number of threads used to run the validator.
 * The country code used for phone number validation.
 
-# Run the app via command line
+# Using the command line
 ### Setup
 1. Install [Java 11 or higher](https://www.oracle.com/java/technologies/javase-downloads.html). To check which version of Java is installed on your computer, type the following command in the terminal: `java --version`.
 2. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` CLI jar (not OS-specific). It is located in the **Assets** section of the release, and it looks like `gtfs-validator-vX.X.X_cli.jar`
@@ -90,7 +100,7 @@ More detailed instructions with all the parameters that exists are available on 
 ### Visualize the results
 In the output directory, the reports will be created as described [here](#visualize-the-results).
 
-# Run the app using Docker
+# Using Docker
 ### Setup
 1. Download and install [Docker](https://docs.docker.com/get-started/)
 1. To obtain a validator Docker container image, you have two options:
@@ -133,16 +143,6 @@ The validator can then be executed via bash commands. See the [preceeding instru
 
 ### Visualize the results
 In the output directory, the reports will be created as described [here](#visualize-the-results).
-
-# GTFS Web Validator
-
-The GTFS Web Validator can be accessed from [https://gtfs-validator.mobilitydata.org/](https://gtfs-validator.mobilitydata.org/).
-The GTFS Web Validator accepts locally saved datasets and datasets available via the Web. Validation reports are available 30 days after creation and can be shared with their unique link.
-
-The GTFS Web Validator contains two main components the GTFS Web Validator Client and the GTFS Validator Web Service. More information about these components can be found in [GTFS Web Validator Client](./web/client/README.md) and [GTFS Validator Web Service](./web/service/README.md)
-
-<video src="https://user-images.githubusercontent.com/1192523/234625823-6ea6beb3-3449-4bb9-8195-274c75c6da4a.mov" controls="controls" style="max-width: 730px;">
-</video>
 
 # Validation rules
 * See the list of all the noticed emitted by this validator in [RULES.md](/RULES.md).

--- a/web/client/README.md
+++ b/web/client/README.md
@@ -1,18 +1,4 @@
-# create-svelte
-
-Everything you need to build a Svelte project, powered by [`create-svelte`](https://github.com/sveltejs/kit/tree/master/packages/create-svelte).
-
-## Creating a project
-
-If you're seeing this, you've probably already done this step. Congrats!
-
-```bash
-# create a new project in the current directory
-npm create svelte@latest
-
-# create a new project in my-app
-npm create svelte@latest my-app
-```
+# GTFS Web Validator Client
 
 ## Developing
 
@@ -55,3 +41,5 @@ npm run build
 ```bash
 gcloud storage cp --recursive ./build/* gs://gtfs-validator-web/
 ```
+
+*This project is powered by [`SvelteKit`](https://kit.svelte.dev/).*


### PR DESCRIPTION
**Summary:**

This is part of the pre-release tasks. This PR adds the GTFS Web validator information to the project root's README file.

**Expected behavior:** 

The GTFS Web Validator information is in the project root's  README file and linking web client and service sub-packages README for more information.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
