### PR TITLE
Fix: Switch javadoc aggregation plugin to non-jar version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'java'
     id 'test-report-aggregation'
     id 'com.github.sherter.google-java-format' version '0.9'
-    id "io.freefair.aggregate-javadoc-jar" version "6.4.3"
+    id "io.freefair.aggregate-javadoc" version "6.4.3"
     id "pl.allegro.tech.build.axion-release" version "1.13.6"
 }
 


### PR DESCRIPTION
Per issue #1431, this PR switches us away from the Javadoc jar-based aggregation step since, best I can tell, no one is using the `jar` output (only the uncompressed Javadoc content itself) and the `jar` step is currently hanging gradle.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
