### PR TITLE
feat: Change Notice field comment format and unit-test to enforce they exist

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/CsvParsingFailedNotice.java
@@ -31,22 +31,22 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class CsvParsingFailedNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The location of the last character read from before the error occurred.
+  /** The location of the last character read from before the error occurred. */
   private final long charIndex;
 
-  // The column index where the exception occurred.
+  /** The column index where the exception occurred. */
   private final long columnIndex;
 
-  // The line number where the exception occurred.
+  /** The line number where the exception occurred. */
   private final long lineIndex;
 
-  // The detailed message describing the error, and the internal state of the parser/writer.
+  /** The detailed message describing the error, and the internal state of the parser/writer. */
   private final String message;
 
-  // The record number when the exception occurred.
+  /** The record number when the exception occurred. */
   private final String parsedContent;
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateKeyNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicateKeyNotice.java
@@ -38,25 +38,25 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class DuplicateKeyNotice extends ValidationNotice {
 
-  // The name of the faulty file
+  /** The name of the faulty file */
   private final String filename;
 
-  // The row of the first occurrence.
+  /** The row of the first occurrence. */
   private final long oldCsvRowNumber;
 
-  // The row of the other occurrence.
+  /** The row of the other occurrence. */
   private final long newCsvRowNumber;
 
-  // Composite key's first field name.
+  /** Composite key's first field name. */
   private final String fieldName1;
 
-  // Composite key's first value.
+  /** Composite key's first value. */
   private final Object fieldValue1;
 
-  // Composite key's second field name.
+  /** Composite key's second field name. */
   @Nullable private final String fieldName2;
 
-  // Composite key's second value.
+  /** Composite key's second value. */
   @Nullable private final Object fieldValue2;
 
   public DuplicateKeyNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicatedColumnNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/DuplicatedColumnNotice.java
@@ -37,16 +37,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class DuplicatedColumnNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The name of the faulty field.
+  /** The name of the faulty field. */
   private final String fieldName;
 
-  // Index of the first occurrence.
+  /** Index of the first occurrence. */
   private final int firstIndex;
 
-  // Index of the other occurrence.
+  /** Index of the other occurrence. */
   private final int secondIndex;
 
   public DuplicatedColumnNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyColumnNameNotice.java
@@ -29,10 +29,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILE_REQUIREMENTS))
 public class EmptyColumnNameNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The index of the empty column.
+  /** The index of the empty column. */
   private final int index;
 
   public EmptyColumnNameNotice(String filename, int index) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyFileNotice.java
@@ -29,7 +29,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILE_REQUIREMENTS))
 public class EmptyFileNotice extends ValidationNotice {
 
-  /** The name of the faulty file */
+  /** The name of the faulty file. */
   private final String filename;
 
   public EmptyFileNotice(String filename) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyFileNotice.java
@@ -29,7 +29,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILE_REQUIREMENTS))
 public class EmptyFileNotice extends ValidationNotice {
 
-  // The name of the faulty file
+  /** The name of the faulty file */
   private final String filename;
 
   public EmptyFileNotice(String filename) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/EmptyRowNotice.java
@@ -32,10 +32,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = WARNING, sections = @SectionRefs(FILE_REQUIREMENTS))
 public class EmptyRowNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row number of the faulty record.
+  /** The row number of the faulty record. */
   private final int csvRowNumber;
 
   public EmptyRowNotice(String filename, int csvRowNumber) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ForeignKeyViolationNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ForeignKeyViolationNotice.java
@@ -41,22 +41,22 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class ForeignKeyViolationNotice extends ValidationNotice {
 
-  // The name of the file from which reference is made.
+  /** The name of the file from which reference is made. */
   private final String childFilename;
 
-  // The name of the field that makes reference.
+  /** The name of the field that makes reference. */
   private final String childFieldName;
 
-  // The name of the file that is referred to.
+  /** The name of the file that is referred to. */
   private final String parentFilename;
 
-  // The name of the field that is referred to.
+  /** The name of the field that is referred to. */
   private final String parentFieldName;
 
-  // The faulty record's value.
+  /** The faulty record's value. */
   private final String fieldValue;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
   public ForeignKeyViolationNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/IOError.java
@@ -29,8 +29,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class IOError extends SystemError {
 
+  /** The name of the exception. */
   private final String exception;
 
+  /** The error message that explains the reason for the exception. */
   private final String message;
 
   public IOError(IOException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidColorNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidColorNotice.java
@@ -34,16 +34,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidColorNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidColorNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyAmountNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyAmountNotice.java
@@ -18,16 +18,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidCurrencyAmountNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty currency amount value.
+  /** Faulty currency amount value. */
   private final String amount;
 
   public InvalidCurrencyAmountNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidCurrencyNotice.java
@@ -35,16 +35,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidCurrencyNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidCurrencyNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidDateNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidDateNotice.java
@@ -33,16 +33,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidDateNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidDateNotice(String filename, int csvRowNumber, String fieldName, String fieldValue) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidEmailNotice.java
@@ -42,16 +42,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class InvalidEmailNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidFloatNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidFloatNotice.java
@@ -29,16 +29,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidFloatNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidFloatNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidIntegerNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidIntegerNotice.java
@@ -29,16 +29,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidIntegerNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidIntegerNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidLanguageCodeNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidLanguageCodeNotice.java
@@ -34,16 +34,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidLanguageCodeNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidLanguageCodeNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidPhoneNumberNotice.java
@@ -33,16 +33,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidPhoneNumberNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidRowLengthNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidRowLengthNotice.java
@@ -37,16 +37,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class InvalidRowLengthNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // The length of the faulty record.
+  /** The length of the faulty record. */
   private final int rowLength;
 
-  // The number of column in the faulty file.
+  /** The number of column in the faulty file. */
   private final int headerCount;
 
   public InvalidRowLengthNotice(String filename, int csvRowNumber, int rowLength, int headerCount) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimeNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimeNotice.java
@@ -33,16 +33,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidTimeNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidTimeNotice(String filename, int csvRowNumber, String fieldName, String fieldValue) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimezoneNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidTimezoneNotice.java
@@ -35,16 +35,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILED_TYPES))
 public class InvalidTimezoneNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public InvalidTimezoneNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidUrlNotice.java
@@ -50,16 +50,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class InvalidUrlNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/LeadingOrTrailingWhitespacesNotice.java
@@ -38,16 +38,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = WARNING, sections = @SectionRefs(FILE_REQUIREMENTS))
 public class LeadingOrTrailingWhitespacesNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // Faulty record's field name.
+  /** Faulty record's field name. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public LeadingOrTrailingWhitespacesNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFieldNotice.java
@@ -27,13 +27,13 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = WARNING)
 public class MissingRecommendedFieldNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // The name of the missing field.
+  /** The name of the missing field. */
   private final String fieldName;
 
   public MissingRecommendedFieldNotice(String filename, int csvRowNumber, String fieldName) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRecommendedFileNotice.java
@@ -27,7 +27,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = WARNING)
 public class MissingRecommendedFileNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
   public MissingRecommendedFileNotice(String filename) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredColumnNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredColumnNotice.java
@@ -29,10 +29,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(TERM_DEFINITIONS))
 public class MissingRequiredColumnNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The name of the missing column.
+  /** The name of the missing column. */
   private final String fieldName;
 
   public MissingRequiredColumnNotice(String filename, String fieldName) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFieldNotice.java
@@ -29,13 +29,13 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(TERM_DEFINITIONS))
 public class MissingRequiredFieldNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // The name of the missing field.
+  /** The name of the missing field. */
   private final String fieldName;
 
   public MissingRequiredFieldNotice(String filename, int csvRowNumber, String fieldName) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MissingRequiredFileNotice.java
@@ -29,7 +29,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(TERM_DEFINITIONS))
 public class MissingRequiredFileNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
   public MissingRequiredFileNotice(String filename) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
@@ -22,12 +22,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class MixedCaseRecommendedFieldNotice extends ValidationNotice {
 
+  /** Name of the faulty file. */
   private final String filename;
 
+  /** Name of the faulty field. */
   private final String fieldName;
 
+  /** Name of the faulty field. */
   private final String fieldValue;
 
+  /** The row number of the faulty record. */
   private final int csvRowNumber;
 
   public MixedCaseRecommendedFieldNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
@@ -28,7 +28,7 @@ public class MixedCaseRecommendedFieldNotice extends ValidationNotice {
   /** Name of the faulty field. */
   private final String fieldName;
 
-  /** Name of the faulty field. */
+  /** Faulty value. */
   private final String fieldValue;
 
   /** The row number of the faulty record. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MoreThanOneEntityNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MoreThanOneEntityNotice.java
@@ -29,10 +29,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = WARNING, sections = @SectionRefs(FIELD_DEFINITIONS))
 public class MoreThanOneEntityNotice extends ValidationNotice {
 
-  // Name of the faulty file.
+  /** Name of the faulty file. */
   private final String filename;
 
-  // Number of occurrences.
+  /** Number of occurrences. */
   private final long entityCount;
 
   public MoreThanOneEntityNotice(String filename, long entityCount) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NewLineInValueNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NewLineInValueNotice.java
@@ -40,16 +40,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILE_REQUIREMENTS))
 public class NewLineInValueNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // The name of the faulty field.
