### PR TITLE
feat: add stop_id to the decreasing_or_equal_stop_time_distance notice

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -57,6 +57,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
           noticeContainer.addValidationNotice(
               new DecreasingOrEqualStopTimeDistanceNotice(
                   curr.tripId(),
+                  curr.stopId(),
                   curr.csvRowNumber(),
                   curr.shapeDistTraveled(),
                   curr.stopSequence(),
@@ -81,6 +82,9 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
     /** The id of the faulty trip. */
     private final String tripId;
 
+    /** The id of the faulty stop. */
+    private final String stopId;
+
     /** The row number from `stop_times.txt`. */
     private final int csvRowNumber;
 
@@ -104,6 +108,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
 
     DecreasingOrEqualStopTimeDistanceNotice(
         String tripId,
+        String stopId,
         int csvRowNumber,
         double shapeDistTraveled,
         int stopSequence,
@@ -111,6 +116,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
         double prevStopTimeDistTraveled,
         int prevStopSequence) {
       this.tripId = tripId;
+      this.stopId = stopId;
       this.csvRowNumber = csvRowNumber;
       this.shapeDistTraveled = shapeDistTraveled;
       this.stopSequence = stopSequence;

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidatorTest.java
@@ -67,7 +67,8 @@ public class StopTimeIncreasingDistanceValidatorTest {
                     createStopTime(2, "first trip", "s1", 42, 45.0d),
                     createStopTime(3, "first trip", "s2", 46, 4.0d))))
         .containsExactly(
-            new DecreasingOrEqualStopTimeDistanceNotice("first trip", 3, 4.0d, 46, 2, 45.0d, 42));
+            new DecreasingOrEqualStopTimeDistanceNotice(
+                "first trip", "s2", 3, 4.0d, 46, 2, 45.0d, 42));
   }
 
   @Test
@@ -79,7 +80,8 @@ public class StopTimeIncreasingDistanceValidatorTest {
                     createStopTime(2, "first trip", "s1", 42, 45.0d),
                     createStopTime(3, "first trip", "s2", 46, 45.0d))))
         .containsExactly(
-            new DecreasingOrEqualStopTimeDistanceNotice("first trip", 3, 45.0d, 46, 2, 45.0d, 42));
+            new DecreasingOrEqualStopTimeDistanceNotice(
+                "first trip", "s2", 3, 45.0d, 46, 2, 45.0d, 42));
   }
 
   @Test
@@ -91,6 +93,7 @@ public class StopTimeIncreasingDistanceValidatorTest {
                     createStopTime(2, "first trip", "s1", 42, 8.6d),
                     createStopTime(3, "first trip", "s2", 46, 46.0d))))
         .containsExactly(
-            new DecreasingOrEqualStopTimeDistanceNotice("first trip", 2, 8.6d, 42, 1, 10.0d, 2));
+            new DecreasingOrEqualStopTimeDistanceNotice(
+                "first trip", "s1", 2, 8.6d, 42, 1, 10.0d, 2));
   }
 }


### PR DESCRIPTION
**Summary:**
Added `stop_id` after `trip_id` in the notice details of `decreasing_or_equal_stop_time_distance`. 
Closes #1547 

**Expected behavior:** 
The `stop_id` field is included in the notice details.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
