### PR TITLE
feat: Resolve notice severity level from @GtfsValidationNotice annotation.

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/model/NoticeReport.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/model/NoticeReport.java
@@ -16,9 +16,8 @@
 
 package org.mobilitydata.gtfsvalidator.model;
 
+import com.google.gson.JsonElement;
 import com.google.gson.annotations.Expose;
-import com.google.gson.internal.LinkedTreeMap;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
@@ -34,13 +33,10 @@ public class NoticeReport {
   @Expose() private final String code;
   @Expose() private final SeverityLevel severity;
   @Expose() private final int totalNotices;
-  @Expose() private final List<LinkedTreeMap<String, Object>> sampleNotices;
+  @Expose() private final List<JsonElement> sampleNotices;
 
   public NoticeReport(
-      String code,
-      SeverityLevel severity,
-      int count,
-      List<LinkedTreeMap<String, Object>> sampleNotices) {
+      String code, SeverityLevel severity, int count, List<JsonElement> sampleNotices) {
     this.code = code;
     this.severity = severity;
     this.totalNotices = count;
@@ -59,8 +55,8 @@ public class NoticeReport {
     return code;
   }
 
-  public List<LinkedTreeMap<String, Object>> getSampleNotices() {
-    return Collections.unmodifiableList(sampleNotices);
+  public List<JsonElement> getSampleNotices() {
+    return sampleNotices;
   }
 
   public boolean isError() {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -18,8 +18,6 @@ package org.mobilitydata.gtfsvalidator.notice;
 
 import com.google.common.base.CaseFormat;
 import com.google.common.geometry.S2LatLng;
-import com.google.gson.ExclusionStrategy;
-import com.google.gson.FieldAttributes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
@@ -28,7 +26,6 @@ import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializationContext;
 import com.google.gson.JsonSerializer;
 import java.lang.reflect.Type;
-import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
@@ -38,7 +35,6 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 public abstract class Notice {
   public static final Gson GSON =
       new GsonBuilder()
-          .setExclusionStrategies(new NoticeExclusionStrategy())
           .registerTypeAdapter(GtfsColor.class, new GtfsColorSerializer())
           .registerTypeAdapter(GtfsDate.class, new GtfsDateSerializer())
           .registerTypeAdapter(GtfsTime.class, new GtfsTimeSerializer())
@@ -48,18 +44,8 @@ public abstract class Notice {
 
   private static final String NOTICE_SUFFIX = "Notice";
 
-  private final SeverityLevel severityLevel;
-
-  public Notice(SeverityLevel severityLevel) {
-    this.severityLevel = severityLevel;
-  }
-
-  public JsonElement getContext() {
+  public JsonElement toJsonTree() {
     return GSON.toJsonTree(this);
-  }
-
-  public SeverityLevel getSeverityLevel() {
-    return this.severityLevel;
   }
 
   /**
@@ -82,60 +68,29 @@ public abstract class Notice {
         StringUtils.removeEnd(noticeClass.getSimpleName(), NOTICE_SUFFIX));
   }
 
-  /**
-   * Returns the key used to group notices per type and severity: code + ordinal of severity level.
-   *
-   * @return the key used to group notices per type and severity: code + ordinal of severity level.
-   */
-  public String getMappingKey() {
-    return getCode() + getSeverityLevel().ordinal();
-  }
-
   @Override
-  public boolean equals(Object other) {
-    if (this == other) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
-    if (other instanceof Notice) {
-      Notice otherNotice = (Notice) other;
-      return getClass().equals(otherNotice.getClass())
-          && severityLevel.equals(otherNotice.severityLevel)
-          && getContext().equals(otherNotice.getContext());
+    if (o == null || this.getClass() != o.getClass()) {
+      return false;
     }
-    return false;
+    Notice notice = (Notice) o;
+
+    JsonElement lhsJson = this.toJsonTree();
+    JsonElement rhsJson = notice.toJsonTree();
+    return lhsJson.equals(rhsJson);
   }
 
   @Override
   public String toString() {
-    return String.format("%s %s %s", getCode(), getSeverityLevel(), getContext());
+    return toJsonTree().toString();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), getContext(), getSeverityLevel());
-  }
-
-  /**
-   * Tells if this notice is an {@code ERROR}.
-   *
-   * <p>This method is preferred to checking {@code severityLevel} directly since more levels may be
-   * added in the future.
-   *
-   * @return true if this notice is an error, false otherwise
-   */
-  public boolean isError() {
-    return getSeverityLevel().ordinal() >= SeverityLevel.ERROR.ordinal();
-  }
-
-  /** JSON exclusion strategy for notice context. It skips {@link Notice#severityLevel}. */
-  private static class NoticeExclusionStrategy implements ExclusionStrategy {
-    public boolean shouldSkipClass(Class<?> clazz) {
-      return false;
-    }
-
-    public boolean shouldSkipField(FieldAttributes f) {
-      return f.getName().equals("severityLevel");
-    }
+    return toJsonTree().hashCode();
   }
 
   private static class GtfsColorSerializer implements JsonSerializer<GtfsColor> {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2020 Google LLC, MobilityData IO
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.notice;
+
+import java.util.Objects;
+
+/**
+ * A resolved notice is a wrapper around a plain {@link Notice} that includes the resolved {@link
+ * SeverityLevel} for the notice.
+ */
+public final class ResolvedNotice<T extends Notice> {
+  // The underlying Notice.
+  private final T context;
+
+  private final SeverityLevel severityLevel;
+
+  public ResolvedNotice(T context, SeverityLevel severityLevel) {
+    this.context = context;
+    this.severityLevel = severityLevel;
+  }
+
+  public T getContext() {
+    return this.context;
+  }
+
+  public SeverityLevel getSeverityLevel() {
+    return this.severityLevel;
+  }
+
+  /**
+   * @return the key used to group notices per type and severity: code + ordinal of severity level.
+   */
+  public String getMappingKey() {
+    return context.getCode() + getSeverityLevel().ordinal();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ResolvedNotice<?> notice = (ResolvedNotice<?>) o;
+    return severityLevel == notice.severityLevel && context.equals(notice.context);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("%s %s %s", context.getCode(), getSeverityLevel(), getContext());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), getContext(), getSeverityLevel());
+  }
+
+  /**
+   * Tells if this notice is an {@code ERROR}.
+   *
+   * <p>This method is preferred to checking {@code severityLevel} directly since more levels may be
+   * added in the future.
+   *
+   * @return true if this notice is an error, false otherwise
+   */
+  public boolean isError() {
+    return getSeverityLevel().ordinal() >= SeverityLevel.ERROR.ordinal();
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/SystemError.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/SystemError.java
@@ -31,8 +31,5 @@ package org.mobilitydata.gtfsvalidator.notice;
  */
 public abstract class SystemError extends Notice {
 
-  public SystemError() {
-    // by default SystemError.severity is set to SeverityLevel.ERROR
-    super(SeverityLevel.ERROR);
-  }
+  public SystemError() {}
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ValidationNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ValidationNotice.java
@@ -16,6 +16,9 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.base.Preconditions;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+
 /**
  * ValidationNotice is the base class for all validation errors and warnings related to the content
  * of a GTFS feed.
@@ -26,7 +29,25 @@ package org.mobilitydata.gtfsvalidator.notice;
  */
 public abstract class ValidationNotice extends Notice {
 
-  public ValidationNotice(SeverityLevel severityLevel) {
-    super(severityLevel);
+  public ValidationNotice() {}
+
+  // TODO(bdferris): Remove this constructor in a follow-up PR.
+  public ValidationNotice(SeverityLevel severityLevel) {}
+
+  /**
+   * Resolves the default {@link SeverityLevel} for a validation notice from its {@link
+   * GtfsValidationNotice} annotation.
+   */
+  public static <T extends ValidationNotice> SeverityLevel getDefaultSeverityLevel(
+      Class<T> noticeType) {
+    GtfsValidationNotice annotation = noticeType.getAnnotation(GtfsValidationNotice.class);
+    Preconditions.checkNotNull(
+        annotation,
+        "Found ValidationNotice without a @GtfsValidationNotice annotation: " + noticeType);
+    return annotation.severity();
+  }
+
+  public ResolvedNotice<ValidationNotice> resolveWithDefaultSeverity() {
+    return new ResolvedNotice<>(this, getDefaultSeverityLevel(getClass()));
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/model/NoticeReportTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/model/NoticeReportTest.java
@@ -16,60 +16,47 @@ package org.mobilitydata.gtfsvalidator.model;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gson.internal.LinkedTreeMap;
-import java.util.List;
+import com.google.gson.JsonElement;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.InvalidUrlNotice;
+import org.mobilitydata.gtfsvalidator.notice.Notice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 
 @RunWith(JUnit4.class)
 public class NoticeReportTest {
 
   private static NoticeReport createNoticeReport(
-      String code,
-      SeverityLevel severityLevel,
-      int totalNotices,
-      List<LinkedTreeMap<String, Object>> notices) {
-    return new NoticeReport(code, severityLevel, totalNotices, notices);
+      String code, SeverityLevel severityLevel, int totalNotices, ImmutableList<Notice> notices) {
+    ImmutableList<JsonElement> sampleNotices =
+        notices.stream().map(Notice::toJsonTree).collect(ImmutableList.toImmutableList());
+    return new NoticeReport(code, severityLevel, totalNotices, sampleNotices);
   }
 
-  private static LinkedTreeMap<String, Object> invalidUrlNoticeContext = new LinkedTreeMap<>();
-  private static LinkedTreeMap<String, Object> otherInvalidUrlNoticeContext = new LinkedTreeMap<>();
-
-  static {
-    invalidUrlNoticeContext.put("filename", "stops.txt");
-    invalidUrlNoticeContext.put("csvRowNumber", 16);
-    invalidUrlNoticeContext.put("fieldName", "stop_url");
-    invalidUrlNoticeContext.put("fieldValue", "erroneous url");
-
-    otherInvalidUrlNoticeContext.put("filename", "stops.txt");
-    otherInvalidUrlNoticeContext.put("csvRowNumber", 163);
-    otherInvalidUrlNoticeContext.put("fieldName", "other_url_field");
-    otherInvalidUrlNoticeContext.put("fieldValue", "erroneous url");
-  }
+  private static final Notice INVALID_URL_NOTICE =
+      new InvalidUrlNotice("stops.txt", 16, "stop_url", "erroneous url");
+  private static final Notice OTHER_INVALID_URL_NOTICE =
+      new InvalidUrlNotice("stops.txt", 163, "other_url_field", "erroneous url");
 
   @Test
   public void equals_sameNotices_true() {
     assertThat(
             createNoticeReport(
-                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(invalidUrlNoticeContext)))
+                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(INVALID_URL_NOTICE)))
         .isEqualTo(
             createNoticeReport(
-                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(invalidUrlNoticeContext)));
+                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(INVALID_URL_NOTICE)));
   }
 
   @Test
   public void equals_differentNotices_false() {
     assertThat(
             createNoticeReport(
-                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(invalidUrlNoticeContext)))
+                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(INVALID_URL_NOTICE)))
         .isNotEqualTo(
             createNoticeReport(
-                "invalid_url",
-                SeverityLevel.ERROR,
-                1,
-                ImmutableList.of(otherInvalidUrlNoticeContext)));
+                "invalid_url", SeverityLevel.ERROR, 1, ImmutableList.of(OTHER_INVALID_URL_NOTICE)));
   }
 
   @Test
@@ -83,10 +70,10 @@ public class NoticeReportTest {
   public void equals_differentSeverity_false() {
     assertThat(
             createNoticeReport(
-                "invalid_url", SeverityLevel.INFO, 2, ImmutableList.of(invalidUrlNoticeContext)))
+                "invalid_url", SeverityLevel.INFO, 2, ImmutableList.of(INVALID_URL_NOTICE)))
         .isNotEqualTo(
             createNoticeReport(
-                "invalid_url", SeverityLevel.ERROR, 2, ImmutableList.of(invalidUrlNoticeContext)));
+                "invalid_url", SeverityLevel.ERROR, 2, ImmutableList.of(INVALID_URL_NOTICE)));
   }
 
   @Test

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
@@ -20,52 +20,35 @@ import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 public class NoticeTest {
 
   @Test
-  public void equals_sameNotices() {
-    assertThat(new StringFieldNotice("value1", SeverityLevel.ERROR))
-        .isEqualTo(new StringFieldNotice("value1", SeverityLevel.ERROR));
+  public void equals_sameContext() {
+    assertThat(new StringFieldNotice("value1")).isEqualTo(new StringFieldNotice("value1"));
   }
 
   @Test
   public void equals_differentCode() {
-    assertThat(new StringFieldNotice("value1", SeverityLevel.ERROR))
-        .isNotEqualTo(new OtherStringFieldNotice("value1", SeverityLevel.ERROR));
+    assertThat(new StringFieldNotice("value1")).isNotEqualTo(new OtherStringFieldNotice("value1"));
   }
 
   @Test
   public void equals_differentContext() {
-    assertThat(new StringFieldNotice("value1", SeverityLevel.ERROR))
-        .isNotEqualTo(new StringFieldNotice("value2", SeverityLevel.ERROR));
-  }
-
-  @Test
-  public void equals_differentSeverity() {
-    assertThat(new StringFieldNotice("value1", SeverityLevel.ERROR))
-        .isNotEqualTo(new StringFieldNotice("value1", SeverityLevel.INFO));
-  }
-
-  @Test
-  public void toString_exportsContext() {
-    assertThat(new StringFieldNotice("value1", SeverityLevel.ERROR).toString())
-        .isEqualTo("string_field ERROR {\"someField\":\"value1\"}");
+    assertThat(new StringFieldNotice("value1")).isNotEqualTo(new StringFieldNotice("value2"));
   }
 
   @Test
   public void getCode() {
-    assertThat(new StringFieldNotice("value1", SeverityLevel.ERROR).getCode())
-        .isEqualTo("string_field");
+    assertThat(new StringFieldNotice("value1").getCode()).isEqualTo("string_field");
   }
 
   @Test
-  public void getContext() {
+  public void toJsonTree() {
     JsonObject expected = new JsonObject();
     expected.addProperty("someField", "someValue");
 
-    assertThat(new StringFieldNotice("someValue", SeverityLevel.ERROR).getContext())
-        .isEqualTo(expected);
+    assertThat(new StringFieldNotice("someValue").toJsonTree()).isEqualTo(expected);
   }
 
   @Test
-  public void getContext_gtfsTypes() {
+  public void toJsonTree_gtfsTypes() {
     JsonObject expected = new JsonObject();
     expected.addProperty("color", "#FF00BB");
     expected.addProperty("date", "20210102");
@@ -76,12 +59,12 @@ public class NoticeTest {
                     GtfsColor.fromString("ff00bb"),
                     GtfsDate.fromString("20210102"),
                     GtfsTime.fromString("12:20:34"))
-                .getContext())
+                .toJsonTree())
         .isEqualTo(expected);
   }
 
   @Test
-  public void getContext_s2LatLng() {
+  public void toJsonTree_s2LatLng() {
     S2LatLng latLng = S2LatLng.fromDegrees(45, 48);
     JsonObject expected = new JsonObject();
     JsonArray point = new JsonArray();
@@ -89,38 +72,30 @@ public class NoticeTest {
     point.add(latLng.lngDegrees());
     expected.add("point", point);
 
-    assertThat(new S2LatLngNotice(latLng).getContext()).isEqualTo(expected);
+    assertThat(new S2LatLngNotice(latLng).toJsonTree()).isEqualTo(expected);
   }
 
   @Test
-  public void getContext_noNull() {
+  public void toJsonTree_noNull() {
     JsonObject expected = new JsonObject();
 
     // Null fields should be skipped from the export.
-    assertThat(new StringFieldNotice(null, SeverityLevel.ERROR).getContext()).isEqualTo(expected);
+    assertThat(new StringFieldNotice(null).toJsonTree()).isEqualTo(expected);
   }
 
   @Test
-  public void getContext_exportsInfinity() {
+  public void toJsonTree_exportsInfinity() {
     JsonObject expected = new JsonObject();
     expected.addProperty("doubleField", Double.POSITIVE_INFINITY);
 
-    assertThat(new DoubleFieldNotice(Double.POSITIVE_INFINITY, SeverityLevel.ERROR).getContext())
-        .isEqualTo(expected);
+    assertThat(new DoubleFieldNotice(Double.POSITIVE_INFINITY).toJsonTree()).isEqualTo(expected);
   }
 
-  private static class OtherStringFieldNotice extends Notice {
+  private static class OtherStringFieldNotice extends ValidationNotice {
     private final String someField;
 
-    public OtherStringFieldNotice(String someField, SeverityLevel severityLevel) {
-      super(severityLevel);
+    public OtherStringFieldNotice(String someField) {
       this.someField = someField;
     }
-  }
-
-  @Test
-  public void getMappingKey_returnsFieldCombination() {
-    OtherStringFieldNotice notice = new OtherStringFieldNotice("some field", SeverityLevel.ERROR);
-    assertThat(notice.getMappingKey()).matches("other_string_field2");
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNoticeTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNoticeTest.java
@@ -1,0 +1,58 @@
+package org.mobilitydata.gtfsvalidator.notice;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.testnotices.StringFieldNotice;
+
+@RunWith(JUnit4.class)
+public class ResolvedNoticeTest {
+
+  @Test
+  public void equals_sameContext() {
+    assertThat(
+            new ResolvedNotice<ValidationNotice>(
+                new StringFieldNotice("value1"), SeverityLevel.ERROR))
+        .isEqualTo(
+            new ResolvedNotice<ValidationNotice>(
+                new StringFieldNotice("value1"), SeverityLevel.ERROR));
+  }
+
+  @Test
+  public void equals_differentContext() {
+    assertThat(
+            new ResolvedNotice<ValidationNotice>(
+                new StringFieldNotice("value1"), SeverityLevel.ERROR))
+        .isNotEqualTo(
+            new ResolvedNotice<ValidationNotice>(
+                new StringFieldNotice("value2"), SeverityLevel.ERROR));
+  }
+
+  @Test
+  public void equals_differentSeverity() {
+    assertThat(
+            new ResolvedNotice<ValidationNotice>(
+                new StringFieldNotice("value1"), SeverityLevel.ERROR))
+        .isNotEqualTo(
+            new ResolvedNotice<ValidationNotice>(
+                new StringFieldNotice("value1"), SeverityLevel.WARNING));
+  }
+
+  @Test
+  public void toString_exportsContext() {
+    assertThat(
+            new ResolvedNotice<ValidationNotice>(
+                    new StringFieldNotice("value1"), SeverityLevel.ERROR)
+                .toString())
+        .isEqualTo("string_field ERROR {\"someField\":\"value1\"}");
+  }
+
+  @Test
+  public void getMappingKey_returnsFieldCombination() {
+    ResolvedNotice<ValidationNotice> notice =
+        new ResolvedNotice<>(new StringFieldNotice("some field"), SeverityLevel.ERROR);
+    assertThat(notice.getMappingKey()).matches("string_field2");
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/DoubleFieldNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/DoubleFieldNotice.java
@@ -16,15 +16,17 @@
 
 package org.mobilitydata.gtfsvalidator.notice.testnotices;
 
-import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 
+@GtfsValidationNotice(severity = ERROR)
 public class DoubleFieldNotice extends ValidationNotice {
 
   private final double doubleField;
 
-  public DoubleFieldNotice(double doubleField, SeverityLevel severityLevel) {
-    super(severityLevel);
+  public DoubleFieldNotice(double doubleField) {
     this.doubleField = doubleField;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/GtfsTypesValidationNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/GtfsTypesValidationNotice.java
@@ -16,13 +16,13 @@
 
 package org.mobilitydata.gtfsvalidator.notice.testnotices;
 
-import org.mobilitydata.gtfsvalidator.notice.Notice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 
-public class GtfsTypesValidationNotice extends Notice {
+public class GtfsTypesValidationNotice extends ValidationNotice {
 
   private final GtfsColor color;
   private final GtfsDate date;

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/StringFieldNotice.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/testnotices/StringFieldNotice.java
@@ -16,15 +16,17 @@
 
 package org.mobilitydata.gtfsvalidator.notice.testnotices;
 
-import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 
+@GtfsValidationNotice(severity = ERROR)
 public class StringFieldNotice extends ValidationNotice {
 
   private final String someField;
 
-  public StringFieldNotice(String someField, SeverityLevel severityLevel) {
-    super(severityLevel);
+  public StringFieldNotice(String someField) {
     this.someField = someField;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/parsing/RowParserTest.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Arrays;
 import java.util.function.Function;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -68,7 +69,7 @@ public class RowParserTest {
     RowParser parser = createParser(cellValue);
     assertThat(parse.apply(parser)).isEqualTo(expected);
     assertThat(parser.getNoticeContainer().getValidationNotices())
-        .containsExactlyElementsIn(validationNotices);
+        .containsExactlyElementsIn(Arrays.asList(validationNotices));
     assertThat(parser.getNoticeContainer().hasValidationErrors()).isTrue();
   }
 
@@ -91,7 +92,7 @@ public class RowParserTest {
     RowParser parser = createParser("ABCDE");
 
     assertThat(parser.asString(0, FieldLevelEnum.RECOMMENDED)).isEqualTo("ABCDE");
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
   }
 
   @Test
@@ -99,7 +100,7 @@ public class RowParserTest {
     RowParser parser = createParser("ABCDE");
 
     assertThat(parser.asString(0, FieldLevelEnum.REQUIRED)).isEqualTo("ABCDE");
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
   }
 
   @Test
@@ -129,19 +130,19 @@ public class RowParserTest {
     RowParser parser = createParser("12345");
 
     assertThat(parser.asInteger(0, FieldLevelEnum.REQUIRED)).isEqualTo(12345);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asInteger(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.NON_NEGATIVE))
         .isEqualTo(12345);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asInteger(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.NON_ZERO))
         .isEqualTo(12345);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asInteger(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.POSITIVE))
         .isEqualTo(12345);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(createParser("abc").asInteger(0, FieldLevelEnum.REQUIRED)).isNull();
   }
@@ -151,19 +152,19 @@ public class RowParserTest {
     RowParser parser = createParser("123.45");
 
     assertThat(parser.asDecimal(0, FieldLevelEnum.REQUIRED)).isEqualTo(new BigDecimal("123.45"));
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asDecimal(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.NON_NEGATIVE))
         .isEqualTo(new BigDecimal("123.45"));
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asDecimal(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.NON_ZERO))
         .isEqualTo(new BigDecimal("123.45"));
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asDecimal(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.POSITIVE))
         .isEqualTo(new BigDecimal("123.45"));
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(createParser("abc").asDecimal(0, FieldLevelEnum.REQUIRED)).isNull();
   }
@@ -173,19 +174,19 @@ public class RowParserTest {
     RowParser parser = createParser("123.45");
 
     assertThat(parser.asFloat(0, FieldLevelEnum.REQUIRED)).isEqualTo(123.45);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asFloat(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.NON_NEGATIVE))
         .isEqualTo(123.45);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asFloat(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.NON_ZERO))
         .isEqualTo(123.45);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(parser.asFloat(0, FieldLevelEnum.REQUIRED, RowParser.NumberBounds.POSITIVE))
         .isEqualTo(123.45);
-    assertThat(parser.getNoticeContainer().getValidationNotices().isEmpty()).isTrue();
+    assertThat(parser.getNoticeContainer().getValidationNotices()).isEmpty();
 
     assertThat(createParser("abc").asFloat(0, FieldLevelEnum.REQUIRED)).isNull();
   }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
@@ -79,8 +79,7 @@ public class AnyTableLoaderTest {
             GtfsTableContainer.TableStatus.INVALID_HEADERS))
         .thenReturn(mockContainer);
     InputStream csvInputStream = toInputStream("A file with no headers");
-    ValidationNotice headerValidationNotice = mock(ValidationNotice.class);
-    when(headerValidationNotice.isError()).thenReturn(true);
+    ValidationNotice headerValidationNotice = new EmptyColumnNameNotice("stops.txt", 0);
     TableHeaderValidator tableHeaderValidator =
         new TableHeaderValidator() {
           @Override

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
@@ -8,19 +8,20 @@ import java.util.ArrayList;
 import java.util.List;
 import org.mobilitydata.gtfsvalidator.notice.Notice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeDocComments;
+import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.notice.schema.NoticeSchemaGenerator;
 
 /** NoticeView is a wrapper class to display a Notice. */
 public class NoticeView {
-  private final Notice notice;
+  private final ResolvedNotice notice;
   private final JsonObject json;
   private final List<String> fields;
   private final NoticeDocComments comments;
 
-  public NoticeView(Notice notice) {
+  public NoticeView(ResolvedNotice<? extends Notice> notice) {
     this.notice = notice;
-    this.json = notice.getContext().getAsJsonObject();
+    this.json = notice.getContext().toJsonTree().getAsJsonObject();
     this.fields = new ArrayList<>(json.keySet());
     this.comments = NoticeSchemaGenerator.loadComments(notice.getClass());
   }
@@ -31,7 +32,7 @@ public class NoticeView {
    * @return notice name, e.g., "ForeignKeyViolationNotice".
    */
   public String getName() {
-    return notice.getClass().getSimpleName();
+    return notice.getContext().getClass().getSimpleName();
   }
 
   /**
@@ -90,6 +91,6 @@ public class NoticeView {
    * @return notice code, e.g., "foreign_key_violation".
    */
   public String getCode() {
-    return notice.getCode();
+    return notice.getContext().getCode();
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/ReportSummary.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-import org.mobilitydata.gtfsvalidator.notice.Notice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
 import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
@@ -36,10 +36,11 @@ public class ReportSummary {
   public ReportSummary(NoticeContainer container, VersionInfo versionInfo) {
     this.container = container;
     this.severityCounts =
-        container.getValidationNotices().stream()
-            .collect(Collectors.groupingBy(Notice::getSeverityLevel, Collectors.counting()));
+        container.getResolvedValidationNotices().stream()
+            .collect(
+                Collectors.groupingBy(ResolvedNotice::getSeverityLevel, Collectors.counting()));
     this.noticesMap =
-        container.getValidationNotices().stream()
+        container.getResolvedValidationNotices().stream()
             .map(NoticeView::new)
             .collect(
                 Collectors.groupingBy(

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/report/model/NoticeViewTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/report/model/NoticeViewTest.java
@@ -7,8 +7,9 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
-import org.mobilitydata.gtfsvalidator.notice.Notice;
+import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 
 public class NoticeViewTest {
   private static final String FILENAME = "filename";
@@ -19,8 +20,9 @@ public class NoticeViewTest {
   private static final int CSV_ROW_NUMBER_VALUE = 1;
   private static final String FIELD_NAME_VALUE = "field";
 
-  private static final Notice notice =
-      new MissingRequiredFieldNotice(FILENAME_VALUE, CSV_ROW_NUMBER_VALUE, FIELD_NAME_VALUE);
+  private static final ResolvedNotice<ValidationNotice> notice =
+      new MissingRequiredFieldNotice(FILENAME_VALUE, CSV_ROW_NUMBER_VALUE, FIELD_NAME_VALUE)
+          .resolveWithDefaultSeverity();
   private static final NoticeView noticeView = new NoticeView(notice);
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/AgencyConsistencyValidatorTest.java
@@ -73,7 +73,6 @@ public class AgencyConsistencyValidatorTest {
                     Locale.CANADA)));
     assertThat(notices)
         .containsExactly(new MissingRecommendedFieldNotice("agency.txt", 0, "agency name"));
-    assertThat(notices.get(0).getSeverityLevel()).isEqualTo(SeverityLevel.WARNING);
   }
 
   @Test
@@ -97,7 +96,6 @@ public class AgencyConsistencyValidatorTest {
                     Locale.CANADA)));
     assertThat(notices)
         .containsExactly(new MissingRequiredFieldNotice("agency.txt", 1, "agency_id"));
-    assertThat(notices.get(0).getSeverityLevel()).isEqualTo(SeverityLevel.ERROR);
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidatorTest.java
@@ -59,8 +59,7 @@ public class ShapeToStopMatchingValidatorTest {
 
   private static boolean noticeApproxEquals(
       ValidationNotice n1, ValidationNotice n2, double maxError) {
-    if (!n1.getClass().equals(n2.getClass())
-        || !n1.getSeverityLevel().equals(n2.getSeverityLevel())) {
+    if (!n1.getClass().equals(n2.getClass())) {
       return false;
     }
     for (Field field : n1.getClass().getDeclaredFields()) {

--- a/output-comparator/src/test/java/org/mobilitydata/gtfsvalidator/outputcomparator/cli/MainTest.java
+++ b/output-comparator/src/test/java/org/mobilitydata/gtfsvalidator/outputcomparator/cli/MainTest.java
@@ -98,10 +98,11 @@ public class MainTest {
         new MissingRecommendedFieldNotice("other filename", 12, "other field name"));
 
     writeFile(
-        latestNoticeContainer.exportJson(latestNoticeContainer.getValidationNotices()),
+        latestNoticeContainer.exportJson(latestNoticeContainer.getResolvedValidationNotices()),
         resolve(NO_NEW_NOTICE_FOLDER_NAME, "source-id-1", LATEST_JSON));
     writeFile(
-        referenceNoticeContainer.exportJson(referenceNoticeContainer.getValidationNotices()),
+        referenceNoticeContainer.exportJson(
+            referenceNoticeContainer.getResolvedValidationNotices()),
         resolve(NO_NEW_NOTICE_FOLDER_NAME, "source-id-1", REFERENCE_JSON));
 
     JsonObject sourceUrlJsonObject = new JsonObject();
@@ -152,10 +153,11 @@ public class MainTest {
     latestNoticeContainer.addValidationNotice(new EmptyColumnNameNotice("filename", 5));
 
     writeFile(
-        latestNoticeContainer.exportJson(latestNoticeContainer.getValidationNotices()),
+        latestNoticeContainer.exportJson(latestNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-1", LATEST_JSON));
     writeFile(
-        referenceNoticeContainer.exportJson(referenceNoticeContainer.getValidationNotices()),
+        referenceNoticeContainer.exportJson(
+            referenceNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-1", REFERENCE_JSON));
 
     latestNoticeContainer.addValidationNotice(
@@ -168,10 +170,11 @@ public class MainTest {
         new MissingRecommendedFieldNotice("other filename", 12, "other field name"));
 
     writeFile(
-        latestNoticeContainer.exportJson(latestNoticeContainer.getValidationNotices()),
+        latestNoticeContainer.exportJson(latestNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-2", LATEST_JSON));
     writeFile(
-        referenceNoticeContainer.exportJson(referenceNoticeContainer.getValidationNotices()),
+        referenceNoticeContainer.exportJson(
+            referenceNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-2", REFERENCE_JSON));
 
     latestNoticeContainer.addValidationNotice(
@@ -183,10 +186,11 @@ public class MainTest {
         new DuplicateKeyNotice("some filename", 9, 11, "field name 1", "field value1"));
 
     writeFile(
-        latestNoticeContainer.exportJson(latestNoticeContainer.getValidationNotices()),
+        latestNoticeContainer.exportJson(latestNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-3", LATEST_JSON));
     writeFile(
-        referenceNoticeContainer.exportJson(referenceNoticeContainer.getValidationNotices()),
+        referenceNoticeContainer.exportJson(
+            referenceNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-3", REFERENCE_JSON));
 
     JsonObject sourceUrlJsonObject = new JsonObject();
@@ -238,10 +242,11 @@ public class MainTest {
     latestNoticeContainer.addValidationNotice(new EmptyColumnNameNotice("filename", 5));
 
     writeFile(
-        latestNoticeContainer.exportJson(latestNoticeContainer.getValidationNotices()),
+        latestNoticeContainer.exportJson(latestNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-1", LATEST_JSON));
     writeFile(
-        referenceNoticeContainer.exportJson(referenceNoticeContainer.getValidationNotices()),
+        referenceNoticeContainer.exportJson(
+            referenceNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-1", REFERENCE_JSON));
 
     // An error notice present only in the reference report.
@@ -252,10 +257,11 @@ public class MainTest {
         new MissingRecommendedFieldNotice("other filename", 12, "other field name"));
 
     writeFile(
-        latestNoticeContainer.exportJson(latestNoticeContainer.getValidationNotices()),
+        latestNoticeContainer.exportJson(latestNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-2", LATEST_JSON));
     writeFile(
-        referenceNoticeContainer.exportJson(referenceNoticeContainer.getValidationNotices()),
+        referenceNoticeContainer.exportJson(
+            referenceNoticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-2", REFERENCE_JSON));
 
     JsonObject sourceUrlJsonObject = new JsonObject();
@@ -302,24 +308,24 @@ public class MainTest {
     noticeContainer.addValidationNotice(new EmptyColumnNameNotice("other file", 4));
 
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-1", LATEST_JSON));
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-1", REFERENCE_JSON));
 
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-2", LATEST_JSON));
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-2", REFERENCE_JSON));
 
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-3", LATEST_JSON));
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-3", REFERENCE_JSON));
 
     JsonObject sourceUrlJsonObject = new JsonObject();
@@ -351,14 +357,14 @@ public class MainTest {
     };
 
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-4", "invalid_latest.json"));
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-4", "invalid_reference.json"));
 
     writeFile(
-        noticeContainer.exportJson(noticeContainer.getValidationNotices()),
+        noticeContainer.exportJson(noticeContainer.getResolvedValidationNotices()),
         resolve(NEW_NOTICES_TYPE_FOLDER_NAME, "source-id-5", "latest.json"));
 
     int exitCode = Main.run(argv);

--- a/output-comparator/src/test/java/org/mobilitydata/gtfsvalidator/outputcomparator/io/NoticeSetTest.java
+++ b/output-comparator/src/test/java/org/mobilitydata/gtfsvalidator/outputcomparator/io/NoticeSetTest.java
@@ -19,7 +19,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
 
 import com.google.common.collect.ImmutableList;
-import com.google.gson.internal.LinkedTreeMap;
+import com.google.gson.JsonElement;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
@@ -27,7 +27,7 @@ import org.mobilitydata.gtfsvalidator.model.NoticeReport;
 
 public class NoticeSetTest {
 
-  private static final List<LinkedTreeMap<String, Object>> SAMPLES = Collections.emptyList();
+  private static final List<JsonElement> SAMPLES = Collections.emptyList();
 
   @Test
   public void hasSameErrorCodes_sameErrorsInReports_true() {


### PR DESCRIPTION
As originally discussed in https://bit.ly/gtfs-validator-notice-documentation, when we introduced @GtfsValidationNotice to document validation notice, the plan was to follow-up by refactoring SeverityLevel from the notice constructor. This PR performs that refactor.

Specifically, it pulls `severityLevel` out of `Notice` and moves it to a new `ResolvedNotice` class, which is a wrapper around  `Notice` object that includes the resolved severity level.  Additionally, the severity level of the notice is resolved when it is added to `NoticeContainer`, which has been refactored to hold `ResolvedNotices` now.  This paves the way for config-driven severity levels for notices, which could be implemented within `NoticeContainer` in the future.

Closes #1472.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
