### PR TITLE
fix: Web validator allows non-zip files to be uploaded

### DIFF
--- a/web/client/src/routes/+page.svelte
+++ b/web/client/src/routes/+page.svelte
@@ -137,6 +137,7 @@
     if (file.type != 'application/zip' && file.type != 'application/x-zip-compressed') {
       console.log('file type error', file.type);
       addError('Sorry, only ZIP files are supported at this time.');
+      fileInput.value = ''; // clear input to avoid validation
       console.log(errors);
     } else {
       pendingFilename = file?.name;


### PR DESCRIPTION
**Summary:**

Fix for bug [#1440](https://github.com/MobilityData/gtfs-validator/issues/1440): Web validator allows non-zip files to be uploaded

**Expected behavior:** 

The result should be the same as when the Validate button is clicked when no file was selected. A message should say Please include a file to validate.
![Screenshot 2023-06-05 at 12 26 41 PM](https://github.com/MobilityData/gtfs-validator/assets/60586858/b78821e0-e539-402f-9159-f5fe8e6e7a4d)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
