### PR TITLE
fix: Forced java version to 17.0.7 in github action 

### DIFF
--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           # We need a recent version of Java with jpackage included.
-          java-version: '17'
+          java-version: '17.0.7'
           # We use the zulu distribution, which is an OpenJDK distro.
           distribution: 'zulu'
 


### PR DESCRIPTION
Forced java version to 17.0.7 in Github action package_installers.yml because the action fails with latest version which is currently 17.0.8

**Summary:**
This is a workaround until we understands what's going on with java 17.0.8-zulu

**Expected behavior:** 
The github action should run without error

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
