### PR TITLE
feat: Add unit-test check for @GtfsValidationNotice annotation and notices that I missed

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
@@ -13,19 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.mobilitydata.gtfsvalidator.notice;
+
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
 
 import com.google.common.base.Strings;
 import java.io.IOException;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 
 /**
  * This is related to Input and Output operations in the code.
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
+@GtfsValidationNotice(severity = ERROR)
 public class IOError extends SystemError {
+
   private final String exception;
+
   private final String message;
 
   public IOError(IOException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
@@ -27,6 +27,7 @@ public class MixedCaseRecommendedFieldNotice extends ValidationNotice {
   private final String fieldName;
 
   private final String fieldValue;
+
   private final int csvRowNumber;
 
   public MixedCaseRecommendedFieldNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
@@ -1,6 +1,9 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+
 import com.google.common.base.Strings;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 
 /**
  * Describes a runtime exception during loading a table. This normally indicates a bug in validator
@@ -8,10 +11,13 @@ import com.google.common.base.Strings;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
+@GtfsValidationNotice(severity = ERROR)
 public class RuntimeExceptionInLoaderError extends SystemError {
 
   private final String filename;
+
   private final String exception;
+
   private final String message;
 
   public RuntimeExceptionInLoaderError(String filename, RuntimeException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInValidatorError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInValidatorError.java
@@ -1,6 +1,9 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+
 import com.google.common.base.Strings;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 
 /**
  * Describes a runtime exception during validation. This normally indicates a bug in validator code,
@@ -8,9 +11,13 @@ import com.google.common.base.Strings;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
+@GtfsValidationNotice(severity = ERROR)
 public class RuntimeExceptionInValidatorError extends SystemError {
+
   private final String validator;
+
   private final String exception;
+
   private final String message;
 
   public RuntimeExceptionInValidatorError(String validatorClassName, RuntimeException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadExecutionError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadExecutionError.java
@@ -1,7 +1,10 @@
 package org.mobilitydata.gtfsvalidator.notice;
 
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+
 import com.google.common.base.Strings;
 import java.util.concurrent.ExecutionException;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 
 /**
  * Describes an ExecutionException during multithreaded validation.
@@ -11,8 +14,11 @@ import java.util.concurrent.ExecutionException;
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
+@GtfsValidationNotice(severity = ERROR)
 public class ThreadExecutionError extends SystemError {
+
   private final String exception;
+
   private final String message;
 
   public ThreadExecutionError(ExecutionException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
@@ -13,19 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.mobilitydata.gtfsvalidator.notice;
+
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
 
 import com.google.common.base.Strings;
 import java.net.URISyntaxException;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 
 /**
  * Indicates that a string could not be parsed as a URI reference.
  *
  * <p>Severity: {@code SeverityLevel.ERROR}
  */
