### PR TITLE
chore: ignore web packages on acceptance and e2e tests

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -13,6 +13,7 @@ on:
       - 'test_pack_dock.yml'
       - 'triage.yml'
       - 'end_to_end.yml'
+      - 'web/**'
 concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -14,6 +14,7 @@ on:
       - 'test_pack_dock.yml'
       - 'triage.yml'
       - 'acceptance_test.yml'
+      - 'web/**'
   pull_request:
     branches: [ master ]
     paths-ignore:
@@ -27,6 +28,7 @@ on:
       - 'test_pack_dock.yml'
       - 'triage.yml'
       - 'acceptance_test.yml'
+      - 'web/**'
 jobs:
   validate_gradle_wrapper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
**Summary:**

The acceptance and E2E tests are time and cost-consuming workflows. As web projects have no impact on the validator's core implementation, we can ignore them in the mentioned test workflows. Web projects run their own independent set of tests.

**Expected behavior:** 

When changes are pushed from `web` projects, the acceptance and E2E tests should not run.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