+  /** The name of the faulty field. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public NewLineInValueNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
@@ -37,16 +37,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class NonAsciiOrNonPrintableCharNotice extends ValidationNotice {
 
-  // Name of the faulty file.
+  /** Name of the faulty file. */
   private final String filename;
 
-  // Row number of the faulty record.
+  /** Row number of the faulty record. */
   private final int csvRowNumber;
 
-  // Name of the column where the error occurred.
+  /** Name of the column where the error occurred. */
   private final String columnName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final String fieldValue;
 
   public NonAsciiOrNonPrintableCharNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NumberOutOfRangeNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NumberOutOfRangeNotice.java
@@ -38,19 +38,19 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class NumberOutOfRangeNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row of the faulty record.
+  /** The row of the faulty record. */
   private final int csvRowNumber;
 
-  // The name of the faulty field.
+  /** The name of the faulty field. */
   private final String fieldName;
 
-  // The type of the faulty field.
+  /** The type of the faulty field. */
   private final String fieldType;
 
-  // Faulty value.
+  /** Faulty value. */
   private final Object fieldValue;
 
   public NumberOutOfRangeNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearOriginNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearOriginNotice.java
@@ -35,25 +35,25 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class PointNearOriginNotice extends ValidationNotice {
 
-  // The name of the affected GTFS file.
+  /** The name of the affected GTFS file. */
   private final String filename;
 
-  // The row of the faulty row.
+  /** The row of the faulty row. */
   private final int csvRowNumber;
 
-  // The id of the faulty entity.
+  /** The id of the faulty entity. */
   @Nullable private final String entityId;
 
-  // The name of the field that uses latitude value.
+  /** The name of the field that uses latitude value. */
   private final String latFieldName;
 
-  // The latitude of the faulty row.
+  /** The latitude of the faulty row. */
   private final double latFieldValue;
 
-  // The name of the field that uses longitude value.
+  /** The name of the field that uses longitude value. */
   private final String lonFieldName;
 
-  // The longitude of the faulty row
+  /** The longitude of the faulty row */
   private final double lonFieldValue;
 
   public PointNearOriginNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
@@ -53,7 +53,7 @@ public class PointNearPoleNotice extends ValidationNotice {
   /** The name of the field that uses longitude value. */
   private final String lonFieldName;
 
-  /** The longitude of the faulty row */
+  /** The longitude of the faulty row. */
   private final double lonFieldValue;
 
   public PointNearPoleNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
@@ -35,25 +35,25 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class PointNearPoleNotice extends ValidationNotice {
 
-  // The name of the affected GTFS file.
+  /** The name of the affected GTFS file. */
   private final String filename;
 
-  // The row of the faulty row.
+  /** The row of the faulty row. */
   private final int csvRowNumber;
 
-  // The id of the faulty entity.
+  /** The id of the faulty entity. */
   @Nullable private final String entityId;
 
-  // The name of the field that uses latitude value.
+  /** The name of the field that uses latitude value. */
   private final String latFieldName;
 
-  // The latitude of the faulty row.
+  /** The latitude of the faulty row. */
   private final double latFieldValue;
 
-  // The name of the field that uses longitude value.
+  /** The name of the field that uses longitude value. */
   private final String lonFieldName;
 
-  // The longitude of the faulty row
+  /** The longitude of the faulty row */
   private final double lonFieldValue;
 
   public PointNearPoleNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInLoaderError.java
@@ -14,10 +14,13 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class RuntimeExceptionInLoaderError extends SystemError {
 
+  /** The name of the file that caused the exception. */
   private final String filename;
 
+  /** The name of the exception. */
   private final String exception;
 
+  /** The error message that explains the reason for the exception. */
   private final String message;
 
   public RuntimeExceptionInLoaderError(String filename, RuntimeException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInValidatorError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/RuntimeExceptionInValidatorError.java
@@ -14,10 +14,13 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class RuntimeExceptionInValidatorError extends SystemError {
 
+  /** The name of the validator that caused the exception. */
   private final String validator;
 
+  /** The name of the exception. */
   private final String exception;
 
+  /** The error message that explains the reason for the exception. */
   private final String message;
 
   public RuntimeExceptionInValidatorError(String validatorClassName, RuntimeException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeEqualNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeEqualNotice.java
@@ -37,22 +37,22 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class StartAndEndRangeEqualNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row number of the faulty record.
+  /** The row number of the faulty record. */
   private final int csvRowNumber;
 
-  // The id of the faulty entity.
+  /** The id of the faulty entity. */
   @Nullable private final String entityId;
 
-  // The start value's field name.
+  /** The start value's field name. */
   private final String startFieldName;
 
-  // The end value's field name.
+  /** The end value's field name. */
   private final String endFieldName;
 
-  // The faulty value.
+  /** The faulty value. */
   private final String value;
 
   public StartAndEndRangeEqualNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeOutOfOrderNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/StartAndEndRangeOutOfOrderNotice.java
@@ -37,25 +37,25 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class StartAndEndRangeOutOfOrderNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row number of the faulty record.
+  /** The row number of the faulty record. */
   private final int csvRowNumber;
 
-  // The faulty service id.
+  /** The faulty service id. */
   @Nullable private final String entityId;
 
-  // The start value's field name.
+  /** The start value's field name. */
   private final String startFieldName;
 
-  // The start value.
+  /** The start value. */
   private final String startValue;
 
-  // The end value's field name.
+  /** The end value's field name. */
   private final String endFieldName;
 
-  // The end value.
+  /** The end value. */
   private final String endValue;
 
   public StartAndEndRangeOutOfOrderNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadExecutionError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ThreadExecutionError.java
@@ -17,8 +17,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class ThreadExecutionError extends SystemError {
 
+  /** The name of the exception. */
   private final String exception;
 
+  /** The error message that explains the reason for the exception. */
   private final String message;
 
   public ThreadExecutionError(ExecutionException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/TooManyRowsNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/TooManyRowsNotice.java
@@ -14,10 +14,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class TooManyRowsNotice extends ValidationNotice {
 
-  // Name of the CSV file that has too many rows.
+  /** Name of the CSV file that has too many rows. */
   private final String filename;
 
-  // Number of the row when reading was stopped.
+  /** Number of the row when reading was stopped. */
   private final long rowNumber;
 
   public TooManyRowsNotice(String filename, long rowNumber) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/URISyntaxError.java
@@ -29,8 +29,10 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 @GtfsValidationNotice(severity = ERROR)
 public class URISyntaxError extends SystemError {
 
+  /** The name of the exception. */
   private final String exception;
 
+  /** The error message that explains the reason for the exception. */
   private final String message;
 
   public URISyntaxError(URISyntaxException exception) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnexpectedEnumValueNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnexpectedEnumValueNotice.java
@@ -29,16 +29,16 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef
 @GtfsValidationNotice(severity = WARNING, sections = @SectionRefs(FIELD_DEFINITIONS))
 public class UnexpectedEnumValueNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The row number of the faulty record.
+  /** The row number of the faulty record. */
   private final int csvRowNumber;
 
-  // The name of the field where the error occurred.
+  /** The name of the field where the error occurred. */
   private final String fieldName;
 
-  // Faulty value.
+  /** Faulty value. */
   private final int fieldValue;
 
   public UnexpectedEnumValueNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownColumnNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownColumnNotice.java
@@ -34,13 +34,13 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class UnknownColumnNotice extends ValidationNotice {
 
-  // The name of the faulty file.
+  /** The name of the faulty file. */
   private final String filename;
 
-  // The name of the unknown column.
+  /** The name of the unknown column. */
   private final String fieldName;
 
-  // The index of the faulty column.
+  /** The index of the faulty column. */
   private final int index;
 
   public UnknownColumnNotice(String filename, String fieldName, int index) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownFileNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UnknownFileNotice.java
@@ -34,7 +34,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     })
 public class UnknownFileNotice extends ValidationNotice {
 
-  // The name of the unknown file.
+  /** The name of the unknown file. */
   private final String filename;
 
   public UnknownFileNotice(String filename) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGenerator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGenerator.java
@@ -103,7 +103,7 @@ public class NoticeSchemaGenerator {
     return schema;
   }
 
-  private static NoticeDocComments loadComments(Class<?> noticeClass) {
+  public static NoticeDocComments loadComments(Class<?> noticeClass) {
     String resourceName = NoticeDocComments.getResourceNameForClass(noticeClass);
     InputStream is = noticeClass.getResourceAsStream(resourceName);
     if (is == null) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest.java
@@ -66,17 +66,30 @@ public class NoticeSchemaGeneratorTest {
     assertThat(schema.getFields())
         .containsExactly(
             "childFieldName",
-            new FieldSchema(FieldTypeSchema.STRING, "childFieldName", null),
+            new FieldSchema(
+                FieldTypeSchema.STRING,
+                "childFieldName",
+                "The name of the field that makes reference."),
             "childFilename",
-            new FieldSchema(FieldTypeSchema.STRING, "childFilename", null),
+            new FieldSchema(
+                FieldTypeSchema.STRING,
+                "childFilename",
+                "The name of the file from which reference is made."),
             "csvRowNumber",
-            new FieldSchema(FieldTypeSchema.INTEGER, "csvRowNumber", null),
+            new FieldSchema(
+                FieldTypeSchema.INTEGER, "csvRowNumber", "The row of the faulty record."),
             "fieldValue",
-            new FieldSchema(FieldTypeSchema.STRING, "fieldValue", null),
+            new FieldSchema(FieldTypeSchema.STRING, "fieldValue", "The faulty record's value."),
             "parentFieldName",
-            new FieldSchema(FieldTypeSchema.STRING, "parentFieldName", null),
+            new FieldSchema(
+                FieldTypeSchema.STRING,
+                "parentFieldName",
+                "The name of the field that is referred to."),
             "parentFilename",
-            new FieldSchema(FieldTypeSchema.STRING, "parentFilename", null));
+            new FieldSchema(
+                FieldTypeSchema.STRING,
+                "parentFilename",
+                "The name of the file that is referred to."));
   }
 
   @Test

--- a/core/src/test/resources/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest-generateJsonSchemaForNotice_duplicateKeyNotice.json
+++ b/core/src/test/resources/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest-generateJsonSchemaForNotice_duplicateKeyNotice.json
@@ -16,30 +16,37 @@
   "properties": {
     "fieldName1": {
       "fieldName": "fieldName1",
+      "description": "Composite key\u0027s first field name.",
       "type": "string"
     },
     "fieldName2": {
       "fieldName": "fieldName2",
+      "description": "Composite key\u0027s second field name.",
       "type": "string"
     },
     "fieldValue1": {
       "fieldName": "fieldValue1",
+      "description": "Composite key\u0027s first value.",
       "type": "object"
     },
     "fieldValue2": {
       "fieldName": "fieldValue2",
+      "description": "Composite key\u0027s second value.",
       "type": "object"
     },
     "filename": {
       "fieldName": "filename",
+      "description": "The name of the faulty file",
       "type": "string"
     },
     "newCsvRowNumber": {
       "fieldName": "newCsvRowNumber",
+      "description": "The row of the other occurrence.",
       "type": "integer"
     },
     "oldCsvRowNumber": {
       "fieldName": "oldCsvRowNumber",
+      "description": "The row of the first occurrence.",
       "type": "integer"
     }
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidator.java
@@ -124,13 +124,13 @@ public class AgencyConsistencyValidator extends FileValidator {
       })
   static class InconsistentAgencyLangNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
-    // Expected language.
+    /** Expected language. */
     private final String expected;
 
-    // Faulty record's language.
+    /** Faulty record's language. */
     private final String actual;
 
     InconsistentAgencyLangNotice(int csvRowNumber, String expected, String actual) {
@@ -149,13 +149,13 @@ public class AgencyConsistencyValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsAgencySchema.class))
   static class InconsistentAgencyTimezoneNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
-    // Expected timezone.
+    /** Expected timezone. */
     private final String expected;
 
-    // Faulty record's timezone.
+    /** Faulty record's timezone. */
     private final String actual;
 
     InconsistentAgencyTimezoneNotice(int csvRowNumber, String expected, String actual) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/AttributionWithoutRoleValidator.java
@@ -59,10 +59,10 @@ public class AttributionWithoutRoleValidator extends SingleEntityValidator<GtfsA
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsAttributionSchema.class))
   static class AttributionWithoutRoleNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String attributionId;
 
     AttributionWithoutRoleNotice(int csvRowNumber, String attributionId) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BlockTripsWithOverlappingStopTimesValidator.java
@@ -276,25 +276,25 @@ public class BlockTripsWithOverlappingStopTimesValidator extends FileValidator {
     /** The row number from `trips.txt` of the first faulty trip. */
     private final int csvRowNumberA;
 
-    // The id of first faulty trip.
+    /** The id of first faulty trip. */
     private final String tripIdA;
 
-    // The service id of the first faulty trip.
+    /** The service id of the first faulty trip. */
     private final String serviceIdA;
 
-    // The row number from `trips.txt` of the second faulty trip.
+    /** The row number from `trips.txt` of the second faulty trip. */
     private final int csvRowNumberB;
 
-    // The id of the other faulty trip.
+    /** The id of the other faulty trip. */
     private final String tripIdB;
 
-    // The service id of the other faulty trip.
+    /** The service id of the other faulty trip. */
     private final String serviceIdB;
 
-    // The `trips.block_id` of the overlapping trip.
+    /** The `trips.block_id` of the overlapping trip. */
     private final String blockId;
 
-    // The overlapping period.
+    /** The overlapping period. */
     private final GtfsDate intersection;
 
     BlockTripsWithOverlappingStopTimesNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidator.java
@@ -106,7 +106,7 @@ public class DateTripsValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING)
   static class TripCoverageNotActiveForNext7DaysNotice extends ValidationNotice {
 
-    /** Current date (YYYYMMDD format) */
+    /** Current date (YYYYMMDD format). */
     private final GtfsDate currentDate;
 
     /** The start date of the majority service window. */

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidator.java
@@ -106,13 +106,13 @@ public class DateTripsValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING)
   static class TripCoverageNotActiveForNext7DaysNotice extends ValidationNotice {
 
-    // Current date (YYYYMMDD format)
+    /** Current date (YYYYMMDD format) */
     private final GtfsDate currentDate;
 
-    // The start date of the majority service window.
+    /** The start date of the majority service window. */
     private final GtfsDate serviceWindowStartDate;
 
-    // The end date of the majority service window.
+    /** The end date of the majority service window. */
     private final GtfsDate serviceWindowEndDate;
 
     TripCoverageNotActiveForNext7DaysNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareMediaValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateFareMediaValidator.java
@@ -47,16 +47,16 @@ public class DuplicateFareMediaValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsFareMediaSchema.class))
   static class DuplicateFareMediaNotice extends ValidationNotice {
 
-    // The row number of the first fare media.
+    /** The row number of the first fare media. */
     private final int csvRowNumber1;
 
-    // The id of the first fare media.
+    /** The id of the first fare media. */
     private final String fareMediaId1;
 
-    // The row number of the second fare media.
+    /** The row number of the second fare media. */
     private final int csvRowNumber2;
 
-    // The id of the second fare media.
+    /** The id of the second fare media. */
     private final String fareMediaId2;
 
     DuplicateFareMediaNotice(GtfsFareMedia lhs, GtfsFareMedia rhs) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -82,28 +82,28 @@ public class DuplicateRouteNameValidator extends FileValidator {
       bestPractices = @FileRefs(GtfsRouteSchema.class))
   static class DuplicateRouteNameNotice extends ValidationNotice {
 
-    // The row number of the first occurrence.
+    /** The row number of the first occurrence. */
     private final int csvRowNumber1;
 
-    // The id of the the first occurrence.
+    /** The id of the the first occurrence. */
     private final String routeId1;
 
-    // The row number of the other occurrence.
+    /** The row number of the other occurrence. */
     private final int csvRowNumber2;
 
-    // The id of the the other occurrence.
+    /** The id of the the other occurrence. */
     private final String routeId2;
 
-    // Common `routes.route_short_name`.
+    /** Common `routes.route_short_name`. */
     private final String routeShortName;
 
-    // Common `routes.route_long_name`.
+    /** Common `routes.route_long_name`. */
     private final String routeLongName;
 
-    // Common `routes.route_type`.
+    /** Common `routes.route_type`. */
     private final int routeTypeValue;
 
-    // Common `routes.agency_id`.
+    /** Common `routes.agency_id`. */
     private final String agencyId;
 
     DuplicateRouteNameNotice(GtfsRoute route1, GtfsRoute route2) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
@@ -75,10 +75,10 @@ public class ExpiredCalendarValidator extends FileValidator {
       })
   static class ExpiredCalendarNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
-    // The service id of the faulty record.
+    /** The service id of the faulty record. */
     private final String serviceId;
 
     ExpiredCalendarNotice(int csvRowNumber, String serviceId) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleDurationLimitTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleDurationLimitTypeValidator.java
@@ -36,7 +36,7 @@ public class FareTransferRuleDurationLimitTypeValidator
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleDurationLimitWithoutTypeNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
     FareTransferRuleDurationLimitWithoutTypeNotice(int csvRowNumber) {
@@ -55,7 +55,7 @@ public class FareTransferRuleDurationLimitTypeValidator
   static class FareTransferRuleDurationLimitTypeWithoutDurationLimitNotice
       extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
     FareTransferRuleDurationLimitTypeWithoutDurationLimitNotice(int csvRowNumber) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleTransferCountValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FareTransferRuleTransferCountValidator.java
@@ -48,10 +48,10 @@ public class FareTransferRuleTransferCountValidator
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleInvalidTransferCountNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
-    // The transfer count value of the faulty record.
+    /** The transfer count value of the faulty record. */
     private final int transferCount;
 
     FareTransferRuleInvalidTransferCountNotice(int csvRowNumber, int transferCount) {
@@ -70,7 +70,7 @@ public class FareTransferRuleTransferCountValidator
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleMissingTransferCountNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
     FareTransferRuleMissingTransferCountNotice(int csvRowNumber) {
@@ -88,7 +88,7 @@ public class FareTransferRuleTransferCountValidator
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFareTransferRuleSchema.class))
   static class FareTransferRuleWithForbiddenTransferCountNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
     FareTransferRuleWithForbiddenTransferCountNotice(int csvRowNumber) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -81,16 +81,16 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
   @GtfsValidationNotice(severity = WARNING)
   static class FeedExpirationDate7DaysNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // Current date (YYYYMMDD format).
+    /** Current date (YYYYMMDD format). */
     private final GtfsDate currentDate;
 
-    // Feed end date (YYYYMMDD format).
+    /** Feed end date (YYYYMMDD format). */
     private final GtfsDate feedEndDate;
 
-    // Suggested expiration date (YYYYMMDD format).
+    /** Suggested expiration date (YYYYMMDD format). */
     private final GtfsDate suggestedExpirationDate;
 
     FeedExpirationDate7DaysNotice(
@@ -115,16 +115,16 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
       })
   static class FeedExpirationDate30DaysNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // Current date (YYYYMMDD format).
+    /** Current date (YYYYMMDD format). */
     private final GtfsDate currentDate;
 
-    // Feed end date (YYYYMMDD format).
+    /** Feed end date (YYYYMMDD format). */
     private final GtfsDate feedEndDate;
 
-    // Suggested expiration date (YYYYMMDD format).
+    /** Suggested expiration date (YYYYMMDD format). */
     private final GtfsDate suggestedExpirationDate;
 
     FeedExpirationDate30DaysNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -58,7 +58,7 @@ public class FeedServiceDateValidator extends SingleEntityValidator<GtfsFeedInfo
     /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    /** Either `feed_end_date` or `feed_start_date` */
+    /** Either `feed_end_date` or `feed_start_date`. */
     private final String fieldName;
 
     MissingFeedInfoDateNotice(int csvRowNumber, String fieldName) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceDateValidator.java
@@ -55,10 +55,10 @@ public class FeedServiceDateValidator extends SingleEntityValidator<GtfsFeedInfo
   @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsFeedInfoSchema.class))
   static class MissingFeedInfoDateNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // Either `feed_end_date` or `feed_start_date`
+    /** Either `feed_end_date` or `feed_start_date` */
     private final String fieldName;
 
     MissingFeedInfoDateNotice(int csvRowNumber, String fieldName) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationHasStopTimesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationHasStopTimesValidator.java
@@ -77,13 +77,13 @@ public class LocationHasStopTimesValidator extends FileValidator {
       files = @FileRefs({GtfsStopTimeSchema.class, GtfsStopSchema.class}))
   static class StopWithoutStopTimeNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty stop.
+    /** The id of the faulty stop. */
     private final String stopId;
 
-    // The name of the faulty stop.
+    /** The name of the faulty stop. */
     private final String stopName;
 
     StopWithoutStopTimeNotice(GtfsStop stop) {
@@ -100,16 +100,16 @@ public class LocationHasStopTimesValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class LocationWithUnexpectedStopTimeNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `stops.txt`.
+    /** The row number of the faulty record from `stops.txt`. */
     private final int csvRowNumber;
 
-    // The id of the faulty record from `stops.txt`.
+    /** The id of the faulty record from `stops.txt`. */
     private final String stopId;
 
-    // The `stops.stop_name` of the faulty record.
+    /** The `stops.stop_name` of the faulty record. */
     private final String stopName;
 
-    // The row number of the faulty record from `stop_times.txt`.
+    /** The row number of the faulty record from `stop_times.txt`. */
     private final long stopTimeCsvRowNumber;
 
     LocationWithUnexpectedStopTimeNotice(GtfsStop location, GtfsStopTime stopTime) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/LocationTypeSingleEntityValidator.java
@@ -85,16 +85,16 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
   @GtfsValidationNotice(severity = ERROR)
   static class StationWithParentStationNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String stopId;
 
-    // The stops.stop_name of the faulty record.
+    /** The stops.stop_name of the faulty record. */
     private final String stopName;
 
-    // Parent station's id.
+    /** Parent station's id. */
     private final String parentStation;
 
     StationWithParentStationNotice(
@@ -118,16 +118,16 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopSchema.class))
   static class LocationWithoutParentStationNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String stopId;
 
-    // The `stops.stop_name` of the faulty record.
+    /** The `stops.stop_name` of the faulty record. */
     private final String stopName;
 
-    // The `stops.location_type` of the faulty record.
+    /** The `stops.location_type` of the faulty record. */
     private final int locationType;
 
     LocationWithoutParentStationNotice(
@@ -150,13 +150,13 @@ public class LocationTypeSingleEntityValidator extends SingleEntityValidator<Gtf
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopSchema.class))
   static class PlatformWithoutParentStationNotice extends ValidationNotice {
 
-    // Row number of the faulty record.
+    /** Row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String stopId;
 
-    // The stop name of the faulty record.
+    /** The stop name of the faulty record. */
     private final String stopName;
 
     PlatformWithoutParentStationNotice(int csvRowNumber, String stopId, String stopName) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidator.java
@@ -101,19 +101,19 @@ public class MatchingFeedAndAgencyLangValidator extends FileValidator {
       files = @FileRefs({GtfsFeedInfoSchema.class, GtfsAgencySchema.class}))
   static class FeedInfoLangAndAgencyLangMismatchNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The agency id of the faulty record.
+    /** The agency id of the faulty record. */
     private final String agencyId;
 
-    // The agency name of the faulty record.
+    /** The agency name of the faulty record. */
     private final String agencyName;
 
-    // The agency language of the faulty record.
+    /** The agency language of the faulty record. */
     private final String agencyLang;
 
-    // The feed language of the faulty record.
+    /** The feed language of the faulty record. */
     private final String feedLang;
 
     FeedInfoLangAndAgencyLangMismatchNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingLevelIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingLevelIdValidator.java
@@ -81,13 +81,13 @@ public class MissingLevelIdValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsLevelSchema.class))
   static class MissingLevelIdNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty stop from `stops.txt`.
+    /** The id of the faulty stop from `stops.txt`. */
     private final String stopId;
 
-    // The name of the faulty stop from `stops.txt`.
+    /** The name of the faulty stop from `stops.txt`. */
     private final String stopName;
 
     MissingLevelIdNotice(GtfsStop stop) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -105,16 +105,16 @@ public class MissingTripEdgeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class MissingTripEdgeNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final int csvRowNumber;
 
-    // `stops.stop_sequence` of the faulty record.
+    /** `stops.stop_sequence` of the faulty record. */
     private final int stopSequence;
 
-    // The `trips.trip_id` of the faulty record.
+    /** The `trips.trip_id` of the faulty record. */
     private final String tripId;
 
-    // Name of the missing field.
+    /** Name of the missing field. */
     private final String specifiedField;
 
     MissingTripEdgeNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/OverlappingFrequencyValidator.java
@@ -76,19 +76,19 @@ public class OverlappingFrequencyValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsFrequencySchema.class))
   static class OverlappingFrequencyNotice extends ValidationNotice {
 
-    // The row number of the first frequency.
+    /** The row number of the first frequency. */
     private final long prevCsvRowNumber;
 
-    // The first frequency end time.
+    /** The first frequency end time. */
     private final GtfsTime prevEndTime;
 
-    // The overlapping frequency's row number.
+    /** The overlapping frequency's row number. */
     private final long currCsvRowNumber;
 
-    // The overlapping frequency's start time.
+    /** The overlapping frequency's start time. */
     private final GtfsTime currStartTime;
 
-    // The trip id associated to the first frequency.
+    /** The trip id associated to the first frequency. */
     private final String tripId;
 
     OverlappingFrequencyNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentLocationTypeValidator.java
@@ -96,31 +96,31 @@ public class ParentLocationTypeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopSchema.class))
   static class WrongParentLocationTypeNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String stopId;
 
-    // The faulty record's `stops.stop_name`.
+    /** The faulty record's `stops.stop_name`. */
     private final String stopName;
 
-    // The faulty record's `stops.location_type`.
+    /** The faulty record's `stops.location_type`. */
     private final int locationType;
 
-    // The row number of the faulty record's parent.
+    /** The row number of the faulty record's parent. */
     private final long parentCsvRowNumber;
 
-    // The id of the faulty record's parent station.
+    /** The id of the faulty record's parent station. */
     private final String parentStation;
 
-    // The stop name of the faulty record's parent.
+    /** The stop name of the faulty record's parent. */
     private final String parentStopName;
 
-    // The location type of the faulty record's parent.
+    /** The location type of the faulty record's parent. */
     private final int parentLocationType;
 
-    // The expected location type of the faulty record.
+    /** The expected location type of the faulty record. */
     private final int expectedLocationType;
 
     WrongParentLocationTypeNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayDanglingGenericNodeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayDanglingGenericNodeValidator.java
@@ -81,16 +81,16 @@ public class PathwayDanglingGenericNodeValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsPathwaySchema.class))
   static class PathwayDanglingGenericNodeNotice extends ValidationNotice {
 
-    // Row number of the dangling generic node.
+    /** Row number of the dangling generic node. */
     private final int csvRowNumber;
 
-    // The id of the dangling generic node.
+    /** The id of the dangling generic node. */
     private final String stopId;
 
-    // The stop name of the dangling generic node.
+    /** The stop name of the dangling generic node. */
     private final String stopName;
 
-    // The parent station of the dangling generic node.
+    /** The parent station of the dangling generic node. */
     private final String parentStation;
 
     PathwayDanglingGenericNodeNotice(GtfsStop genericNode) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayEndpointTypeValidator.java
@@ -91,16 +91,16 @@ public class PathwayEndpointTypeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsPathwaySchema.class))
   static class PathwayToWrongLocationTypeNotice extends ValidationNotice {
 
-    // The row of the faulty row.
+    /** The row of the faulty row. */
     private final int csvRowNumber;
 
-    // The id of the faulty pathway.
+    /** The id of the faulty pathway. */
     private final String pathwayId;
 
-    // The station id field name.
+    /** The station id field name. */
     private final String fieldName;
 
-    // The id of the endpoint station.
+    /** The id of the endpoint station. */
     private final String stopId;
 
     PathwayToWrongLocationTypeNotice(GtfsPathway pathway, String fieldName, String stopId) {
@@ -116,16 +116,16 @@ public class PathwayEndpointTypeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsPathwaySchema.class))
   static class PathwayToPlatformWithBoardingAreasNotice extends ValidationNotice {
 
-    // The row of the faulty row.
+    /** The row of the faulty row. */
     private final int csvRowNumber;
 
-    // The id of the faulty pathway.
+    /** The id of the faulty pathway. */
     private final String pathwayId;
 
-    // The platform id field name.
+    /** The platform id field name. */
     private final String fieldName;
 
-    // The id of the endpoint platform.
+    /** The id of the endpoint platform. */
     private final String stopId;
 
     PathwayToPlatformWithBoardingAreasNotice(GtfsPathway pathway, String fieldName, String stopId) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayLoopValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayLoopValidator.java
@@ -42,13 +42,15 @@ public class PathwayLoopValidator extends SingleEntityValidator<GtfsPathway> {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsPathwaySchema.class))
   static class PathwayLoopNotice extends ValidationNotice {
 
-    // Row number of the faulty row from `pathways.txt`.
+    /** Row number of the faulty row from `pathways.txt`. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String pathwayId;
 
-    // The `pathway.stop_id` that is repeated in `pathways.from_stop_id` and `pathways.to_stop_id`.
+    /**
+     * The `pathway.stop_id` that is repeated in `pathways.from_stop_id` and `pathways.to_stop_id`.
+     */
     private final String stopId;
 
     PathwayLoopNotice(GtfsPathway pathway) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PathwayReachableLocationValidator.java
@@ -168,25 +168,25 @@ public class PathwayReachableLocationValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsPathwaySchema.class))
   static class PathwayUnreachableLocationNotice extends ValidationNotice {
 
-    // Row number of the unreachable location.
+    /** Row number of the unreachable location. */
     private final int csvRowNumber;
 
-    // The id of the unreachable location.
+    /** The id of the unreachable location. */
     private final String stopId;
 
-    // The stop name of the unreachable location.
+    /** The stop name of the unreachable location. */
     private final String stopName;
 
-    // The type of the unreachable location.
+    /** The type of the unreachable location. */
     private final int locationType;
 
-    // The parent of the unreachable location.
+    /** The parent of the unreachable location. */
     private final String parentStation;
 
-    // Whether the location is reachable from entrances.
+    /** Whether the location is reachable from entrances. */
     private final boolean hasEntrance;
 
-    // Whether some exit can be reached from the location.
+    /** Whether some exit can be reached from the location. */
     private final boolean hasExit;
 
     PathwayUnreachableLocationNotice(GtfsStop location, boolean hasEntrance, boolean hasExit) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteColorContrastValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteColorContrastValidator.java
@@ -77,16 +77,16 @@ public class RouteColorContrastValidator extends SingleEntityValidator<GtfsRoute
       })
   static class RouteColorContrastNotice extends ValidationNotice {
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String routeId;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's HTML route color.
+    /** The faulty record's HTML route color. */
     private final GtfsColor routeColor;
 
-    // The faulty record's HTML route text color.
+    /** The faulty record's HTML route text color. */
     private final GtfsColor routeTextColor;
 
     RouteColorContrastNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/RouteNameValidator.java
@@ -102,10 +102,10 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsRouteSchema.class))
   static class RouteBothShortAndLongNameMissingNotice extends ValidationNotice {
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String routeId;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
     RouteBothShortAndLongNameMissingNotice(String routeId, int csvRowNumber) {
@@ -123,16 +123,16 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
   @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsRouteSchema.class))
   static class RouteLongNameContainsShortNameNotice extends ValidationNotice {
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String routeId;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's `route_short_name`.
+    /** The faulty record's `route_short_name`. */
     private final String routeShortName;
 
-    // The faulty record's `route_long_name`.
+    /** The faulty record's `route_long_name`. */
     private final String routeLongName;
 
     RouteLongNameContainsShortNameNotice(
@@ -154,13 +154,13 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
   @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsRouteSchema.class))
   static class RouteShortNameTooLongNotice extends ValidationNotice {
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String routeId;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's `route_short_name`.
+    /** The faulty record's `route_short_name`. */
     private final String routeShortName;
 
     RouteShortNameTooLongNotice(String routeId, int csvRowNumber, String routeShortName) {
@@ -180,16 +180,16 @@ public class RouteNameValidator extends SingleEntityValidator<GtfsRoute> {
   @GtfsValidationNotice(severity = WARNING)
   static class SameNameAndDescriptionForRouteNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String routeId;
 
-    // The `routes.routes_desc` of the faulty record.
+    /** The `routes.routes_desc` of the faulty record. */
     private final String routeDesc;
 
-    // Either `route_short_name` or `route_long_name`.
+    /** Either `route_short_name` or `route_long_name`. */
     private final String specifiedField;
 
     SameNameAndDescriptionForRouteNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -111,8 +111,10 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
     /** The row number from `shapes.txt` of the previous shape point. */
     private final long prevCsvRowNumber;
 
-    // Actual distance traveled along the shape from the first shape point to the previous shape
-    /** point. */
+    /**
+     * Actual distance traveled along the shape from the first shape point to the previous shape
+     * point.
+     */
     private final double prevShapeDistTraveled;
 
     /** The previous record's `shapes.shape_pt_sequence`. */
@@ -158,8 +160,10 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
     /** The row number from `shapes.txt` of the previous shape point. */
     private final long prevCsvRowNumber;
 
-    // Actual distance traveled along the shape from the first shape point to the previous shape
-    /** point. */
+    /**
+     * Actual distance traveled along the shape from the first shape point to the previous shape
+     * point.
+     */
     private final double prevShapeDistTraveled;
 
     /** The previous record's `shapes.shape_pt_sequence`. */

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -96,26 +96,26 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsShapeSchema.class))
   static class DecreasingShapeDistanceNotice extends ValidationNotice {
 
-    // The id of the faulty shape.
+    /** The id of the faulty shape. */
     private final String shapeId;
 
-    // The row number from `shapes.txt`.
+    /** The row number from `shapes.txt`. */
     private final int csvRowNumber;
 
-    // Actual distance traveled along the shape from the first shape point to the faulty record.
+    /** Actual distance traveled along the shape from the first shape point to the faulty record. */
     private final double shapeDistTraveled;
 
-    // The faulty record's `shapes.shape_pt_sequence`.
+    /** The faulty record's `shapes.shape_pt_sequence`. */
     private final int shapePtSequence;
 
-    // The row number from `shapes.txt` of the previous shape point.
+    /** The row number from `shapes.txt` of the previous shape point. */
     private final long prevCsvRowNumber;
 
     // Actual distance traveled along the shape from the first shape point to the previous shape
-    // point.
+    /** point. */
     private final double prevShapeDistTraveled;
 
-    // The previous record's `shapes.shape_pt_sequence`.
+    /** The previous record's `shapes.shape_pt_sequence`. */
     private final int prevShapePtSequence;
 
     DecreasingShapeDistanceNotice(GtfsShape current, GtfsShape previous) {
@@ -143,26 +143,26 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsShapeSchema.class))
   static class EqualShapeDistanceSameCoordinatesNotice extends ValidationNotice {
 
-    // The id of the faulty shape.
+    /** The id of the faulty shape. */
     private final String shapeId;
 
-    // The row number from `shapes.txt`.
+    /** The row number from `shapes.txt`. */
     private final int csvRowNumber;
 
-    // Actual distance traveled along the shape from the first shape point to the faulty record.
+    /** Actual distance traveled along the shape from the first shape point to the faulty record. */
     private final double shapeDistTraveled;
 
-    // The faulty record's `shapes.shape_pt_sequence`.
+    /** The faulty record's `shapes.shape_pt_sequence`. */
     private final int shapePtSequence;
 
-    // The row number from `shapes.txt` of the previous shape point.
+    /** The row number from `shapes.txt` of the previous shape point. */
     private final long prevCsvRowNumber;
 
     // Actual distance traveled along the shape from the first shape point to the previous shape
-    // point.
+    /** point. */
     private final double prevShapeDistTraveled;
 
-    // The previous record's `shapes.shape_pt_sequence`.
+    /** The previous record's `shapes.shape_pt_sequence`. */
     private final int prevShapePtSequence;
 
     EqualShapeDistanceSameCoordinatesNotice(GtfsShape previous, GtfsShape current) {
@@ -189,29 +189,29 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsShapeSchema.class))
   static class EqualShapeDistanceDiffCoordinatesNotice extends ValidationNotice {
 
-    // The id of the faulty shape.
+    /** The id of the faulty shape. */
     private final String shapeId;
 
-    // The row number from `shapes.txt`.
+    /** The row number from `shapes.txt`. */
     private final int csvRowNumber;
 
-    // The faulty record's `shape_dist_traveled` value.
+    /** The faulty record's `shape_dist_traveled` value. */
     private final double shapeDistTraveled;
 
-    // The faulty record's `shapes.shape_pt_sequence`.
+    /** The faulty record's `shapes.shape_pt_sequence`. */
     private final int shapePtSequence;
 
-    // The row number from `shapes.txt` of the previous shape point.
+    /** The row number from `shapes.txt` of the previous shape point. */
     private final long prevCsvRowNumber;
 
-    // The previous shape point's `shape_dist_traveled` value.
+    /** The previous shape point's `shape_dist_traveled` value. */
     private final double prevShapeDistTraveled;
 
-    // The previous record's `shapes.shape_pt_sequence`.
+    /** The previous record's `shapes.shape_pt_sequence`. */
     private final int prevShapePtSequence;
 
     // Actual distance traveled along the shape from the first shape point to the previous shape
-    // point.
+    /** point. */
     private final double actualDistanceBetweenShapePoints;
 
     EqualShapeDistanceDiffCoordinatesNotice(GtfsShape previous, GtfsShape current) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
@@ -250,28 +250,28 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       files = @FileRefs({GtfsTripSchema.class, GtfsStopTimeSchema.class, GtfsStopSchema.class}))
   static class StopHasTooManyMatchesForShapeNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `trips.txt`.
+    /** The row number of the faulty record from `trips.txt`. */
     private final long tripCsvRowNumber;
 
-    // The id of the shape that is referred to.
+    /** The id of the shape that is referred to. */
     private final String shapeId;
 
-    // The id of the trip that is referred to.
+    /** The id of the trip that is referred to. */
     private final String tripId;
 
-    // The row number of the faulty record from `stop_times.txt`.
+    /** The row number of the faulty record from `stop_times.txt`. */
     private final long stopTimeCsvRowNumber;
 
-    // The id of the stop that is referred to.
+    /** The id of the stop that is referred to. */
     private final String stopId;
 
-    // The name of the stop that is referred to.
+    /** The name of the stop that is referred to. */
     private final String stopName;
 
-    // Latitude and longitude pair of the location.
+    /** Latitude and longitude pair of the location. */
     private final S2LatLng match;
 
-    // The number of matches for the stop that is referred to.
+    /** The number of matches for the stop that is referred to. */
     private final int matchCount;
 
     StopHasTooManyMatchesForShapeNotice(
@@ -300,28 +300,28 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       files = @FileRefs({GtfsTripSchema.class, GtfsStopTimeSchema.class, GtfsStopSchema.class}))
   static class StopTooFarFromShapeUsingUserDistanceNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `trips.txt`.
+    /** The row number of the faulty record from `trips.txt`. */
     private final long tripCsvRowNumber;
 
-    // The id of the shape that is referred to.
+    /** The id of the shape that is referred to. */
     private final String shapeId;
 
-    // The id of the trip that is referred to.
+    /** The id of the trip that is referred to. */
     private final String tripId;
 
-    // The row number of the faulty record from `stop_times.txt`.
+    /** The row number of the faulty record from `stop_times.txt`. */
     private final long stopTimeCsvRowNumber;
 
-    // The id of the stop that is referred to.
+    /** The id of the stop that is referred to. */
     private final String stopId;
 
-    // The name of the stop that is referred to.
+    /** The name of the stop that is referred to. */
     private final String stopName;
 
-    // Latitude and longitude pair of the location.
+    /** Latitude and longitude pair of the location. */
     private final S2LatLng match;
 
-    // Distance from stop to shape.
+    /** Distance from stop to shape. */
     private final double geoDistanceToShape;
 
     StopTooFarFromShapeUsingUserDistanceNotice(
@@ -351,28 +351,28 @@ public class ShapeToStopMatchingValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsShapeSchema.class))
   static class StopTooFarFromShapeNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `trips.txt`.
