### PR TITLE
fix: Bug in HTML report generation where feed metadata can be null

### DIFF
--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -168,7 +168,7 @@
 
     <h2>Summary</h2>
 
-    <div class="summary">
+    <div class="summary" th:if="${metadata}">
         <div class="summary-row">
             <div class="summary-cell summary_info">
                 <h4>Agencies included</h4>


### PR DESCRIPTION
This fixes a bug introduced in #1363 when metadata was added to the validation HTML report.  The `metadata` data structure can be null when a system error occurs when processing a feed, which ultimately results in a NPE when generating the HTML report.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
