### PR TITLE
fix: Mixed Case false positives

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
@@ -35,7 +35,6 @@ public interface GtfsStopSchema extends GtfsEntity {
 
   String ttsStopName();
 
-  @MixedCase
   String stopDesc();
 
   @FieldType(FieldTypeEnum.LATITUDE)

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -76,8 +76,16 @@ public class MixedCaseValidatorGenerator {
           .beginControlFlow(
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
+          .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}]+\")", String.class)
+          .addStatement("$T isValid = true", boolean.class)
+          .beginControlFlow("for ($T token : tokens)", String.class)
           .beginControlFlow(
-              "if (value.matches(\".*\\\\p{L}{2}.*\") && (value.toLowerCase() == value || value.toUpperCase() == value))")
+              "if (!((token.length() <= 3) || (Character.isUpperCase(token.charAt(0)) && token.substring(1).toLowerCase().equals(token.substring(1)))))")
+          .addStatement("isValid = false")
+          .addStatement("break")
+          .endControlFlow()
+          .endControlFlow()
+          .beginControlFlow("if (!isValid)")
           .addStatement(
               "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
               MixedCaseRecommendedFieldNotice.class,

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -70,11 +70,14 @@ public class MixedCaseValidatorGenerator {
       if (!mixedCaseField.mixedCase()) {
         continue;
       }
+      String test = "blah";
+
       validateMethod
           .beginControlFlow(
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
-          .beginControlFlow("if (!(value.matches(\".*[a-z].*\") && value.matches(\".*[A-Z].*\")))")
+          .beginControlFlow(
+              "if (value.matches(\".*\\\\p{L}{2}.*\") && (value.toLowerCase() == value || value.toUpperCase() == value))")
           .addStatement(
               "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
               MixedCaseRecommendedFieldNotice.class,

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -77,73 +77,81 @@ public class MixedCaseValidatorGenerator {
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
           .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}]+\")", String.class)
-              .addComment("If there is only one token, check that it is not all lowercase")
-              .beginControlFlow("if (tokens.length == 1)")
-              .beginControlFlow("if (tokens[0].length() > 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$$\"))")
-              .addStatement(
-                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
-                      MixedCaseRecommendedFieldNotice.class,
-                      fileDescriptor.filename(),
-                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-              .endControlFlow()
-              .endControlFlow()
-              .beginControlFlow("else")
-              .addComment("If there are multiple tokens, find all with no numbers and check that at least one is mixed case")
-              .addStatement("boolean hasMixedCaseToken = false")
-              .addStatement("int noNumberTokensCount = 0")
-              .beginControlFlow("for (String token : tokens)")
-              .beginControlFlow("if (token.length() == 1 || token.matches(\".*\\\\d+.*\"))")
-              .addStatement("continue")
-              .endControlFlow()
-              .beginControlFlow("else")
-              .addStatement("noNumberTokensCount++")
-              .beginControlFlow("if (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$$\"))")
-              .addStatement("hasMixedCaseToken = true")
-              .endControlFlow()
-              .endControlFlow()
-              .endControlFlow()
-              .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
-              .addStatement(
-                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
-                      MixedCaseRecommendedFieldNotice.class,
-                      fileDescriptor.filename(),
-                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-              .endControlFlow()
-              .endControlFlow()
-              .endControlFlow();
+          .addComment("If there is only one token, check that it is not all lowercase")
+          .beginControlFlow("if (tokens.length == 1)")
+          .beginControlFlow(
+              "if (tokens[0].length() > 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$$\"))")
+          .addStatement(
+              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
+              MixedCaseRecommendedFieldNotice.class,
+              fileDescriptor.filename(),
+              FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+          .endControlFlow()
+          .endControlFlow()
+          .beginControlFlow("else")
+          .addComment(
+              "If there are multiple tokens, find all without numbers and check that at least one is mixed case")
+          .addStatement("boolean hasMixedCaseToken = false")
+          .addStatement("int noNumberTokensCount = 0")
+          .beginControlFlow("for (String token : tokens)")
+          .beginControlFlow("if (token.length() == 1 || token.matches(\".*\\\\d+.*\"))")
+          .addStatement("continue")
+          .endControlFlow()
+          .beginControlFlow("else")
+          .addStatement("noNumberTokensCount++")
+          .beginControlFlow("if (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$$\"))")
+          .addStatement("hasMixedCaseToken = true")
+          .endControlFlow()
+          .endControlFlow()
+          .endControlFlow()
+          .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
+          .addStatement(
+              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
+              MixedCaseRecommendedFieldNotice.class,
+              fileDescriptor.filename(),
+              FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+          .endControlFlow()
+          .endControlFlow()
+          .endControlFlow();
 
-//      validateMethod
-//              .beginControlFlow("if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
-//              .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
-//              .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}\\\\d]+\")", String.class)
-//              .beginControlFlow("if (tokens.length == 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$\"))")
-//              .addStatement(
-//                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
-//                      MixedCaseRecommendedFieldNotice.class,
-//                      fileDescriptor.filename(),
-//                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-//              .endControlFlow()
-//              .addStatement("boolean hasMixedCaseToken = false")
-//              .addStatement("int noNumberTokensCount = 0")
-//              .beginControlFlow("for (String token : tokens)")
-//              .beginControlFlow("if (token.matches(\".*\\\\d+.*\"))")
-//              .addStatement("continue")
-//              .endControlFlow()
-//              .beginControlFlow("else")
-//              .addStatement("noNumberTokensCount++")
-//              .beginControlFlow("if (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$\"))")
-//              .addStatement("hasMixedCaseToken = true")
-//              .endControlFlow()
-//              .endControlFlow()
-//              .endControlFlow()
-//              .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
-//              .addStatement(
-//                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
-//                      MixedCaseRecommendedFieldNotice.class,
-//                      fileDescriptor.filename(),
-//                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-//              .endControlFlow()
-//              .endControlFlow();
+      //      validateMethod
+      //              .beginControlFlow("if (entity.$L())",
+      // FieldNameConverter.hasMethodName(mixedCaseField.name()))
+      //              .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
+      //              .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}\\\\d]+\")",
+      // String.class)
+      //              .beginControlFlow("if (tokens.length == 1 &&
+      // !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$\"))")
+      //              .addStatement(
+      //                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value,
+      // entity.csvRowNumber()))",
+      //                      MixedCaseRecommendedFieldNotice.class,
+      //                      fileDescriptor.filename(),
+      //                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+      //              .endControlFlow()
+      //              .addStatement("boolean hasMixedCaseToken = false")
+      //              .addStatement("int noNumberTokensCount = 0")
+      //              .beginControlFlow("for (String token : tokens)")
+      //              .beginControlFlow("if (token.matches(\".*\\\\d+.*\"))")
+      //              .addStatement("continue")
+      //              .endControlFlow()
+      //              .beginControlFlow("else")
+      //              .addStatement("noNumberTokensCount++")
+      //              .beginControlFlow("if
+      // (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$\"))")
+      //              .addStatement("hasMixedCaseToken = true")
+      //              .endControlFlow()
+      //              .endControlFlow()
+      //              .endControlFlow()
+      //              .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
+      //              .addStatement(
+      //                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value,
+      // entity.csvRowNumber()))",
+      //                      MixedCaseRecommendedFieldNotice.class,
+      //                      fileDescriptor.filename(),
+      //                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+      //              .endControlFlow()
+      //              .endControlFlow();
 
     }
 

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -77,7 +77,8 @@ public class MixedCaseValidatorGenerator {
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
           .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}]+\")", String.class)
-          .addComment("If there is only one token, check that it is not all lowercase")
+          .addComment(
+              "If there is only one token, and no numbers, check that it is not all lowercase")
           .beginControlFlow("if (tokens.length == 1)")
           .beginControlFlow(
               "if (tokens[0].length() > 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$$\"))")

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -77,6 +77,7 @@ public class MixedCaseValidatorGenerator {
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
           .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}]+\")", String.class)
+              .addComment("If there is only one token, check that it is not all lowercase")
               .beginControlFlow("if (tokens.length == 1)")
               .beginControlFlow("if (tokens[0].length() > 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$$\"))")
               .addStatement(
@@ -87,6 +88,7 @@ public class MixedCaseValidatorGenerator {
               .endControlFlow()
               .endControlFlow()
               .beginControlFlow("else")
+              .addComment("If there are multiple tokens, find all with no numbers and check that at least one is mixed case")
               .addStatement("boolean hasMixedCaseToken = false")
               .addStatement("int noNumberTokensCount = 0")
               .beginControlFlow("for (String token : tokens)")

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -77,22 +77,72 @@ public class MixedCaseValidatorGenerator {
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
           .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
           .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}]+\")", String.class)
-          .addStatement("$T isValid = true", boolean.class)
-          .beginControlFlow("for ($T token : tokens)", String.class)
-          .beginControlFlow(
-              "if (!((token.length() <= 3) || (Character.isUpperCase(token.charAt(0)) && token.substring(1).toLowerCase().equals(token.substring(1)))))")
-          .addStatement("isValid = false")
-          .addStatement("break")
-          .endControlFlow()
-          .endControlFlow()
-          .beginControlFlow("if (!isValid)")
-          .addStatement(
-              "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
-              MixedCaseRecommendedFieldNotice.class,
-              fileDescriptor.filename(),
-              FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-          .endControlFlow()
-          .endControlFlow();
+              .beginControlFlow("if (tokens.length == 1)")
+              .beginControlFlow("if (tokens[0].length() > 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$$\"))")
+              .addStatement(
+                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
+                      MixedCaseRecommendedFieldNotice.class,
+                      fileDescriptor.filename(),
+                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+              .endControlFlow()
+              .endControlFlow()
+              .beginControlFlow("else")
+              .addStatement("boolean hasMixedCaseToken = false")
+              .addStatement("int noNumberTokensCount = 0")
+              .beginControlFlow("for (String token : tokens)")
+              .beginControlFlow("if (token.length() == 1 || token.matches(\".*\\\\d+.*\"))")
+              .addStatement("continue")
+              .endControlFlow()
+              .beginControlFlow("else")
+              .addStatement("noNumberTokensCount++")
+              .beginControlFlow("if (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$$\"))")
+              .addStatement("hasMixedCaseToken = true")
+              .endControlFlow()
+              .endControlFlow()
+              .endControlFlow()
+              .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
+              .addStatement(
+                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
+                      MixedCaseRecommendedFieldNotice.class,
+                      fileDescriptor.filename(),
+                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+              .endControlFlow()
+              .endControlFlow()
+              .endControlFlow();
+
+//      validateMethod
+//              .beginControlFlow("if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
+//              .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
+//              .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}\\\\d]+\")", String.class)
+//              .beginControlFlow("if (tokens.length == 1 && !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$\"))")
+//              .addStatement(
+//                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
+//                      MixedCaseRecommendedFieldNotice.class,
+//                      fileDescriptor.filename(),
+//                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+//              .endControlFlow()
+//              .addStatement("boolean hasMixedCaseToken = false")
+//              .addStatement("int noNumberTokensCount = 0")
+//              .beginControlFlow("for (String token : tokens)")
+//              .beginControlFlow("if (token.matches(\".*\\\\d+.*\"))")
+//              .addStatement("continue")
+//              .endControlFlow()
+//              .beginControlFlow("else")
+//              .addStatement("noNumberTokensCount++")
+//              .beginControlFlow("if (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$\"))")
+//              .addStatement("hasMixedCaseToken = true")
+//              .endControlFlow()
+//              .endControlFlow()
+//              .endControlFlow()
+//              .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
+//              .addStatement(
+//                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value, entity.csvRowNumber()))",
+//                      MixedCaseRecommendedFieldNotice.class,
+//                      fileDescriptor.filename(),
+//                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
+//              .endControlFlow()
+//              .endControlFlow();
+
     }
 
     typeSpec.addMethod(validateMethod.build());

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -70,8 +70,6 @@ public class MixedCaseValidatorGenerator {
       if (!mixedCaseField.mixedCase()) {
         continue;
       }
-      String test = "blah";
-
       validateMethod
           .beginControlFlow(
               "if (entity.$L())", FieldNameConverter.hasMethodName(mixedCaseField.name()))
@@ -114,45 +112,6 @@ public class MixedCaseValidatorGenerator {
           .endControlFlow()
           .endControlFlow()
           .endControlFlow();
-
-      //      validateMethod
-      //              .beginControlFlow("if (entity.$L())",
-      // FieldNameConverter.hasMethodName(mixedCaseField.name()))
-      //              .addStatement("$T value = entity.$L()", String.class, mixedCaseField.name())
-      //              .addStatement("$T[] tokens = value.split(\"[^\\\\p{L}\\\\d]+\")",
-      // String.class)
-      //              .beginControlFlow("if (tokens.length == 1 &&
-      // !tokens[0].matches(\".*\\\\d+.*\") && tokens[0].matches(\"^\\\\p{Ll}+$\"))")
-      //              .addStatement(
-      //                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value,
-      // entity.csvRowNumber()))",
-      //                      MixedCaseRecommendedFieldNotice.class,
-      //                      fileDescriptor.filename(),
-      //                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-      //              .endControlFlow()
-      //              .addStatement("boolean hasMixedCaseToken = false")
-      //              .addStatement("int noNumberTokensCount = 0")
-      //              .beginControlFlow("for (String token : tokens)")
-      //              .beginControlFlow("if (token.matches(\".*\\\\d+.*\"))")
-      //              .addStatement("continue")
-      //              .endControlFlow()
-      //              .beginControlFlow("else")
-      //              .addStatement("noNumberTokensCount++")
-      //              .beginControlFlow("if
-      // (token.matches(\"^(?=.*\\\\p{Lu})(?=.*\\\\p{Ll}).*$\"))")
-      //              .addStatement("hasMixedCaseToken = true")
-      //              .endControlFlow()
-      //              .endControlFlow()
-      //              .endControlFlow()
-      //              .beginControlFlow("if (noNumberTokensCount >= 2 && !hasMixedCaseToken)")
-      //              .addStatement(
-      //                      "noticeContainer.addValidationNotice(new $T(\"$L\", \"$L\", value,
-      // entity.csvRowNumber()))",
-      //                      MixedCaseRecommendedFieldNotice.class,
-      //                      fileDescriptor.filename(),
-      //                      FieldNameConverter.gtfsColumnName(mixedCaseField.name()))
-      //              .endControlFlow()
-      //              .endControlFlow();
 
     }
 

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/MixedCaseValidatorGenerator.java
@@ -112,7 +112,6 @@ public class MixedCaseValidatorGenerator {
           .endControlFlow()
           .endControlFlow()
           .endControlFlow();
-
     }
 
     typeSpec.addMethod(validateMethod.build());

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MixedCaseSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MixedCaseSchemaTest.java
@@ -79,19 +79,19 @@ public class MixedCaseSchemaTest {
           {"Route 1 Boulevard", true},
           {"ZA12", true},
           {"Avenue des Champs-Élysées", true},
+          {"UPPERCASE", true},
+          {"ROUTE 22", true},
+          {"ROUTE 1", true},
+          {"route 1 Boulevard", true},
+          {"Sentences are ok with one mixed case word", true},
+          {"MixedCaseButSingleWord", true},
           // invalid values
           {"lowercase", false},
-          {"UPPERCASE", false},
           {"snake_case", false},
           {"kebab-case", false},
           {"UPPER-CASE", false},
           {"lower case space", false},
-          {"ROUTE 22", false},
           {"34broadst", false},
-          {"ROUTE 1", false},
-          {"route 1 Boulevard", false},
-          {"Another bad value", false},
-          {"MixedCaseButSingleWord", false},
         });
   }
 

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MixedCaseSchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/MixedCaseSchemaTest.java
@@ -58,19 +58,26 @@ public class MixedCaseSchemaTest {
     return Arrays.asList(
         new Object[][] {
           // valid values
-          {"MixedCase", true},
           {"Mixed-Case", true},
           {"Mixed_Case", true},
           {"Mixed Case", true},
-          {"Another good value", true},
           {"22222", true},
+          {"A1", true},
+          {"ZA112", true},
+          {"301", true},
+          {"RTE 30", true},
+          {"급 행 12", true},
+          {"급행12", true},
+          {"東西線", true},
           {"101B", true},
           {"A14C", true},
           {"A14c", true},
           {"A14-C", true},
           {"A14_C", true},
           {"A14 C", true},
-          //          {"ZA12", true}, // TODO: Should this be allowed to succeed?
+          {"Route 1", true},
+          {"Route 1 Boulevard", true},
+          {"ZA12", true},
           {"Avenue des Champs-Élysées", true},
           // invalid values
           {"lowercase", false},
@@ -80,32 +87,20 @@ public class MixedCaseSchemaTest {
           {"UPPER-CASE", false},
           {"lower case space", false},
           {"ROUTE 22", false},
-          {"34broadst", false}
+          {"34broadst", false},
+          {"ROUTE 1", false},
+          {"route 1 Boulevard", false},
+          {"Another bad value", false},
+          {"MixedCaseButSingleWord", false},
         });
   }
 
   @Test
-  public void testValidMixedCase() throws ValidatorLoaderException {
+  public void testMixedCase() throws ValidatorLoaderException {
     helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, value);
     if (isValid) {
       assertThat(helper.getValidationNotices()).isEmpty();
     } else {
-      assertThat(helper.getValidationNotices())
-          .containsExactly(
-              new MixedCaseRecommendedFieldNotice(
-                  MixedCaseTest.FILENAME, MixedCaseTest.SOME_FIELD_FIELD_NAME, value, 2));
-    }
-  }
-
-  @Test
-  public void testInvalidMixedCases() throws ValidatorLoaderException {
-    String[] invalidValues = {
-      "lowercase", "UPPERCASE", "snake_case", "kebab-case", "UPPER-CASE", "lower case space"
-    };
-
-    for (String value : invalidValues) {
-      helper.load(tableDescriptor, MixedCaseTest.SOME_FIELD_FIELD_NAME, value);
-
       assertThat(helper.getValidationNotices())
           .containsExactly(
               new MixedCaseRecommendedFieldNotice(


### PR DESCRIPTION
**Summary:**

Should close #1402.  False positives when warning for Mixed Case values such as when numbers and letters are mixed. 

**Expected behavior:** 

Values with a letter and numbers such as `A102` `302-B` and those with only numbers like `321` should not trigger a warning.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
