### PR TITLE
fix: Add back support for @GtfsTable.maxCharsPerColumn.

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -4,9 +4,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import com.univocity.parsers.common.TextParsingException;
+import com.univocity.parsers.csv.CsvParserSettings;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.mobilitydata.gtfsvalidator.notice.CsvParsingFailedNotice;
@@ -33,9 +35,15 @@ public final class AnyTableLoader {
       InputStream csvInputStream,
       NoticeContainer noticeContainer) {
     final String gtfsFilename = tableDescriptor.gtfsFilename();
+
     CsvFile csvFile;
     try {
-      csvFile = new CsvFile(csvInputStream, gtfsFilename);
+      CsvParserSettings settings = CsvFile.createDefaultParserSettings();
+      if (tableDescriptor.maxCharsPerColumn().isPresent()) {
+        Optional<Integer> maxCharsPerColumn = tableDescriptor.maxCharsPerColumn();
+        settings.setMaxCharsPerColumn(maxCharsPerColumn.get());
+      }
+      csvFile = new CsvFile(csvInputStream, gtfsFilename, settings);
     } catch (TextParsingException e) {
       noticeContainer.addValidationNotice(new CsvParsingFailedNotice(gtfsFilename, e));
       return tableDescriptor.createContainerForInvalidStatus(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableDescriptor.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableDescriptor.java
@@ -3,6 +3,7 @@ package org.mobilitydata.gtfsvalidator.table;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Optional;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 
@@ -24,6 +25,8 @@ public abstract class GtfsTableDescriptor<T extends GtfsEntity> {
   public abstract boolean isRecommended();
 
   public abstract boolean isRequired();
+
+  public abstract Optional<Integer> maxCharsPerColumn();
 
   public abstract ImmutableList<GtfsColumnDescriptor> getColumns();
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableDescriptor.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableDescriptor.java
@@ -3,6 +3,7 @@ package org.mobilitydata.gtfsvalidator.testgtfs;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.List;
+import java.util.Optional;
 import org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
@@ -104,5 +105,10 @@ public class GtfsTestTableDescriptor extends GtfsTableDescriptor<GtfsTestEntity>
   @Override
   public boolean isRequired() {
     return true;
+  }
+
+  @Override
+  public Optional<Integer> maxCharsPerColumn() {
+    return Optional.empty();
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableDescriptorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableDescriptorGenerator.java
@@ -33,6 +33,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import java.util.List;
+import java.util.Optional;
 import javax.lang.model.element.Modifier;
 import org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
@@ -114,6 +115,7 @@ public class TableDescriptorGenerator {
     typeSpec.addMethod(generateGtfsFilenameMethod());
     typeSpec.addMethod(generateIsRecommendedMethod());
     typeSpec.addMethod(generateIsRequiredMethod());
+    typeSpec.addMethod(generateMaxCharsPerColumnMethod());
 
     return typeSpec.build();
   }
@@ -306,5 +308,19 @@ public class TableDescriptorGenerator {
         .addAnnotation(Override.class)
         .addStatement("return $L", fileDescriptor.required())
         .build();
+  }
+
+  private MethodSpec generateMaxCharsPerColumnMethod() {
+    MethodSpec.Builder m =
+        MethodSpec.methodBuilder("maxCharsPerColumn")
+            .addModifiers(Modifier.PUBLIC)
+            .returns(ParameterizedTypeName.get(Optional.class, Integer.class))
+            .addAnnotation(Override.class);
+    if (fileDescriptor.maxCharsPerColumn().isPresent()) {
+      m.addStatement("return Optional.of($L)", fileDescriptor.maxCharsPerColumn().get());
+    } else {
+      m.addStatement("return Optional.empty()");
+    }
+    return m.build();
   }
 }


### PR DESCRIPTION
Closes #1461.

In PR #1228 I added support for @GtfsTable.maxCharsPerColumn to support files with especially large column values. Unfortunately, this feature was accidentally removed in PR #1284.  This PR adds it back.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
