### PR TITLE
fix: Web Validator hangs after supplying non-zip URL #1445

### DIFF
--- a/web/client/src/routes/+page.svelte
+++ b/web/client/src/routes/+page.svelte
@@ -221,7 +221,13 @@
       const xhr = new XMLHttpRequest();
       xhr.responseType = 'json';
       xhr.onerror = () => reject('Error authorizing upload.');
-      xhr.onload = () => resolve(xhr.response);
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          resolve(xhr.response);
+        } else {
+          reject('Error authorizing upload.');
+        }
+      };
       xhr.open('POST', `${apiRoot}/create-job`);
       xhr.setRequestHeader('Content-Type', 'application/json');
       xhr.send(JSON.stringify(data));


### PR DESCRIPTION
**Summary:**

Fix for bug [#1445](https://github.com/MobilityData/gtfs-validator/issues/1445) : Web Validator hangs after supplying non-zip URL

**Expected behavior:** 
Error is displayed when the supplied url is invalid.
 
![Screenshot 2023-06-05 at 12 04 48 PM](https://github.com/MobilityData/gtfs-validator/assets/60586858/7a62bdbe-d98b-4067-baeb-20a4de3bb38c)


**Implementation Details**:
The `load` event for `XMLHttpRequest` is triggered once the request is complete even in the case of server error status code 500 which we send from `web/service/controller/ValidationController`. 
Ref: https://javascript.info/xmlhttprequest 


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
