### PR TITLE
fix(web/service): change permissions for application.properties, service acount json, & newrelic.yml

### DIFF
--- a/web/service/Dockerfile
+++ b/web/service/Dockerfile
@@ -4,19 +4,26 @@ RUN addgroup -S spring && adduser -S spring -G spring
 RUN mkdir -p /newrelic/logs
 RUN chown -R spring:spring /newrelic/logs
 
-USER spring:spring
-ARG JAR_FILES=build/libs/\*.jar
 ARG PROPERTIES_FILE=build/resources/main/application.properties
 ARG CREDS_FILE=src/main/resources/web-based-gtfs-validator-a088ec5f045d.json
+COPY ${PROPERTIES_FILE} /application.properties
+RUN chown spring:spring /application.properties
+RUN chmod 0644 /application.properties
+COPY ${CREDS_FILE} /web-based-gtfs-validator-a088ec5f045d.json
+RUN chown spring:spring /web-based-gtfs-validator-a088ec5f045d.json
+RUN chmod 0644 /web-based-gtfs-validator-a088ec5f045d.json
+ADD ./newrelic/newrelic.yml /newrelic/newrelic.yml
+RUN chown spring:spring /newrelic/newrelic.yml
+RUN chmod 0644 /newrelic/newrelic.yml
+
+USER spring:spring
+ARG JAR_FILES=build/libs/\*.jar
 ARG CURRENT_VERSION
 RUN test -n "$CURRENT_VERSION" || { echo "missing required build arg: CURRENT_VERSION"; exit 1; }
 ENV CURRENT_VERSION=${CURRENT_VERSION}
 
 COPY ${JAR_FILES} /
-COPY ${PROPERTIES_FILE} /
-COPY ${CREDS_FILE} /
 
 ADD ./newrelic/newrelic.jar /newrelic/newrelic.jar
-ADD ./newrelic/newrelic.yml /newrelic/newrelic.yml
 
 ENTRYPOINT exec java -Xmx12g  -javaagent:/newrelic/newrelic.jar -jar /service-${CURRENT_VERSION}.jar


### PR DESCRIPTION
The gcloud-secrets CLI will create these files with 0600 permissions, and does not document an option to change the mode. This patch uses the chown/chmod CLI utilities rather than --chown and --chmod flags because their support is not universal across docker versions or distributions which do not include buildkit (the cloudbuild environment provides one such distribution).