### PR TITLE
fix: Use correct import for @Nullable annotation.

### DIFF
--- a/model/build.gradle
+++ b/model/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     annotationProcessor 'com.google.auto.value:auto-value:1.7.4'
     compileOnly 'com.google.auto.value:auto-value-annotations:1.7.4'
     implementation 'org.jetbrains:annotations:20.1.0'
+    implementation 'com.google.code.findbugs:jsr305:3.0.2'
 }
 
 compileJava {

--- a/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeDocComments.java
+++ b/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeDocComments.java
@@ -3,7 +3,8 @@ package org.mobilitydata.gtfsvalidator.notice;
 import java.util.HashMap;
 import java.util.Map;
 import javax.lang.model.element.TypeElement;
-import org.jetbrains.annotations.Nullable;
+import javax.annotation.Nullable;
+
 
 /**
  * Documentation comments associated with a notice and its fields, as extracted from source code.
@@ -16,7 +17,8 @@ import org.jetbrains.annotations.Nullable;
 public class NoticeDocComments {
 
   /** The main notice description, extracted from the notice's Javadoc comment. */
-  @Nullable private String docComment;
+  @Nullable
+  private String docComment;
 
   /** Field-specific comments, keyed by field name. */
   private Map<String, String> fieldDocComments = new HashMap<>();

--- a/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeDocComments.java
+++ b/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeDocComments.java
@@ -2,9 +2,8 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.lang.model.element.TypeElement;
 import javax.annotation.Nullable;
-
+import javax.lang.model.element.TypeElement;
 
 /**
  * Documentation comments associated with a notice and its fields, as extracted from source code.
@@ -17,8 +16,7 @@ import javax.annotation.Nullable;
 public class NoticeDocComments {
 
   /** The main notice description, extracted from the notice's Javadoc comment. */
-  @Nullable
-  private String docComment;
+  @Nullable private String docComment;
 
   /** Field-specific comments, keyed by field name. */
   private Map<String, String> fieldDocComments = new HashMap<>();


### PR DESCRIPTION
I accidentally included the wrong @Nullable annotation on a new class (used `org.jetbrains.annotations.Nullable` when I should have used `javax.annotation.Nullable`).  We should be consistent with the rest of the codebase.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