+    /** The row number of the faulty record from `trips.txt`. */
     private final long tripCsvRowNumber;
 
-    // The id of the shape that is referred to.
+    /** The id of the shape that is referred to. */
     private final String shapeId;
 
-    // The id of the trip that is referred to.
+    /** The id of the trip that is referred to. */
     private final String tripId;
 
-    // The row number of the faulty record from `stop_times.txt`.
+    /** The row number of the faulty record from `stop_times.txt`. */
     private final long stopTimeCsvRowNumber;
 
-    // The id of the stop that is referred to.
+    /** The id of the stop that is referred to. */
     private final String stopId;
 
-    // The name of the stop that is referred to.
+    /** The name of the stop that is referred to. */
     private final String stopName;
 
-    // Latitude and longitude pair of the location.
+    /** Latitude and longitude pair of the location. */
     private final S2LatLng match;
 
-    // Distance from stop to shape.
+    /** Distance from stop to shape. */
     private final double geoDistanceToShape;
 
     StopTooFarFromShapeNotice(
@@ -405,37 +405,37 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       files = @FileRefs({GtfsTripSchema.class, GtfsStopTimeSchema.class, GtfsStopSchema.class}))
   static class StopsMatchShapeOutOfOrderNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `trips.txt`.
+    /** The row number of the faulty record from `trips.txt`. */
     private final long tripCsvRowNumber;
 
