### PR TITLE
refactor(ci): rename cypress workflow to be consistent

### DIFF
--- a/.github/workflows/web_client_test.yml
+++ b/.github/workflows/web_client_test.yml
@@ -1,4 +1,4 @@
-name: Cypress E2E Tests
+name: Web client Cypress e2e tests
 
 on:
   pull_request:


### PR DESCRIPTION
Minor change to promote consistency. This also highlights that maybe this workflow could/should be merged into `.github/workflows/web_client_pr.yml` if we're factoring workflows more around lifecycle stage than outcome