### PR TITLE
feat: Provide an explanation to users about what a GTFS Component is #1505

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
@@ -23,7 +23,7 @@ public class NoticeView {
     this.notice = notice;
     this.json = notice.getContext().toJsonTree().getAsJsonObject();
     this.fields = new ArrayList<>(json.keySet());
-    this.comments = NoticeSchemaGenerator.loadComments(notice.getClass());
+    this.comments = NoticeSchemaGenerator.loadComments(notice.getContext().getClass());
   }
 
   /**

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -73,6 +73,7 @@
     .summary-cell {
         padding: 5px;
         box-sizing: border-box;
+        flex: 1;
     }
 
     .summary h4 {
@@ -129,10 +130,19 @@
         position: absolute;
         z-index: 1;
         bottom: 100%;
-        left: 50%;
-        margin-left: -60px;
+        transform: translateX(-50%);
         opacity: 0;
         transition: opacity 0.3s;
+        max-width: 400px;
+        min-width: 100px;
+        width: max-content;
+        white-space: normal;
+    }
+
+    .tooltip {
+        position: relative;
+        display: inline-block;
+        cursor: help;
     }
 
     .tooltip:hover .tooltiptext {
@@ -262,7 +272,12 @@
                 </ul>
             </div>
             <div class="summary-cell summary_list">
-                <h4>GTFS Components included</h4>
+                <h4>
+                    GTFS Components included
+                    <a href="#" class="tooltip" onclick="event.preventDefault();"><span>(?)</span>
+                        <span class="tooltiptext" style="transform: translateX(-100%)">GTFS components provide a standardized vocabulary to define and describe features that are officially adopted in GTFS.</span>
+                    </a>
+                </h4>
                 <hr />
                 <div>
                     <span class="spec-feature" th:each="feature: ${metadata.specFeatures}" th:if="${feature.value == 'Yes'}" th:text="${feature.key}" />


### PR DESCRIPTION
**Summary:**

The GTFS Component now has a description to help the user understand its value.
The summary section is as wide as the compliance report.

**Expected behavior:** 
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/3f4b82a3-8348-491e-b458-456db50d89d7)

Closes #1505 
Closes #1467 

Also fixes missing summary section for notices and missing description for the notice's fields.
Before:
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/d56c23aa-7c9a-4921-9edb-0a76b2514b76)


With the changes:
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/caf89386-2786-4c1f-8a05-08518273f1d6)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
