### PR TITLE
feat: Split the notice doc comment into a short summary string and additional documentation.

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchema.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchema.java
@@ -20,7 +20,14 @@ public class NoticeSchema {
   /** This field is kept for compatibility with the original schema serialization code. */
   private final String type = "object";
 
-  /** The textual description associated with this notice. May contain Markdown markup. */
+  /** A short single-line summary describing the notice. May contain Markdown markup. */
+  @Nullable private String shortSummary;
+
+  /**
+   * Additional textual description associated with this notice. It will not contain the
+   * `shortSummary` string, but is typically combined as `shortSummary` + "\n\n" + `description`.
+   * May contain Markdown markup.
+   */
   @Nullable private String description;
 
   @Nullable private ReferencesSchema references;
@@ -42,6 +49,15 @@ public class NoticeSchema {
 
   public SeverityLevel getSeverityLevel() {
     return this.severityLevel;
+  }
+
+  @Nullable
+  public String getShortSummary() {
+    return shortSummary;
+  }
+
+  public void setShortSummary(@Nullable String shortSummary) {
+    this.shortSummary = shortSummary;
   }
 
   public String getDescription() {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGenerator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGenerator.java
@@ -82,8 +82,11 @@ public class NoticeSchemaGenerator {
     NoticeSchema schema = new NoticeSchema(Notice.getCode(noticeClass), severity);
 
     NoticeDocComments comments = loadComments(noticeClass);
-    if (comments.getDocComment() != null) {
-      schema.setDescription(comments.getDocComment());
+    if (comments.getShortSummary() != null) {
+      schema.setShortSummary(comments.getShortSummary());
+    }
+    if (comments.getAdditionalDocumentation() != null) {
+      schema.setDescription(comments.getAdditionalDocumentation());
     }
 
     if (noticeAnnotation != null) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest.java
@@ -95,7 +95,8 @@ public class NoticeSchemaGeneratorTest {
   @Test
   public void generateSchemaForNotice_documentedNotice() {
     NoticeSchema schema = NoticeSchemaGenerator.generateSchemaForNotice(DocumentedNotice.class);
-    assertThat(schema.getDescription()).isEqualTo("This is a notice comment.");
+    assertThat(schema.getShortSummary()).isEqualTo("This is a notice comment.");
+    assertThat(schema.getDescription()).isEqualTo("This is additional documentation.");
     ReferencesSchema refs = schema.getReferences();
     assertThat(refs.getFileReferences()).containsExactly("apples.txt");
     assertThat(refs.getBestPracticesFileReferences()).containsExactly("bananas.txt");

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/DocumentedNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/DocumentedNotice.java
@@ -11,6 +11,7 @@ import org.mobilitydata.gtfsvalidator.notice.testnotices.DocumentedNotice.AppleS
 import org.mobilitydata.gtfsvalidator.notice.testnotices.DocumentedNotice.BananaSchema;
 import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
 
+/** Look in `DocumentedNotice-DocComments.json` for actual comment values. */
 @GtfsValidationNotice(
     severity = ERROR,
     files = @FileRefs(AppleSchema.class),

--- a/core/src/test/resources/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest-generateJsonSchemaForNotice_duplicateKeyNotice.json
+++ b/core/src/test/resources/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest-generateJsonSchemaForNotice_duplicateKeyNotice.json
@@ -2,7 +2,8 @@
   "code": "duplicate_key",
   "severityLevel": "ERROR",
   "type": "object",
-  "description": "Duplicated entity.\n\nThe values of the given key and rows are duplicates.",
+  "shortSummary": "Duplicated entity.",
+  "description": "The values of the given key and rows are duplicates.",
   "references": {
     "fileReferences": [],
     "bestPracticesFileReferences": [],

--- a/core/src/test/resources/org/mobilitydata/gtfsvalidator/notice/testnotices/DocumentedNotice-DocComments.json
+++ b/core/src/test/resources/org/mobilitydata/gtfsvalidator/notice/testnotices/DocumentedNotice-DocComments.json
@@ -1,5 +1,6 @@
 {
-  "docComment":"This is a notice comment.",
+  "shortSummary": "This is a notice comment.",
+  "additionalDocumentation": "This is additional documentation.",
   "fieldDocComments":{
     "value": "A field comment"
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
@@ -76,7 +76,7 @@ public class NoticeView {
    * @return description text
    */
   public String getDescription() {
-    String markdown = this.comments.getDocComment();
+    String markdown = this.comments.getCombinedDocumentation();
 
     Parser parser = Parser.builder().build();
     Document document = parser.parse(markdown == null ? "" : markdown);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeDocumentationTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeDocumentationTest.java
@@ -65,7 +65,7 @@ public class NoticeDocumentationTest {
             .filter(
                 clazz -> {
                   NoticeDocComments docComments = NoticeSchemaGenerator.loadComments(clazz);
-                  return docComments.getDocComment() == null;
+                  return docComments.getShortSummary() == null;
                 })
             .collect(Collectors.toList());
     assertWithMessage(
@@ -97,7 +97,7 @@ public class NoticeDocumentationTest {
 
   private static Stream<String> checkNoticeForUnsupportedJavadocInComment(Class<?> noticeClass) {
     NoticeDocComments docComments = NoticeSchemaGenerator.loadComments(noticeClass);
-    String docComment = docComments.getDocComment();
+    String docComment = docComments.getCombinedDocumentation();
 
     List<String> errors = new ArrayList<>();
 

--- a/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeDocComments.java
+++ b/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeDocComments.java
@@ -15,8 +15,15 @@ import javax.lang.model.element.TypeElement;
  */
 public class NoticeDocComments {
 
-  /** The main notice description, extracted from the notice's Javadoc comment. */
-  @Nullable private String docComment;
+  /** A short single-line summary describing the notice. May contain Markdown markup. */
+  @Nullable private String shortSummary;
+
+  /**
+   * Additional multi-line textual description associated with this notice. It will not contain the
+   * `shortSummary` string, but is typically combined as `shortSummary` + "\n\n" + `description`.
+   * May contain Markdown markup.
+   */
+  @Nullable private String additionalDocumentation;
 
   /** Field-specific comments, keyed by field name. */
   private Map<String, String> fieldDocComments = new HashMap<>();
@@ -35,15 +42,43 @@ public class NoticeDocComments {
 
   /** Returns true if there are no actual comments specified. */
   public boolean isEmpty() {
-    return docComment == null && fieldDocComments.isEmpty();
+    return shortSummary == null && additionalDocumentation == null && fieldDocComments.isEmpty();
   }
 
-  public String getDocComment() {
-    return docComment;
+  /** A short single-line summary describing the notice. May contain Markdown markup. */
+  public String getShortSummary() {
+    return shortSummary;
   }
 
-  public void setDocComment(String docComment) {
-    this.docComment = docComment;
+  public void setShortSummary(@Nullable String shortSummary) {
+    this.shortSummary = shortSummary;
+  }
+
+  /**
+   * Additional multi-line textual description associated with this notice. It will not contain the
+   * `shortSummary` string, but is typically combined as `shortSummary` + "\n\n" + `description`
+   * (see {@link #getCombinedDocumentation()}). May be null if a notice only includes a short
+   * summary. May contain Markdown markup.
+   */
+  @Nullable
+  public String getAdditionalDocumentation() {
+    return additionalDocumentation;
+  }
+
+  public void setAdditionalDocumentation(@Nullable String additionalDocumentation) {
+    this.additionalDocumentation = additionalDocumentation;
+  }
+
+  /**
+   * Returns a combined string with the `shortSummary` and `additionalDocumentation` joined with
+   * "\n\n".
+   */
+  public String getCombinedDocumentation() {
+    String docs = this.shortSummary;
+    if (this.additionalDocumentation != null) {
+      docs += "\n\n" + this.additionalDocumentation;
+    }
+    return docs;
   }
 
   public void putFieldComment(String fieldName, String docComment) {

--- a/processor/notices/src/main/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentCleaner.java
+++ b/processor/notices/src/main/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentCleaner.java
@@ -1,5 +1,6 @@
 package org.mobilitydata.gtfsvalidator.processor.notices;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -19,9 +20,10 @@ public class CommentCleaner {
    */
   private static final ImmutableSet<String> LINES_TO_DROP = ImmutableSet.of("<pre>", "</pre>");
 
-  public String cleanComment(String docComment) {
+  /** Returns the cleaned comment split into individual lines. */
+  public List<String> cleanComment(String docComment) {
     if (docComment.isEmpty()) {
-      return docComment;
+      return ImmutableList.of();
     }
 
     List<String> lines = Arrays.asList(docComment.split("\n"));
@@ -60,7 +62,7 @@ public class CommentCleaner {
       lines.remove(lines.size() - 1);
     }
 
-    return lines.stream().collect(Collectors.joining("\n"));
+    return lines;
   }
 
   /** Returns the number of leading whitespace characters at the beginning of the line. */
@@ -70,5 +72,28 @@ public class CommentCleaner {
       i++;
     }
     return i;
+  }
+
+  public SplitComment splitLinesIntoSummaryAndAdditionalDocumentation(List<String> lines) {
+    SplitComment comment = new SplitComment();
+    if (lines.isEmpty()) {
+      return comment;
+    }
+    comment.shortSummary = lines.get(0);
+    int fromIndex = 1;
+    while (fromIndex < lines.size() && lines.get(fromIndex).isBlank()) {
+      fromIndex++;
+    }
+    if (fromIndex < lines.size()) {
+      comment.additionalDocumentation =
+          lines.subList(fromIndex, lines.size()).stream().collect(Collectors.joining("\n"));
+    }
+    return comment;
+  }
+
+  public final class SplitComment {
+    String shortSummary;
+
+    String additionalDocumentation;
   }
 }

--- a/processor/notices/src/main/java/org/mobilitydata/gtfsvalidator/processor/notices/NoticeDocCommentsFactory.java
+++ b/processor/notices/src/main/java/org/mobilitydata/gtfsvalidator/processor/notices/NoticeDocCommentsFactory.java
@@ -1,11 +1,13 @@
 package org.mobilitydata.gtfsvalidator.processor.notices;
 
+import java.util.List;
 import java.util.Optional;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
 import org.mobilitydata.gtfsvalidator.notice.NoticeDocComments;
+import org.mobilitydata.gtfsvalidator.processor.notices.CommentCleaner.SplitComment;
 
 /**
  * Provides methods for constructing {@link NoticeDocComments} from a Notice class' {@link
@@ -30,14 +32,18 @@ public class NoticeDocCommentsFactory {
 
     String noticeComment = elements.getDocComment(element);
     if (noticeComment != null) {
-      comments.setDocComment(cleaner.cleanComment(noticeComment));
+      List<String> lines = cleaner.cleanComment(noticeComment);
+      SplitComment splitComment = cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(lines);
+      comments.setShortSummary(splitComment.shortSummary);
+      comments.setAdditionalDocumentation(splitComment.additionalDocumentation);
     }
 
     for (VariableElement field : ElementFilter.fieldsIn(element.getEnclosedElements())) {
       String fieldName = field.getSimpleName().toString();
       String fieldComment = elements.getDocComment(field);
       if (fieldComment != null) {
-        comments.putFieldComment(fieldName, cleaner.cleanComment(fieldComment));
+        String cleanComment = String.join("\n", cleaner.cleanComment(fieldComment));
+        comments.putFieldComment(fieldName, cleanComment);
       }
     }
 

--- a/processor/notices/src/test/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentCleanerTest.java
+++ b/processor/notices/src/test/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentCleanerTest.java
@@ -2,7 +2,9 @@ package org.mobilitydata.gtfsvalidator.processor.notices;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.collect.ImmutableList;
 import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.processor.notices.CommentCleaner.SplitComment;
 
 public class CommentCleanerTest {
 
@@ -10,45 +12,84 @@ public class CommentCleanerTest {
 
   @Test
   public void testCleanComment_noModification() {
-    assertThat(cleaner.cleanComment("Comment.")).isEqualTo("Comment.");
+    assertThat(cleaner.cleanComment("Comment.")).containsExactly("Comment.");
   }
 
   @Test
   public void testCleanComment_removeTrailingWhitespace() {
-    assertThat(cleaner.cleanComment("Comment.  ")).isEqualTo("Comment.");
+    assertThat(cleaner.cleanComment("Comment.  ")).containsExactly("Comment.");
   }
 
   @Test
   public void testCleanComment_removeConsistentLeadingWhitespace() {
     assertThat(cleaner.cleanComment("  Two spaces.\n   Three spaces.\n  Two spaces.  "))
-        .isEqualTo("Two spaces.\n Three spaces.\nTwo spaces.");
+        .containsExactly("Two spaces.", " Three spaces.", "Two spaces.");
   }
 
   @Test
   public void testCleanComment_removeJavadocParagraphTags() {
     assertThat(cleaner.cleanComment("Line 1.\n\n<p>Line 2.\n\n<p>Line 3."))
-        .isEqualTo("Line 1.\n\nLine 2.\n\nLine 3.");
+        .containsExactly("Line 1.", "", "Line 2.", "", "Line 3.");
   }
 
   @Test
   public void testCleanComment_removeSeverityComment() {
     assertThat(cleaner.cleanComment("Line 1.\n\n<p>Severity: {@code SeverityLevel.ERROR}"))
-        .isEqualTo("Line 1.");
+        .containsExactly("Line 1.");
   }
 
   @Test
   public void testCleanComment_preBlock() {
     assertThat(cleaner.cleanComment("Line 1.\n\n<pre>\n```\nverbatim\n```\n</pre>"))
-        .isEqualTo("Line 1.\n\n```\nverbatim\n```");
+        .containsExactly("Line 1.", "", "```", "verbatim", "```");
   }
 
   @Test
-  public void testCleanComment_what() {
+  public void testCleanComment_removeSeverityTag() {
     assertThat(
             cleaner.cleanComment(
                 " Describes two trips with the same block id that have overlapping stop times.\n"
                     + "\n"
                     + " \u003cp\u003eSeverity: {@code SeverityLevel.ERROR}\n"))
-        .isEqualTo("Describes two trips with the same block id that have overlapping stop times.");
+        .containsExactly(
+            "Describes two trips with the same block id that have overlapping stop times.");
+  }
+
+  @Test
+  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_summaryOnly() {
+    SplitComment split =
+        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(ImmutableList.of("A."));
+
+    assertThat(split.shortSummary).isEqualTo("A.");
+    assertThat(split.additionalDocumentation).isNull();
+  }
+
+  @Test
+  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_bothPresent() {
+    SplitComment split =
+        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(
+            ImmutableList.of("A.", "", "B.", "C."));
+
+    assertThat(split.shortSummary).isEqualTo("A.");
+    assertThat(split.additionalDocumentation).isEqualTo("B.\nC.");
+  }
+
+  @Test
+  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_multipleBlankLines() {
+    SplitComment split =
+        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(
+            ImmutableList.of("A.", "", "", "B."));
+
+    assertThat(split.shortSummary).isEqualTo("A.");
+    assertThat(split.additionalDocumentation).isEqualTo("B.");
+  }
+
+  @Test
+  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_noBlankLines() {
+    SplitComment split =
+        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(ImmutableList.of("A.", "B."));
+
+    assertThat(split.shortSummary).isEqualTo("A.");
+    assertThat(split.additionalDocumentation).isEqualTo("B.");
   }
 }

--- a/processor/notices/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentedNoticeTest.java
+++ b/processor/notices/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentedNoticeTest.java
@@ -20,7 +20,9 @@ public class CommentedNoticeTest {
 
     try (Reader reader = new InputStreamReader(is)) {
       NoticeDocComments comments = new Gson().fromJson(reader, NoticeDocComments.class);
-      assertThat(comments.getDocComment()).isEqualTo("This is the notice comment.");
+      assertThat(comments.getShortSummary()).isEqualTo("This is the notice comment.");
+      assertThat(comments.getAdditionalDocumentation()).isNull();
+      assertThat(comments.getCombinedDocumentation()).isEqualTo("This is the notice comment.");
       assertThat(comments.getFieldComment("fieldA")).isEqualTo("This is the fieldA comment.");
       assertThat(comments.getFieldComment("fieldB")).isEqualTo("This is the fieldB comment.");
     }


### PR DESCRIPTION
This is a usability tweak on the notice documentation support that was implemented in #1324.

We enforce that notice doc comments have the following form:

```
/**
 * Short text describing the notice in a single line (required).
 *
 * Additional text further describing the notice on new lines (optional).
 */
```

We represented that internally as a single combined comment string, but there are uses where we'd like to split out the short summary string and the additional optional documentation so that they can be used and rendered separately, where appropriate.  This PR implements that split.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
