### PR TITLE
Fix: bug in Notice documentation comment splitting.

### DIFF
--- a/processor/notices/src/test/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentCleanerTest.java
+++ b/processor/notices/src/test/java/org/mobilitydata/gtfsvalidator/processor/notices/CommentCleanerTest.java
@@ -85,11 +85,22 @@ public class CommentCleanerTest {
   }
 
   @Test
-  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_noBlankLines() {
+  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_multiLineSummary() {
     SplitComment split =
-        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(ImmutableList.of("A.", "B."));
+        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(
+            ImmutableList.of("This line continues", "onto the next line.", "", "Description."));
+
+    assertThat(split.shortSummary).isEqualTo("This line continues onto the next line.");
+    assertThat(split.additionalDocumentation).isEqualTo("Description.");
+  }
+
+  @Test
+  public void testSplitLinesIntoSummaryAndAdditionalDocumentation_multiLineDescription() {
+    SplitComment split =
+        cleaner.splitLinesIntoSummaryAndAdditionalDocumentation(
+            ImmutableList.of("A.", "", "B.", "", "C."));
 
     assertThat(split.shortSummary).isEqualTo("A.");
-    assertThat(split.additionalDocumentation).isEqualTo("B.");
+    assertThat(split.additionalDocumentation).isEqualTo("B.\n\nC.");
   }
 }


### PR DESCRIPTION
Closes #1478.

There is a bug in extracting `NoticeDocumentation.shortSummary` strings from Notice comment blocks.  Specifically, it's not correctly handling longer short-summary strings.  This PR adds a fix.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