-    // The id of the shape that is referred to.
+    /** The id of the shape that is referred to. */
     private final String shapeId;
 
-    // The id of the trip that is referred to.
+    /** The id of the trip that is referred to. */
     private final String tripId;
 
-    // The row number of the first faulty record from `stop_times.txt`.
+    /** The row number of the first faulty record from `stop_times.txt`. */
     private final long stopTimeCsvRowNumber1;
 
-    // The id of the first stop that is referred to.
+    /** The id of the first stop that is referred to. */
     private final String stopId1;
 
-    // The name of the first stop that is referred to.
+    /** The name of the first stop that is referred to. */
     private final String stopName1;
 
-    // Latitude and longitude pair of the first matching location.
+    /** Latitude and longitude pair of the first matching location. */
     private final S2LatLng match1;
 
-    // The row number of the second faulty record from `stop_times.txt`.
+    /** The row number of the second faulty record from `stop_times.txt`. */
     private final long stopTimeCsvRowNumber2;
 
-    // The id of the second stop that is referred to.
+    /** The id of the second stop that is referred to. */
     private final String stopId2;
 
-    // The name of the second stop that is referred to.
+    /** The name of the second stop that is referred to. */
     private final String stopName2;
 
-    // Latitude and longitude pair of the second matching location.
+    /** Latitude and longitude pair of the second matching location. */
     private final S2LatLng match2;
 
     public StopsMatchShapeOutOfOrderNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeUsageValidator.java