+@GtfsValidationNotice(severity = ERROR)
 public class URISyntaxError extends SystemError {
+
   private final String exception;
+
   private final String message;
 
   public URISyntaxError(URISyntaxException exception) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -15,16 +15,19 @@
  */
 package org.mobilitydata.gtfsvalidator.validator;
 
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import java.time.ZoneId;
 import java.util.Locale;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.*;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
+import org.mobilitydata.gtfsvalidator.table.GtfsAgencySchema;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
 
 /**
@@ -143,6 +146,7 @@ public class AgencyConsistencyValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsAgencySchema.class))
   static class InconsistentAgencyTimezoneNotice extends ValidationNotice {
 
     // The row of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidator.java
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -22,6 +23,7 @@ import java.util.NavigableMap;
 import java.util.Optional;
 import java.util.SortedSet;
 import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -47,9 +49,13 @@ import org.mobilitydata.gtfsvalidator.util.TripCalendarUtil;
 public class DateTripsValidator extends FileValidator {
 
   private final GtfsCalendarDateTableContainer calendarDateTable;
+
   private final GtfsCalendarTableContainer calendarTable;
+
   private final GtfsTripTableContainer tripContainer;
+
   private final GtfsFrequencyTableContainer frequencyTable;
+
   private final CurrentDateTime currentDateTime;
 
   @Inject
@@ -68,20 +74,16 @@ public class DateTripsValidator extends FileValidator {
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-
     LocalDate now = currentDateTime.getNow().toLocalDate();
-
     final Map<String, SortedSet<LocalDate>> servicePeriodMap =
         CalendarUtil.servicePeriodToServiceDatesMap(
             CalendarUtil.buildServicePeriodMap(calendarTable, calendarDateTable));
-
     NavigableMap<LocalDate, Integer> tripCounts =
         TripCalendarUtil.countTripsForEachServiceDate(
             servicePeriodMap, tripContainer, frequencyTable);
     Optional<TripCalendarUtil.DateInterval> majorityServiceDates =
         TripCalendarUtil.computeMajorityServiceCoverage(tripCounts);
     LocalDate currentDatePlusSevenDays = now.plusDays(7);
-
     if (!majorityServiceDates.isEmpty()) {
       LocalDate serviceWindowStartDate = majorityServiceDates.get().startDate();
       LocalDate serviceWindowEndDate = majorityServiceDates.get().endDate();
@@ -101,11 +103,15 @@ public class DateTripsValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.WARNING
    */
+  @GtfsValidationNotice(severity = WARNING)
   static class TripCoverageNotActiveForNext7DaysNotice extends ValidationNotice {
+
     // Current date (YYYYMMDD format)
     private final GtfsDate currentDate;
+
     // The start date of the majority service window.
     private final GtfsDate serviceWindowStartDate;
+
     // The end date of the majority service window.
     private final GtfsDate serviceWindowEndDate;
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareMediaValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareMediaValidator.java
@@ -1,14 +1,19 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
+
 import com.google.auto.value.AutoValue;
 import java.util.HashMap;
 import java.util.Map;
 import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareMedia;
+import org.mobilitydata.gtfsvalidator.table.GtfsFareMediaSchema;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareMediaTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFareMediaType;
 
@@ -39,6 +44,7 @@ public class DuplicateFareMediaValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsFareMediaSchema.class))
   static class DuplicateFareMediaNotice extends ValidationNotice {
 
     // The row number of the first fare media.
@@ -65,6 +71,7 @@ public class DuplicateFareMediaValidator extends FileValidator {
   /** A "primary key" type composed of fare media name + type. */
   @AutoValue
   abstract static class Key {
+
     public abstract String name();
 
     public abstract GtfsFareMediaType type();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import java.time.LocalDate;
 import java.util.Map;
 import java.util.SortedSet;
 import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -30,8 +33,11 @@ import org.mobilitydata.gtfsvalidator.util.CalendarUtil;
 
 @GtfsValidator
 public class ExpiredCalendarValidator extends FileValidator {
+
   private final GtfsCalendarTableContainer calendarTable;
+
   private final GtfsCalendarDateTableContainer calendarDateTable;
+
   private final CurrentDateTime currentDateTime;
 
   @Inject
@@ -47,11 +53,9 @@ public class ExpiredCalendarValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     LocalDate now = currentDateTime.getNow().toLocalDate();
-
     final Map<String, SortedSet<LocalDate>> servicePeriodMap =
         CalendarUtil.servicePeriodToServiceDatesMap(
             CalendarUtil.buildServicePeriodMap(calendarTable, calendarDateTable));
-
     for (var serviceId : servicePeriodMap.keySet()) {
       SortedSet<LocalDate> serviceDates = servicePeriodMap.get(serviceId);
       LocalDate lastServiceDate = serviceDates.last();
@@ -62,9 +66,18 @@ public class ExpiredCalendarValidator extends FileValidator {
     }
   }
 
+  @GtfsValidationNotice(
+      severity = WARNING,
+      urls = {
+        @UrlRef(
+            label = "Dataset Publishing & General Practices",
+            url = "https://gtfs.org/schedule/best-practices/#dataset-publishing-general-practices")
+      })
   static class ExpiredCalendarNotice extends ValidationNotice {
+
     // The row of the faulty record.
     private final int csvRowNumber;
+
     // The service id of the faulty record.
     private final String serviceId;
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleDurationLimitTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleDurationLimitTypeValidator.java
@@ -51,6 +51,7 @@ public class FareTransferRuleDurationLimitTypeValidator
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleDurationLimitTypeWithoutDurationLimitNotice
       extends ValidationNotice {
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleTransferCountValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleTransferCountValidator.java
@@ -67,6 +67,7 @@ public class FareTransferRuleTransferCountValidator
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleMissingTransferCountNotice extends ValidationNotice {
 
     // The row of the faulty record.
@@ -84,6 +85,7 @@ public class FareTransferRuleTransferCountValidator
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleWithForbiddenTransferCountNotice extends ValidationNotice {
 
     // The row of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -20,6 +20,7 @@ import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 import java.time.LocalDate;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -105,6 +106,13 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
     }
   }
 
+  @GtfsValidationNotice(
+      severity = WARNING,
+      urls = {
+        @UrlRef(
+            label = "General Publishing & General Practices",
+            url = "https://gtfs.org/best-practices/#dataset-publishing--general-practices")
+      })
   static class FeedExpirationDate30DaysNotice extends ValidationNotice {
 
     // The row number of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationHasStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationHasStopTimesValidator.java
@@ -15,6 +15,7 @@
  */
 package org.mobilitydata.gtfsvalidator.validator;
 
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import java.util.List;
@@ -96,6 +97,7 @@ public class LocationHasStopTimesValidator extends FileValidator {
   /**
    * Describes a location in {@code stops.txt} that is not a stop but has a stop time associated.
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class LocationWithUnexpectedStopTimeNotice extends ValidationNotice {
 
     // The row number of the faulty record from `stops.txt`.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
@@ -16,14 +16,17 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopSchema;
 
 /**
  * Validates presence or absence of `parent_station` field based on `location_type`.
@@ -112,6 +115,7 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopSchema.class))
   static class LocationWithoutParentStationNotice extends ValidationNotice {
 
     // The row of the faulty record.
@@ -143,6 +147,7 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopSchema.class))
   static class PlatformWithoutParentStationNotice extends ValidationNotice {
 
     // Row number of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
@@ -113,6 +113,7 @@ public class PathwayEndpointTypeValidator extends FileValidator {
   }
 
   /** Describes a pathway which endpoint is a platform that has boarding areas. */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsPathwaySchema.class))
   static class PathwayToPlatformWithBoardingAreasNotice extends ValidationNotice {
 
     // The row of the faulty row.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -16,6 +16,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
@@ -119,6 +120,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsRouteSchema.class))
   static class RouteLongNameContainsShortNameNotice extends ValidationNotice {
 
     // The id of the faulty record.
@@ -149,6 +151,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsRouteSchema.class))
   static class RouteShortNameTooLongNotice extends ValidationNotice {
 
     // The id of the faulty record.
@@ -174,6 +177,7 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING)
   static class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
 
     // The row number of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -16,6 +16,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 import static org.mobilitydata.gtfsvalidator.util.S2Earth.getDistanceMeters;
 
 import com.google.common.collect.Multimaps;
@@ -139,6 +140,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsShapeSchema.class))
   static class EqualShapeDistanceSameCoordinatesNotice extends ValidationNotice {
 
     // The id of the faulty shape.
@@ -184,6 +186,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsShapeSchema.class))
   static class EqualShapeDistanceDiffCoordinatesNotice extends ValidationNotice {
 
     // The id of the faulty shape.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
@@ -37,6 +37,7 @@ import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeSchema;
 import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopSchema;
@@ -294,6 +295,9 @@ public class ShapeToStopMatchingValidator extends FileValidator {
    * <p>This potentially indicates a problem with the location of the stop or the use of {@code
    * shape_dist_traveled} values.
    */
+  @GtfsValidationNotice(
+      severity = WARNING,
+      files = @FileRefs({GtfsTripSchema.class, GtfsStopTimeSchema.class, GtfsStopSchema.class}))
   static class StopTooFarFromShapeUsingUserDistanceNotice extends ValidationNotice {
 
     // The row number of the faulty record from `trips.txt`.
@@ -344,6 +348,7 @@ public class ShapeToStopMatchingValidator extends FileValidator {
    *
    * <p>This potentially indicates a problem with the location of the stop or the path of the shape.
    */
+  @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsShapeSchema.class))
   static class StopTooFarFromShapeNotice extends ValidationNotice {
 
     // The row number of the faulty record from `trips.txt`.
@@ -395,6 +400,9 @@ public class ShapeToStopMatchingValidator extends FileValidator {
    * <p>This could indicate a problem with the location of the stops, the path of the shape, or the
    * sequence of the stops for their trip.
    */
+  @GtfsValidationNotice(
+      severity = WARNING,
+      files = @FileRefs({GtfsTripSchema.class, GtfsStopTimeSchema.class, GtfsStopSchema.class}))
   static class StopsMatchShapeOutOfOrderNotice extends ValidationNotice {
 
     // The row number of the faulty record from `trips.txt`.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -16,6 +16,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
@@ -102,6 +103,7 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING)
   static class SameNameAndDescriptionForStopNotice extends ValidationNotice {
 
     // The row number of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
@@ -142,6 +142,7 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class StopTimeWithOnlyArrivalOrDepartureTimeNotice extends ValidationNotice {
 
     // The row number of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -419,6 +419,13 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
    * <p>This normally indicates a more serious problem than too fast travel between consecutive
    * stops.
    */
+  @GtfsValidationNotice(
+      severity = WARNING,
+      urls = {
+        @UrlRef(
+            label = "Original Python validator implementation",
+            url = "https://github.com/google/transitfeed")
+      })
   static class FastTravelBetweenFarStopsNotice extends ValidationNotice {
 
     // The row number of the problematic trip.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
@@ -16,6 +16,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
@@ -118,6 +119,7 @@ public class TimepointTimeValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopTimeSchema.class))
   static class MissingTimepointValueNotice extends ValidationNotice {
 
     // The row number of the faulty record.
@@ -142,6 +144,7 @@ public class TimepointTimeValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsStopTimeSchema.class))
   static class MissingTimepointColumnNotice extends ValidationNotice {
 
     // The name of the affected file.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersTripReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersTripReferenceValidator.java
@@ -166,6 +166,7 @@ public class TransfersTripReferenceValidator extends FileValidator {
    *
    * <p>Severity: {@code SeverityLevel.ERROR}
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTransferSchema.class))
   public static class TransferWithInvalidTripAndStopNotice extends ValidationNotice {
 
     // The row number from `transfers.txt` for the faulty entry.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -16,6 +16,7 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
@@ -215,6 +216,7 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
   }
 
   /** A translation references an unknown or missing GTFS table. */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsTranslationSchema.class))
   static class TranslationUnknownTableNameNotice extends ValidationNotice {
 
     // The row number of the faulty record.
@@ -234,6 +236,7 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
    * An entity with the given {@code record_id, record_sub_id} cannot be found in the referenced
    * table.
    */
+  @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTranslationSchema.class))
   static class TranslationForeignKeyViolationNotice extends ValidationNotice {
 
     // The row number of the faulty record.

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
@@ -30,6 +30,7 @@ import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgency;
 import org.mobilitydata.gtfsvalidator.table.GtfsAgencyTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsRoute;
+import org.mobilitydata.gtfsvalidator.table.GtfsRouteSchema;
 import org.mobilitydata.gtfsvalidator.table.GtfsRouteTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopSchema;
@@ -161,6 +162,7 @@ public class UrlConsistencyValidator extends FileValidator {
    *
    * <p>{@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsRouteSchema.class))
   static class SameRouteAndAgencyUrlNotice extends ValidationNotice {
 
     // The row number of the faulty record from `routes.txt`.
@@ -193,6 +195,7 @@ public class UrlConsistencyValidator extends FileValidator {
    *
    * <p>{@code SeverityLevel.WARNING}
    */
+  @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopSchema.class))
   static class SameStopAndAgencyUrlNotice extends ValidationNotice {
 
     // The row number of the faulty record from `stops.txt`.

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeAnnotationTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeAnnotationTest.java
@@ -1,0 +1,33 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.notice.Notice;
+
+@RunWith(JUnit4.class)
+public class NoticeAnnotationTest {
+
+  @Test
+  public void testAllNoticesAnnotatedWithGtfsValidationNotice() {
+    List<Class<Notice>> noticesWithoutAnnotation =
+        discoverValidationNoticeClasses()
+            .filter(c -> c.getAnnotation(GtfsValidationNotice.class) == null)
+            .collect(Collectors.toList());
+    assertWithMessage(
+            "All Notice subclasses must be annotated with @GtfsValidationNotice, but the following classes were not:")
+        .that(noticesWithoutAnnotation)
+        .isEmpty();
+  }
+
+  private static Stream<Class<Notice>> discoverValidationNoticeClasses() {
+    return ClassGraphDiscovery.discoverNoticeSubclasses(ClassGraphDiscovery.DEFAULT_NOTICE_PACKAGES)
+        .stream();
+  }
+}


### PR DESCRIPTION
This adds a new `NoticeAnnotationTest` to make sure each validation notice is annotated with @GtfsValidationNotice.  It also adds @GtfsValidationNotices to a number of notices that I missed in the first pass:
* SystemErrors
* Files with more than one child Notice class (my script only caught the first notice in the file)