### PR TITLE
feat: flag 404 error code for URL fields

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UrlNotFoundNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UrlNotFoundNotice.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.notice;
+
+import static org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef.FILED_TYPES;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRefs;
+
+/**
+ * A field contains an inaccessible URL.
+ *
+ * <p>This notice is triggered if a URL field is inaccessible i.e. returns a 404 status code.
+ */
+@GtfsValidationNotice(severity = WARNING, sections = @SectionRefs(FILED_TYPES))
+public class UrlNotFoundNotice extends ValidationNotice {
+
+  /** The name of the faulty file. */
+  private final String filename;
+
+  /** The row of the faulty record. */
+  private final int csvRowNumber;
+
+  /** Faulty record's field name. */
+  private final String fieldName;
+
+  /** Faulty value. */
+  private final String fieldValue;
+
+  public UrlNotFoundNotice(
+      String filename, int csvRowNumber, String fieldName, String fieldValue) {
+    this.filename = filename;
+    this.csvRowNumber = csvRowNumber;
+    this.fieldName = fieldName;
+    this.fieldValue = fieldValue;
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UrlNotFoundNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/UrlNotFoundNotice.java
@@ -41,8 +41,7 @@ public class UrlNotFoundNotice extends ValidationNotice {
   /** Faulty value. */
   private final String fieldValue;
 
-  public UrlNotFoundNotice(
-      String filename, int csvRowNumber, String fieldName, String fieldValue) {
+  public UrlNotFoundNotice(String filename, int csvRowNumber, String fieldName, String fieldValue) {
     this.filename = filename;
     this.csvRowNumber = csvRowNumber;
     this.fieldName = fieldName;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/UrlUtil.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/UrlUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.util;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import org.apache.commons.validator.routines.UrlValidator;
+
+/** Utility functions for validating urls */
+public class UrlUtil {
+  private static final int URL_ERROR_CODE = 404;
+
+  public enum UrlStatus {
+    VALID,
+    INVALID,
+    NOT_FOUND
+  }
+  /**
+   * Validates the provided URL for correctness and accessibility.
+   * <p>
+   * This method first checks if the provided URL string is in a valid format, then checks if the URL
+   * is accessible by making an HTTP connection and checking the response code. The status of the URL
+   * is determined based on these checks and returned as a UrlStatus enum value.
+   *
+   * @param urlString The URL string to be validated.
+   * @return UrlStatus - Returns the status of the URL.
+   *         - INVALID: If the URL is not in a valid format.
+   *         - NOT_FOUND: If the URL is in a valid format but is not accessible (i.e., it does not respond or throws an exception).
+   *         - VALID: If the URL is in a valid format and is accessible.
+   */
+  public static UrlStatus validateUrl(String urlString) {
+    if (!UrlValidator.getInstance().isValid(urlString)) {
+      return UrlStatus.INVALID;
+    }
+    try {
+      URL url = new URL(urlString);
+      HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+      return connection.getResponseCode() != URL_ERROR_CODE
+          ? UrlStatus.VALID
+          : UrlStatus.NOT_FOUND;
+    } catch (MalformedURLException e) {
+      return UrlStatus.INVALID;
+    } catch (IOException e) {
+      return UrlStatus.NOT_FOUND;
+    }
+  }
+
+  private UrlUtil() {}
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/UrlUtil.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/UrlUtil.java
@@ -33,16 +33,16 @@ public class UrlUtil {
   }
   /**
    * Validates the provided URL for correctness and accessibility.
-   * <p>
-   * This method first checks if the provided URL string is in a valid format, then checks if the URL
-   * is accessible by making an HTTP connection and checking the response code. The status of the URL
-   * is determined based on these checks and returned as a UrlStatus enum value.
+   *
+   * <p>This method first checks if the provided URL string is in a valid format, then checks if the
+   * URL is accessible by making an HTTP connection and checking the response code. The status of
+   * the URL is determined based on these checks and returned as a UrlStatus enum value.
    *
    * @param urlString The URL string to be validated.
-   * @return UrlStatus - Returns the status of the URL.
-   *         - INVALID: If the URL is not in a valid format.
-   *         - NOT_FOUND: If the URL is in a valid format but is not accessible (i.e., it does not respond or throws an exception).
-   *         - VALID: If the URL is in a valid format and is accessible.
+   * @return UrlStatus - Returns the status of the URL. - INVALID: If the URL is not in a valid
+   *     format. - NOT_FOUND: If the URL is in a valid format but is not accessible (i.e., it does
+   *     not respond or throws an exception). - VALID: If the URL is in a valid format and is
+   *     accessible.
    */
   public static UrlStatus validateUrl(String urlString) {
     if (!UrlValidator.getInstance().isValid(urlString)) {
@@ -51,9 +51,7 @@ public class UrlUtil {
     try {
       URL url = new URL(urlString);
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
-      return connection.getResponseCode() != URL_ERROR_CODE
-          ? UrlStatus.VALID
-          : UrlStatus.NOT_FOUND;
+      return connection.getResponseCode() != URL_ERROR_CODE ? UrlStatus.VALID : UrlStatus.NOT_FOUND;
     } catch (MalformedURLException e) {
       return UrlStatus.INVALID;
     } catch (IOException e) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultFieldValidator.java
@@ -18,15 +18,10 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.i18n.phonenumbers.PhoneNumberUtil;
 import org.apache.commons.validator.routines.EmailValidator;
-import org.apache.commons.validator.routines.UrlValidator;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.notice.InvalidEmailNotice;
-import org.mobilitydata.gtfsvalidator.notice.InvalidPhoneNumberNotice;
-import org.mobilitydata.gtfsvalidator.notice.InvalidUrlNotice;
-import org.mobilitydata.gtfsvalidator.notice.LeadingOrTrailingWhitespacesNotice;
-import org.mobilitydata.gtfsvalidator.notice.NewLineInValueNotice;
-import org.mobilitydata.gtfsvalidator.notice.NonAsciiOrNonPrintableCharNotice;
-import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.*;
+import org.mobilitydata.gtfsvalidator.util.UrlUtil;
+import org.mobilitydata.gtfsvalidator.util.UrlUtil.UrlStatus;
 
 /** Default implementation of {@link GtfsFieldValidator}. */
 public class DefaultFieldValidator implements GtfsFieldValidator {
@@ -73,11 +68,15 @@ public class DefaultFieldValidator implements GtfsFieldValidator {
   @Override
   public void validateUrl(
       String url, GtfsCellContext cellContext, NoticeContainer noticeContainer) {
-    if (!UrlValidator.getInstance().isValid(url)) {
+    UrlStatus status = UrlUtil.validateUrl(url);
+    if (status == UrlStatus.INVALID)
       noticeContainer.addValidationNotice(
           new InvalidUrlNotice(
               cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), url));
-    }
+    else if (status == UrlStatus.NOT_FOUND)
+      noticeContainer.addValidationNotice(
+          new UrlNotFoundNotice(
+              cellContext.filename(), cellContext.csvRowNumber(), cellContext.fieldName(), url));
   }
 
   @Override


### PR DESCRIPTION
**Summary:**

A user has asked if this validator could validate if the URLs provided in the GTFS dataset (e. g. agency_url, stop_url, etc) work as intended.

**Expected behavior:** 
If one of the URL fields in the GTFS dataset through a 404 Error, a `url_not_found` Warning is generate in the report.
![Screenshot 2023-07-04 at 2 47 47 PM](https://github.com/MobilityData/gtfs-validator/assets/60586858/68f8bf85-36f8-458c-aec7-5aac22ee55a3)

Closes #1521 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
