### PR TITLE
fix: don't throw exception on calendar with no days

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
@@ -57,8 +57,7 @@ public class ExpiredCalendarValidator extends FileValidator {
             CalendarUtil.buildServicePeriodMap(calendarTable, calendarDateTable));
     for (var serviceId : servicePeriodMap.keySet()) {
       SortedSet<LocalDate> serviceDates = servicePeriodMap.get(serviceId);
-      LocalDate lastServiceDate = serviceDates.last();
-      if (lastServiceDate.isBefore(now)) {
+      if (!serviceDates.isEmpty() && serviceDates.last().isBefore(now)) {
         int csvRowNumber = calendarTable.byServiceId(serviceId).get().csvRowNumber();
         noticeContainer.addValidationNotice(new ExpiredCalendarNotice(csvRowNumber, serviceId));
       }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
@@ -195,4 +195,25 @@ public class ExpiredCalendarValidatorTest {
     assertThat(container.getValidationNotices())
         .containsExactly(new ExpiredCalendarValidator.ExpiredCalendarNotice(2, "WEEK"));
   }
+
+  @Test
+  public void calendarWithNoDaysShouldNotGenerateNotice() {
+    NoticeContainer container = new NoticeContainer();
+
+    List<GtfsCalendar> calendars =
+            ImmutableList.of(
+                    new GtfsCalendar.Builder()
+                            .setCsvRowNumber(2)
+                            .setServiceId("WEEK")
+                            .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
+                            .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                            .build());
+
+    GtfsCalendarTableContainer calendarTable =
+            GtfsCalendarTableContainer.forEntities(calendars, container);
+    var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
+    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+            .validate(container);
+    assertThat(container.getValidationNotices()).isEmpty();
+  }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
@@ -201,19 +201,19 @@ public class ExpiredCalendarValidatorTest {
     NoticeContainer container = new NoticeContainer();
 
     List<GtfsCalendar> calendars =
-            ImmutableList.of(
-                    new GtfsCalendar.Builder()
-                            .setCsvRowNumber(2)
-                            .setServiceId("WEEK")
-                            .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                            .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
-                            .build());
+        ImmutableList.of(
+            new GtfsCalendar.Builder()
+                .setCsvRowNumber(2)
+                .setServiceId("WEEK")
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                .build());
 
     GtfsCalendarTableContainer calendarTable =
-            GtfsCalendarTableContainer.forEntities(calendars, container);
+        GtfsCalendarTableContainer.forEntities(calendars, container);
     var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
     new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
-            .validate(container);
+        .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
   }
 }


### PR DESCRIPTION
**Summary:**

Fix ExpiredCalendarValidator throwing NoSuchElementException when checking a calendar with no days set to 1.

**Expected behavior:** 

Checking a calendar.txt file where a row has no days set to 1 does not crash the validator.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
