### PR TITLE
Fix: Update slack links

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -4,7 +4,7 @@
 
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  Thanks for opening your first issue in this project! If you haven't already, you can [join our slack](https://docs.google.com/forms/d/e/1FAIpQLSczZbZB9ql_Xl-1uBtmvYmA0fwfm1UX92SyWAdkuMEDfxac5w/viewform) and join the #gtfs-validators channel to meet our awesome community. Come say hi :wave:!
+  Thanks for opening your first issue in this project! If you haven't already, you can [join our slack](https://share.mobilitydata.org/slack) and join the #gtfs-validators channel to meet our awesome community. Come say hi :wave:!
   <br><br> Welcome to the community and thank you for your engagement in open source! :tada:
   <br><br> ![](https://media.giphy.com/media/l2JHZ0dIcyFo5UQGQ/giphy.gif)
 


### PR DESCRIPTION
**Summary:**

We now have a direct link to slack instead of the Google form. This PR updates the Google form slack links to the new link

**Expected behavior:** 

All slack links are going to https://share.mobilitydata.org/slack

Please make sure these boxes are checked before submitting your pull request - thanks!

- ~~[ ] Run the unit tests with `gradle test` to make sure you didn't break anything~~
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- ~~[ ] Linked all relevant issues~~
- ~~[ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)~~
