### PR TITLE
fix: decreasing_or_equal_stop_time_distance

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -97,7 +97,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
      * Actual distance traveled along the shape from the first shape point to the previous stop
      * time.
      */
-    private final double prevStopTimeDistTraveled;
+    private final double prevShapeDistTraveled;
 
     /** The previous record's `stop_times.stop_sequence`. */
     private final int prevStopSequence;
@@ -108,14 +108,14 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
         double shapeDistTraveled,
         int stopSequence,
         long prevCsvRowNumber,
-        double prevStopTimeDistTraveled,
+        double prevShapeDistTraveled,
         int prevStopSequence) {
       this.tripId = tripId;
       this.csvRowNumber = csvRowNumber;
       this.shapeDistTraveled = shapeDistTraveled;
       this.stopSequence = stopSequence;
       this.prevCsvRowNumber = prevCsvRowNumber;
-      this.prevStopTimeDistTraveled = prevStopTimeDistTraveled;
+      this.prevShapeDistTraveled = prevShapeDistTraveled;
       this.prevStopSequence = prevStopSequence;
     }
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
@@ -133,6 +133,7 @@ public class NoticeFieldsTest {
             "prevShapeDistTraveled",
             "prevShapePtSequence",
             "prevStopSequence",
+            "prevShapeDistTraveled",
             "recordId",
             "recordSubId",
             "routeColor",

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
@@ -133,7 +133,6 @@ public class NoticeFieldsTest {
             "prevShapeDistTraveled",
             "prevShapePtSequence",
             "prevStopSequence",
-            "prevStopTimeDistTraveled",
             "recordId",
             "recordSubId",
             "routeColor",


### PR DESCRIPTION
**Summary:**

Found a bug as I opened #1547. 

For the `decreasing_or_equal_stop_time_distance` notice, it should be `prevShapeDistTraveled` and not `prevStopTimeDistTraveled` in the notice details. 

**Expected behavior:** 
The notice details have `prevShapeDistTraveled` instead of `prevStopTimeDistTraveled`.

- Before:
<img width="1109" alt="Screenshot 2023-08-01 at 6 30 29 PM" src="https://github.com/MobilityData/gtfs-validator/assets/63653518/b3a5ea54-174a-4fee-86f3-19a70c89e083">


- After:


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- ~~[ ] Linked all relevant issues~~
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