@@ -68,10 +68,10 @@ public class ShapeUsageValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING)
   static class UnusedShapeNotice extends ValidationNotice {
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String shapeId;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
     UnusedShapeNotice(String shapeId, int csvRowNumber) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopNameValidator.java
@@ -78,13 +78,13 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopSchema.class))
   static class MissingStopNameNotice extends ValidationNotice {
 
-    // The row of the faulty record.
+    /** The row of the faulty record. */
     private final long csvRowNumber;
 
-    // `stops.location_type` of the faulty record.
+    /** `stops.location_type` of the faulty record. */
     private GtfsLocationType locationType;
 
-    // The `stops.stop_id` of the faulty record.
+    /** The `stops.stop_id` of the faulty record. */
     private final String stopId;
 
     MissingStopNameNotice(long csvRowNumber, String stopId, GtfsLocationType locationType) {
@@ -106,13 +106,13 @@ public class StopNameValidator extends SingleEntityValidator<GtfsStop> {
   @GtfsValidationNotice(severity = WARNING)
   static class SameNameAndDescriptionForStopNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The id of the faulty record.
+    /** The id of the faulty record. */
     private final String stopId;
 
-    // The faulty record's `stop_desc`.
+    /** The faulty record's `stop_desc`. */
     private final String stopDesc;
 
     SameNameAndDescriptionForStopNotice(int csvRowNumber, String stopId, String stopDesc) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopRequiredLocationValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopRequiredLocationValidator.java
@@ -47,13 +47,13 @@ public class StopRequiredLocationValidator extends SingleEntityValidator<GtfsSto
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopSchema.class))
   static class StopWithoutLocationNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's `stops.location_type`.
+    /** The faulty record's `stops.location_type`. */
     private final GtfsLocationType locationType;
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String stopId;
 
     StopWithoutLocationNotice(int csvRowNumber, String stopId, GtfsLocationType type) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeArrivalAndDepartureTimeValidator.java
@@ -107,19 +107,19 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
       })
   static class StopTimeWithArrivalBeforePreviousDepartureTimeNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The row of the previous stop time.
+    /** The row of the previous stop time. */
     private final long prevCsvRowNumber;
 
-    // The trip_id associated to the faulty record.
+    /** The trip_id associated to the faulty record. */
     private final String tripId;
 
-    // Arrival time at the faulty record.
+    /** Arrival time at the faulty record. */
     private final GtfsTime arrivalTime;
 
-    // Departure time at the previous stop time.
+    /** Departure time at the previous stop time. */
     private final GtfsTime departureTime;
 
     StopTimeWithArrivalBeforePreviousDepartureTimeNotice(
@@ -145,16 +145,16 @@ public class StopTimeArrivalAndDepartureTimeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class StopTimeWithOnlyArrivalOrDepartureTimeNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The trip_id associated to the faulty record.
+    /** The trip_id associated to the faulty record. */
     private final String tripId;
 
-    // The sequence of the faulty stop.
+    /** The sequence of the faulty stop. */
     private final int stopSequence;
 
-    // Either `arrival_time` or `departure_time`
+    /** Either `arrival_time` or `departure_time` */
     private final String specifiedField;
 
     StopTimeWithOnlyArrivalOrDepartureTimeNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -96,8 +96,10 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
     /** The row number from `stop_times.txt` of the previous stop time. */
     private final long prevCsvRowNumber;
 
-    // Actual distance traveled along the shape from the first shape point to the previous stop
-    /** time. */
+    /**
+     * Actual distance traveled along the shape from the first shape point to the previous stop
+     * time.
+     */
     private final double prevStopTimeDistTraveled;
 
     /** The previous record's `stop_times.stop_sequence`. */

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -81,26 +81,26 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class DecreasingOrEqualStopTimeDistanceNotice extends ValidationNotice {
 
-    // The id of the faulty trip.
+    /** The id of the faulty trip. */
     private final String tripId;
 
-    // The row number from `stop_times.txt`.
+    /** The row number from `stop_times.txt`. */
     private final int csvRowNumber;
 
-    // Actual distance traveled along the shape from the first shape point to the faulty record.
+    /** Actual distance traveled along the shape from the first shape point to the faulty record. */
     private final double shapeDistTraveled;
 
-    // The faulty record's `stop_times.stop_sequence`.
+    /** The faulty record's `stop_times.stop_sequence`. */
     private final int stopSequence;
 
-    // The row number from `stop_times.txt` of the previous stop time.
+    /** The row number from `stop_times.txt` of the previous stop time. */
     private final long prevCsvRowNumber;
 
     // Actual distance traveled along the shape from the first shape point to the previous stop
-    // time.
+    /** time. */
     private final double prevStopTimeDistTraveled;
 
-    // The previous record's `stop_times.stop_sequence`.
+    /** The previous record's `stop_times.stop_sequence`. */
     private final int prevStopSequence;
 
     DecreasingOrEqualStopTimeDistanceNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -341,49 +341,49 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
       })
   static class FastTravelBetweenConsecutiveStopsNotice extends ValidationNotice {
 
-    // The row number of the problematic trip.
+    /** The row number of the problematic trip. */
     private final long tripCsvRowNumber;
 
-    // `trip_id` of the problematic trip.
+    /** `trip_id` of the problematic trip. */
     private final String tripId;
 
-    // `route_id` of the problematic trip.
+    /** `route_id` of the problematic trip. */
     private final String routeId;
 
-    // Travel speed (km/h).
+    /** Travel speed (km/h). */
     private final double speedKph;
 
-    // Distance between stops (km).
+    /** Distance between stops (km). */
     private final double distanceKm;
 
-    // The row number of the first stop time.
+    /** The row number of the first stop time. */
     private final int csvRowNumber1;
 
-    // `stop_sequence` of the first stop.
+    /** `stop_sequence` of the first stop. */
     private final int stopSequence1;
 
-    // `stop_id` of the first stop.
+    /** `stop_id` of the first stop. */
     private final String stopId1;
 
-    // `stop_name` of the first stop.
+    /** `stop_name` of the first stop. */
     private final String stopName1;
 
-    // `departure_time` of the first stop.
+    /** `departure_time` of the first stop. */
     private final GtfsTime departureTime1;
 
-    // The row number of the second stop time.
+    /** The row number of the second stop time. */
     private final int csvRowNumber2;
 
-    // `stop_sequence` of the second stop.
+    /** `stop_sequence` of the second stop. */
     private final int stopSequence2;
 
-    // `stop_id` of the second stop.
+    /** `stop_id` of the second stop. */
     private final String stopId2;
 
-    // `stop_name` of the second stop.
+    /** `stop_name` of the second stop. */
     private final String stopName2;
 
-    // `arrival_time` of the second stop.
+    /** `arrival_time` of the second stop. */
     private final GtfsTime arrivalTime2;
 
     FastTravelBetweenConsecutiveStopsNotice(
@@ -428,49 +428,49 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
       })
   static class FastTravelBetweenFarStopsNotice extends ValidationNotice {
 
-    // The row number of the problematic trip.
+    /** The row number of the problematic trip. */
     private final long tripCsvRowNumber;
 
-    // `trip_id` of the problematic trip.
+    /** `trip_id` of the problematic trip. */
     private final String tripId;
 
-    // `route_id` of the problematic trip.
+    /** `route_id` of the problematic trip. */
     private final String routeId;
 
-    // Travel speed (km/h).
+    /** Travel speed (km/h). */
     private final double speedKph;
 
-    // Distance between stops (km).
+    /** Distance between stops (km). */
     private final double distanceKm;
 
-    // The row number of the first stop time.
+    /** The row number of the first stop time. */
     private final int csvRowNumber1;
 
-    // `stop_sequence` of the first stop.
+    /** `stop_sequence` of the first stop. */
     private final int stopSequence1;
 
-    // `stop_id` of the first stop.
+    /** `stop_id` of the first stop. */
     private final String stopId1;
 
-    // `stop_name` of the first stop.
+    /** `stop_name` of the first stop. */
     private final String stopName1;
 
-    // `departure_time` of the first stop.
+    /** `departure_time` of the first stop. */
     private final GtfsTime departureTime1;
 
-    // The row number of the second stop time.
+    /** The row number of the second stop time. */
     private final int csvRowNumber2;
 
-    // `stop_sequence` of the second stop.
+    /** `stop_sequence` of the second stop. */
     private final int stopSequence2;
 
-    // `stop_id` of the second stop.
+    /** `stop_id` of the second stop. */
     private final String stopId2;
 
-    // `stop_name` of the second stop.
+    /** `stop_name` of the second stop. */
     private final String stopName2;
 
-    // `arrival_time` of the second stop.
+    /** `arrival_time` of the second stop. */
     private final GtfsTime arrivalTime2;
 
     FastTravelBetweenFarStopsNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopZoneIdValidator.java
@@ -101,13 +101,13 @@ public class StopZoneIdValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopSchema.class))
   static class StopWithoutZoneIdNotice extends ValidationNotice {
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String stopId;
 
-    // The faulty record's `stops.stop_name`.
+    /** The faulty record's `stops.stop_name`. */
     private final String stopName;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
     StopWithoutZoneIdNotice(GtfsStop stop) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidator.java
@@ -93,16 +93,16 @@ public class TimepointTimeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsStopTimeSchema.class))
   static class StopTimeTimepointWithoutTimesNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String tripId;
 
-    // The faulty record's `stops.stop_sequence`.
+    /** The faulty record's `stops.stop_sequence`. */
     private final long stopSequence;
 
-    // Either `departure_time` or `arrival_time`.
+    /** Either `departure_time` or `arrival_time`. */
     private final String specifiedField;
 
     StopTimeTimepointWithoutTimesNotice(GtfsStopTime stopTime, String specifiedField) {
@@ -122,13 +122,13 @@ public class TimepointTimeValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopTimeSchema.class))
   static class MissingTimepointValueNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's `stop_times.trip_id`.
+    /** The faulty record's `stop_times.trip_id`. */
     private final String tripId;
 
-    // The faulty record's `stop_times.stop_sequence`.
+    /** The faulty record's `stop_times.stop_sequence`. */
     private final long stopSequence;
 
     MissingTimepointValueNotice(GtfsStopTime stopTime) {
@@ -147,7 +147,7 @@ public class TimepointTimeValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, bestPractices = @FileRefs(GtfsStopTimeSchema.class))
   static class MissingTimepointColumnNotice extends ValidationNotice {
 
-    // The name of the affected file.
+    /** The name of the affected file. */
     private final String filename;
 
     MissingTimepointColumnNotice() {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersInSeatTransferTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersInSeatTransferTypeValidator.java
@@ -143,19 +143,19 @@ public class TransfersInSeatTransferTypeValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING)
   public static class TransferWithSuspiciousMidTripInSeatNotice extends ValidationNotice {
 
-    // The row number from `transfers.txt` for the faulty entry.
+    /** The row number from `transfers.txt` for the faulty entry. */
     private final int csvRowNumber;
 
-    // The name of the trip id field (e.g. `from_trip_id`) referencing a trip.
+    /** The name of the trip id field (e.g. `from_trip_id`) referencing a trip. */
     private final String tripIdFieldName;
 
-    // The referenced trip id.
+    /** The referenced trip id. */
     private final String tripId;
 
-    // The name of the stop id field (e.g. `from_stop_id`) referencing the stop.
+    /** The name of the stop id field (e.g. `from_stop_id`) referencing the stop. */
     private final String stopIdFieldName;
 
-    // The referenced stop id.
+    /** The referenced stop id. */
     private final String stopId;
 
     public TransferWithSuspiciousMidTripInSeatNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersStopTypeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersStopTypeValidator.java
@@ -79,19 +79,19 @@ public class TransfersStopTypeValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTransferSchema.class))
   public static final class TransferWithInvalidStopLocationTypeNotice extends ValidationNotice {
 
-    // The row number from `transfers.txt` for the faulty entry.
+    /** The row number from `transfers.txt` for the faulty entry. */
     private final int csvRowNumber;
 
-    // The name of the stop id field (e.g. `from_stop_id`) referencing the stop.
+    /** The name of the stop id field (e.g. `from_stop_id`) referencing the stop. */
     private final String stopIdFieldName;
 
-    // The referenced stop id.
+    /** The referenced stop id. */
     private final String stopId;
 
-    // The numeric value of the invalid location type.
+    /** The numeric value of the invalid location type. */
     private final int locationTypeValue;
 
-    // The name of the invalid location type.
+    /** The name of the invalid location type. */
     private String locationTypeName;
 
     public TransferWithInvalidStopLocationTypeNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersTripReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransfersTripReferenceValidator.java
@@ -130,22 +130,22 @@ public class TransfersTripReferenceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTransferSchema.class))
   public static class TransferWithInvalidTripAndRouteNotice extends ValidationNotice {
 
-    // The row number from `transfers.txt` for the faulty entry.
+    /** The row number from `transfers.txt` for the faulty entry. */
     private final int csvRowNumber;
 
-    // The name of the trip id field (e.g. `from_trip_id`) referencing a trip.
+    /** The name of the trip id field (e.g. `from_trip_id`) referencing a trip. */
     private final String tripFieldName;
 
-    // The referenced trip id.
+    /** The referenced trip id. */
     private final String tripId;
 
-    // The name of the route id field (e.g. `from_route_id`) referencing the route.
+    /** The name of the route id field (e.g. `from_route_id`) referencing the route. */
     private final String routeFieldName;
 
-    // The referenced route id.
+    /** The referenced route id. */
     private final String routeId;
 
-    // The expected route id from `trips.txt`.
+    /** The expected route id from `trips.txt`. */
     private final String expectedRouteId;
 
     public TransferWithInvalidTripAndRouteNotice(
@@ -169,19 +169,19 @@ public class TransfersTripReferenceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTransferSchema.class))
   public static class TransferWithInvalidTripAndStopNotice extends ValidationNotice {
 
-    // The row number from `transfers.txt` for the faulty entry.
+    /** The row number from `transfers.txt` for the faulty entry. */
     private final int csvRowNumber;
 
-    // The name of the trip id field (e.g. `from_trip_id`) referencing a trip.
+    /** The name of the trip id field (e.g. `from_trip_id`) referencing a trip. */
     private final String tripFieldName;
 
-    // The referenced trip id.
+    /** The referenced trip id. */
     private final String tripId;
 
-    // The name of the stop id field (e.g. `stop_route_id`) referencing the stop.
+    /** The name of the stop id field (e.g. `stop_route_id`) referencing the stop. */
     private final String stopFieldName;
 
-    // The referenced stop id.
+    /** The referenced stop id. */
     private final String stopId;
 
     public TransferWithInvalidTripAndStopNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -197,13 +197,13 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTranslationSchema.class))
   static class TranslationUnexpectedValueNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The name of the field that was expected to be empty.
+    /** The name of the field that was expected to be empty. */
     private final String fieldName;
 
-    // Actual value of the field that was expected to be empty.
+    /** Actual value of the field that was expected to be empty. */
     private final String fieldValue;
 
     TranslationUnexpectedValueNotice(
@@ -219,10 +219,10 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsTranslationSchema.class))
   static class TranslationUnknownTableNameNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // `table_name` of the faulty record.
+    /** `table_name` of the faulty record. */
     private final String tableName;
 
     TranslationUnknownTableNameNotice(GtfsTranslation translation) {
@@ -239,16 +239,16 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
   @GtfsValidationNotice(severity = ERROR, files = @FileRefs(GtfsTranslationSchema.class))
   static class TranslationForeignKeyViolationNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // `table_name` of the faulty record.
+    /** `table_name` of the faulty record. */
     private final String tableName;
 
-    // `record_id` of the faulty record.
+    /** `record_id` of the faulty record. */
     private final String recordId;
 
-    // `record_sub_id` of the faulty record.
+    /** `record_sub_id` of the faulty record. */
     private final String recordSubId;
 
     TranslationForeignKeyViolationNotice(GtfsTranslation translation) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsabilityValidator.java
@@ -64,10 +64,10 @@ public class TripUsabilityValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING)
   static class UnusableTripNotice extends ValidationNotice {
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String tripId;
 
     UnusableTripNotice(int csvRowNumber, String tripId) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripUsageValidator.java
@@ -79,10 +79,10 @@ public class TripUsageValidator extends FileValidator {
       })
   static class UnusedTripNotice extends ValidationNotice {
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String tripId;
 
-    // The row number of the faulty record.
+    /** The row number of the faulty record. */
     private final int csvRowNumber;
 
     UnusedTripNotice(String tripId, int csvRowNumber) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/UrlConsistencyValidator.java
@@ -131,19 +131,19 @@ public class UrlConsistencyValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopSchema.class))
   static class SameStopAndRouteUrlNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `stops.txt`.
+    /** The row number of the faulty record from `stops.txt`. */
     private final long stopCsvRowNumber;
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String stopId;
 
-    // The duplicate URL value.
+    /** The duplicate URL value. */
     private final String stopUrl;
 
-    // The faulty record's id from `routes.txt.
+    /** The faulty record's id from `routes.txt. */
     private final String routeId;
 
-    // The row number of the faulty record from `routes.txt`.
+    /** The row number of the faulty record from `routes.txt`. */
     private final long routeCsvRowNumber;
 
     SameStopAndRouteUrlNotice(GtfsStop stop, GtfsRoute route) {
@@ -165,19 +165,19 @@ public class UrlConsistencyValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsRouteSchema.class))
   static class SameRouteAndAgencyUrlNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `routes.txt`.
+    /** The row number of the faulty record from `routes.txt`. */
     private final long routeCsvRowNumber;
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String routeId;
 
-    // The faulty record's referenced agency name.
+    /** The faulty record's referenced agency name. */
     private final String agencyName;
 
-    // The duplicate URL value
+    /** The duplicate URL value */
     private final String routeUrl;
 
-    // The row number of the faulty record from `agency.txt`.
+    /** The row number of the faulty record from `agency.txt`. */
     private final long agencyCsvRowNumber;
 
     SameRouteAndAgencyUrlNotice(GtfsRoute route, GtfsAgency agency) {
@@ -198,19 +198,19 @@ public class UrlConsistencyValidator extends FileValidator {
   @GtfsValidationNotice(severity = WARNING, files = @FileRefs(GtfsStopSchema.class))
   static class SameStopAndAgencyUrlNotice extends ValidationNotice {
 
-    // The row number of the faulty record from `stops.txt`.
+    /** The row number of the faulty record from `stops.txt`. */
     private final long stopCsvRowNumber;
 
-    // The faulty record's id.
+    /** The faulty record's id. */
     private final String stopId;
 
-    // The faulty record's `agency.agency_name`.
+    /** The faulty record's `agency.agency_name`. */
     private final String agencyName;
 
-    // The duplicate URL value.
+    /** The duplicate URL value. */
     private final String stopUrl;
 
-    // The row number of the faulty record from `agency.txt`.
+    /** The row number of the faulty record from `agency.txt`. */
     private final long agencyCsvRowNumber;
 
     SameStopAndAgencyUrlNotice(GtfsStop stop, GtfsAgency agency) {


### PR DESCRIPTION
As part of the larger Notice documentation refactor (#1324), PR #1365 added support for extracting field documentation from Javadoc comments (aka /** */ comment style).  Critically, most of the field comments use // after I added them in bulk in PR #1346.  This PR switches the style to /** */.

It also adds a unit-test to enforce that each Notice field specifies a comment of this format.

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
