### PR TITLE
feat: 1537 get list of validators that couldnt run because of a parsing problem

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -30,10 +30,18 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorUtil;
 public final class AnyTableLoader {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-  private static final List<Class<? extends FileValidator>> validatorsWithParsingErrors = new ArrayList<>();
+  private static final List<Class<? extends FileValidator>> validatorsWithParsingErrors =
+      new ArrayList<>();
+
+  private static final List<Class<? extends SingleEntityValidator>>
+      singleEntityValidatorsWithParsingErrors = new ArrayList<>();
 
   public List<Class<? extends FileValidator>> getValidatorsWithParsingErrors() {
     return Collections.unmodifiableList(validatorsWithParsingErrors);
+  }
+
+  public List<Class<? extends SingleEntityValidator>> getSingleEntityValidatorsWithParsingErrors() {
+    return Collections.unmodifiableList(singleEntityValidatorsWithParsingErrors);
   }
 
   public static GtfsTableContainer load(
@@ -91,7 +99,8 @@ public final class AnyTableLoader {
     final List<GtfsEntity> entities = new ArrayList<>();
     boolean hasUnparsableRows = false;
     final List<SingleEntityValidator<GtfsEntity>> singleEntityValidators =
-        validatorProvider.createSingleEntityValidators(tableDescriptor.getEntityClass());
+        validatorProvider.createSingleEntityValidators(
+            tableDescriptor.getEntityClass(), singleEntityValidatorsWithParsingErrors::add);
     try {
       for (CsvRow row : csvFile) {
         if (row.getRowNumber() % 200000 == 0) {
@@ -137,7 +146,8 @@ public final class AnyTableLoader {
     GtfsTableContainer table =
         tableDescriptor.createContainerForHeaderAndEntities(header, entities, noticeContainer);
     ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table, validatorsWithParsingErrors::add), noticeContainer);
+        validatorProvider.createSingleFileValidators(table, validatorsWithParsingErrors::add),
+        noticeContainer);
     return table;
   }
 
@@ -201,7 +211,8 @@ public final class AnyTableLoader {
       noticeContainer.addValidationNotice(new MissingRequiredFileNotice(gtfsFilename));
     }
     ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table, validatorsWithParsingErrors::add), noticeContainer);
+        validatorProvider.createSingleFileValidators(table, validatorsWithParsingErrors::add),
+        noticeContainer);
     return table;
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -46,6 +46,7 @@ public final class AnyTableLoader {
       csvFile = new CsvFile(csvInputStream, gtfsFilename, settings);
     } catch (TextParsingException e) {
       noticeContainer.addValidationNotice(new CsvParsingFailedNotice(gtfsFilename, e));
+      //todo
       return tableDescriptor.createContainerForInvalidStatus(
           GtfsTableContainer.TableStatus.INVALID_HEADERS);
     }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -146,7 +146,8 @@ public final class AnyTableLoader {
     GtfsTableContainer table =
         tableDescriptor.createContainerForHeaderAndEntities(header, entities, noticeContainer);
     ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table, singleFileValidatorsWithParsingErrors::add),
+        validatorProvider.createSingleFileValidators(
+            table, singleFileValidatorsWithParsingErrors::add),
         noticeContainer);
     return table;
   }
@@ -211,7 +212,8 @@ public final class AnyTableLoader {
       noticeContainer.addValidationNotice(new MissingRequiredFileNotice(gtfsFilename));
     }
     ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table, singleFileValidatorsWithParsingErrors::add),
+        validatorProvider.createSingleFileValidators(
+            table, singleFileValidatorsWithParsingErrors::add),
         noticeContainer);
     return table;
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoader.java
@@ -30,14 +30,14 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorUtil;
 public final class AnyTableLoader {
 
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-  private static final List<Class<? extends FileValidator>> validatorsWithParsingErrors =
+  private static final List<Class<? extends FileValidator>> singleFileValidatorsWithParsingErrors =
       new ArrayList<>();
 
   private static final List<Class<? extends SingleEntityValidator>>
       singleEntityValidatorsWithParsingErrors = new ArrayList<>();
 
   public List<Class<? extends FileValidator>> getValidatorsWithParsingErrors() {
-    return Collections.unmodifiableList(validatorsWithParsingErrors);
+    return Collections.unmodifiableList(singleFileValidatorsWithParsingErrors);
   }
 
   public List<Class<? extends SingleEntityValidator>> getSingleEntityValidatorsWithParsingErrors() {
@@ -146,7 +146,7 @@ public final class AnyTableLoader {
     GtfsTableContainer table =
         tableDescriptor.createContainerForHeaderAndEntities(header, entities, noticeContainer);
     ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table, validatorsWithParsingErrors::add),
+        validatorProvider.createSingleFileValidators(table, singleFileValidatorsWithParsingErrors::add),
         noticeContainer);
     return table;
   }
@@ -211,7 +211,7 @@ public final class AnyTableLoader {
       noticeContainer.addValidationNotice(new MissingRequiredFileNotice(gtfsFilename));
     }
     ValidatorUtil.invokeSingleFileValidators(
-        validatorProvider.createSingleFileValidators(table, validatorsWithParsingErrors::add),
+        validatorProvider.createSingleFileValidators(table, singleFileValidatorsWithParsingErrors::add),
         noticeContainer);
     return table;
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -54,6 +54,7 @@ public class GtfsFeedLoader {
    */
   private final List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
 
+
   public GtfsFeedLoader(
       ImmutableList<Class<? extends GtfsTableDescriptor<?>>> tableDescriptorClasses) {
     for (Class<? extends GtfsTableDescriptor<?>> clazz : tableDescriptorClasses) {
@@ -82,6 +83,7 @@ public class GtfsFeedLoader {
   public List<Class<? extends FileValidator>> getSkippedValidators() {
     return Collections.unmodifiableList(skippedValidators);
   }
+
 
   @SuppressWarnings("unchecked")
   public GtfsFeedContainer loadAndValidate(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -52,7 +52,8 @@ public class GtfsFeedLoader {
    * The set of validators that were skipped during validation because their file dependencies had
    * parse errors plus validators that are optional.
    */
-  private final List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
+  private final List<Class<? extends FileValidator>> multiFileValidatorsWithParsingErrors =
+      new ArrayList<>();
 
   public GtfsFeedLoader(
       ImmutableList<Class<? extends GtfsTableDescriptor<?>>> tableDescriptorClasses) {
@@ -79,8 +80,8 @@ public class GtfsFeedLoader {
     this.numThreads = numThreads;
   }
 
-  public List<Class<? extends FileValidator>> getSkippedValidators() {
-    return Collections.unmodifiableList(skippedValidators);
+  public List<Class<? extends FileValidator>> getMultiFileValidatorsWithParsingErrors() {
+    return Collections.unmodifiableList(multiFileValidatorsWithParsingErrors);
   }
 
   @SuppressWarnings("unchecked")
@@ -147,7 +148,8 @@ public class GtfsFeedLoader {
       // Validators with parser-error dependencies will not be returned here, but instead added to
       // the skippedValidators list.
       for (FileValidator validator :
-          validatorProvider.createMultiFileValidators(feed, skippedValidators::add)) {
+          validatorProvider.createMultiFileValidators(
+              feed, multiFileValidatorsWithParsingErrors::add)) {
         validatorCallables.add(
             () -> {
               NoticeContainer validatorNotices = new NoticeContainer();

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -54,7 +54,6 @@ public class GtfsFeedLoader {
    */
   private final List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
 
-
   public GtfsFeedLoader(
       ImmutableList<Class<? extends GtfsTableDescriptor<?>>> tableDescriptorClasses) {
     for (Class<? extends GtfsTableDescriptor<?>> clazz : tableDescriptorClasses) {
@@ -83,7 +82,6 @@ public class GtfsFeedLoader {
   public List<Class<? extends FileValidator>> getSkippedValidators() {
     return Collections.unmodifiableList(skippedValidators);
   }
-
 
   @SuppressWarnings("unchecked")
   public GtfsFeedContainer loadAndValidate(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -50,7 +50,7 @@ public class GtfsFeedLoader {
 
   /**
    * The set of validators that were skipped during validation because their file dependencies had
-   * parse errors.
+   * parse errors plus validators that are optional.
    */
   private final List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
@@ -77,20 +77,21 @@ public class DefaultValidatorProvider implements ValidatorProvider {
   @SuppressWarnings("unchecked")
   public <T extends GtfsEntity> List<SingleEntityValidator<T>> createSingleEntityValidators(
       Class<T> clazz,
-      Consumer<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors) {
+      Consumer<Class<? extends SingleEntityValidator<T>>> singleEntityValidatorsWithParsingErrors) {
     List<SingleEntityValidator<T>> validators = new ArrayList<>();
     for (Class<? extends SingleEntityValidator<?>> validatorClass :
         singleEntityValidators.get(clazz)) {
       try {
-        ValidatorWithDependencyStatus<? extends SingleEntityValidator>
+        ValidatorWithDependencyStatus<? extends SingleEntityValidator<?>>
             validatorWithDependencyStatus =
                 ValidatorLoader.createValidatorWithContext(
-                    ((Class<? extends SingleEntityValidator<T>>) validatorClass),
+                    ((Class<? extends SingleEntityValidator<?>>) validatorClass),
                     validationContext);
         if (validatorWithDependencyStatus.dependenciesHaveErrors()) {
-          singleEntityValidatorsWithParsingErrors.accept(validatorClass);
+          singleEntityValidatorsWithParsingErrors.accept(
+              (Class<? extends SingleEntityValidator<T>>) validatorClass);
         } else {
-          validators.add(validatorWithDependencyStatus.validator());
+          validators.add((SingleEntityValidator<T>) validatorWithDependencyStatus.validator());
         }
       } catch (ReflectiveOperationException e) {
         logger.atSevere().withCause(e).log(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -199,10 +199,10 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  public static <T> ValidatorWithDependencyStatus<T> createValidatorWithContext(
+  public static <T extends SingleEntityValidator> ValidatorWithDependencyStatus<T> createValidatorWithContext(
       Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
     return (ValidatorWithDependencyStatus<T>)
-        createValidator(clazz, new DependencyResolver(validationContext, null, null)).validator();
+        createValidator(clazz, new DependencyResolver(validationContext, null, null));
   }
 
   /** Instantiates a {@code FileValidator} for a single table. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -199,19 +199,21 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  public static <T> T createValidatorWithContext(
+  public static <T> ValidatorWithDependencyStatus<T> createValidatorWithContext(
       Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
-    return createValidator(clazz, new DependencyResolver(validationContext, null, null))
-        .validator();
+    return (ValidatorWithDependencyStatus<T>)
+        createValidator(clazz, new DependencyResolver(validationContext, null, null)).validator();
   }
 
   /** Instantiates a {@code FileValidator} for a single table. */
-  public static <T extends FileValidator> ValidatorWithDependencyStatus<T> createSingleFileValidator(
-      Class<? extends FileValidator> clazz,
-      GtfsTableContainer<?> table,
-      ValidationContext validationContext)
-      throws ReflectiveOperationException {
-    return (ValidatorWithDependencyStatus<T>) createValidator(clazz, new DependencyResolver(validationContext, table, null));
+  public static <T extends FileValidator>
+      ValidatorWithDependencyStatus<T> createSingleFileValidator(
+          Class<? extends FileValidator> clazz,
+          GtfsTableContainer<?> table,
+          ValidationContext validationContext)
+          throws ReflectiveOperationException {
+    return (ValidatorWithDependencyStatus<T>)
+        createValidator(clazz, new DependencyResolver(validationContext, table, null));
   }
 
   /** Instantiates a {@code FileValidator} for multiple tables in a given feed. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -199,8 +199,9 @@ public class ValidatorLoader {
    * @param <T> type of the validator to instantiate
    * @return a new validator
    */
-  public static <T extends SingleEntityValidator> ValidatorWithDependencyStatus<T> createValidatorWithContext(
-      Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
+  public static <T extends SingleEntityValidator>
+      ValidatorWithDependencyStatus<T> createValidatorWithContext(
+          Class<T> clazz, ValidationContext validationContext) throws ReflectiveOperationException {
     return (ValidatorWithDependencyStatus<T>)
         createValidator(clazz, new DependencyResolver(validationContext, null, null));
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -169,7 +169,11 @@ public class ValidatorLoader {
             validatorClass.getCanonicalName()));
   }
 
-  /** Instantiates a validator of given class and injects its dependencies. */
+  /**
+   * Instantiates a validator of given class and injects its dependencies. A dependency is typically
+   * a table that is used by the validator. If any of the dependencies have errors, we put this
+   * information in the returned {@link ValidatorWithDependencyStatus}.
+   */
   private static <T> ValidatorWithDependencyStatus<T> createValidator(
       Class<T> clazz, DependencyResolver dependencyResolver) throws ReflectiveOperationException {
     Constructor<T> chosenConstructor;
@@ -246,6 +250,13 @@ public class ValidatorLoader {
       this.feedContainer = feedContainer;
     }
 
+    /**
+     * This is typically called to obtain the container related to each parameter in a validator's
+     * constructor or a basic type related to country code or date.
+     *
+     * @param parameterClass The parameter of the constructor we want to examine.
+     * @return
+     */
     public Object resolveDependency(Class<?> parameterClass) {
       if (feedContainer != null && parameterClass.isAssignableFrom(GtfsFeedContainer.class)) {
         if (!feedContainer.isParsedSuccessfully()) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -206,13 +206,12 @@ public class ValidatorLoader {
   }
 
   /** Instantiates a {@code FileValidator} for a single table. */
-  public static FileValidator createSingleFileValidator(
+  public static <T extends FileValidator> ValidatorWithDependencyStatus<T> createSingleFileValidator(
       Class<? extends FileValidator> clazz,
       GtfsTableContainer<?> table,
       ValidationContext validationContext)
       throws ReflectiveOperationException {
-    return createValidator(clazz, new DependencyResolver(validationContext, table, null))
-        .validator();
+    return (ValidatorWithDependencyStatus<T>) createValidator(clazz, new DependencyResolver(validationContext, table, null));
   }
 
   /** Instantiates a {@code FileValidator} for multiple tables in a given feed. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
@@ -57,7 +57,7 @@ public interface ValidatorProvider {
    * @param <T> type of the GTFS entity
    */
   <T extends GtfsEntity> List<FileValidator> createSingleFileValidators(
-      GtfsTableContainer<T> table);
+      GtfsTableContainer<T> table, Consumer<Class<? extends FileValidator>> validatorsWithParsingErrors);
 
   /**
    * Creates a list of cross-table validators. Any validator that has a dependency with parse errors

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
@@ -47,7 +47,7 @@ public interface ValidatorProvider {
    */
   <T extends GtfsEntity> List<SingleEntityValidator<T>> createSingleEntityValidators(
       Class<T> clazz,
-      Consumer<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors);
+      Consumer<Class<? extends SingleEntityValidator<T>>> singleEntityValidatorsWithParsingErrors);
 
   /**
    * Creates a list of validators for the given table.

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
@@ -46,7 +46,8 @@ public interface ValidatorProvider {
    * @return a list of validators
    */
   <T extends GtfsEntity> List<SingleEntityValidator<T>> createSingleEntityValidators(
-      Class<T> clazz);
+      Class<T> clazz,
+      Consumer<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors);
 
   /**
    * Creates a list of validators for the given table.
@@ -57,7 +58,8 @@ public interface ValidatorProvider {
    * @param <T> type of the GTFS entity
    */
   <T extends GtfsEntity> List<FileValidator> createSingleFileValidators(
-      GtfsTableContainer<T> table, Consumer<Class<? extends FileValidator>> validatorsWithParsingErrors);
+      GtfsTableContainer<T> table,
+      Consumer<Class<? extends FileValidator>> validatorsWithParsingErrors);
 
   /**
    * Creates a list of cross-table validators. Any validator that has a dependency with parse errors

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
@@ -7,11 +7,9 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Consumer;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -20,14 +18,12 @@ import org.mobilitydata.gtfsvalidator.notice.*;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntity;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
-import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableContainer;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableDescriptor;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
 import org.mobilitydata.gtfsvalidator.validator.GtfsFieldValidator;
 import org.mobilitydata.gtfsvalidator.validator.TableHeaderValidator;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorProvider;
 import org.mockito.ArgumentCaptor;
-import org.mockito.ArgumentMatcher;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
@@ -133,8 +129,10 @@ public class AnyTableLoaderTest {
     when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
     when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
     GtfsTestFileValidator validator = mock(GtfsTestFileValidator.class);
-    ArgumentCaptor<Consumer<Class<? extends FileValidator>>> captor = ArgumentCaptor.forClass(Consumer.class);
-    when(validatorProvider.createSingleFileValidators(ArgumentMatchers.any(), captor.capture())).thenReturn((List.of(validator)));
+    ArgumentCaptor<Consumer<Class<? extends FileValidator>>> captor =
+        ArgumentCaptor.forClass(Consumer.class);
+    when(validatorProvider.createSingleFileValidators(ArgumentMatchers.any(), captor.capture()))
+        .thenReturn((List.of(validator)));
     InputStream inputStream = toInputStream("id,stop_lat,_no_name_\n" + "s1, 23.00, no_value\n");
 
     var loadedContainer =

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
@@ -128,7 +128,8 @@ public class AnyTableLoaderTest {
     when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
     when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
     GtfsTestFileValidator validator = mock(GtfsTestFileValidator.class);
-    when(validatorProvider.createSingleFileValidators(any(), validatorsWithParsingErrors::add)).thenReturn(List.of(validator));
+    when(validatorProvider.createSingleFileValidators(any(), validatorsWithParsingErrors::add))
+        .thenReturn(List.of(validator));
     InputStream inputStream = toInputStream("id,stop_lat,_no_name_\n" + "s1, 23.00, no_value\n");
 
     var loadedContainer =

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
@@ -10,6 +10,8 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,11 +20,15 @@ import org.mobilitydata.gtfsvalidator.notice.*;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntity;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableContainer;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableDescriptor;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
 import org.mobilitydata.gtfsvalidator.validator.GtfsFieldValidator;
 import org.mobilitydata.gtfsvalidator.validator.TableHeaderValidator;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorProvider;
+import org.mockito.ArgumentCaptor;
+import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnit;
 import org.mockito.junit.MockitoRule;
@@ -124,12 +130,11 @@ public class AnyTableLoaderTest {
   @Test
   public void parsableTableRows() {
     var testTableDescriptor = new GtfsTestTableDescriptor();
-    List<Class<? extends FileValidator>> validatorsWithParsingErrors = new ArrayList<>();
     when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
     when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
     GtfsTestFileValidator validator = mock(GtfsTestFileValidator.class);
-    when(validatorProvider.createSingleFileValidators(any(), validatorsWithParsingErrors::add))
-        .thenReturn(List.of(validator));
+    ArgumentCaptor<Consumer<Class<? extends FileValidator>>> captor = ArgumentCaptor.forClass(Consumer.class);
+    when(validatorProvider.createSingleFileValidators(ArgumentMatchers.any(), captor.capture())).thenReturn((List.of(validator)));
     InputStream inputStream = toInputStream("id,stop_lat,_no_name_\n" + "s1, 23.00, no_value\n");
 
     var loadedContainer =

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
@@ -17,7 +17,7 @@ import org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum;
 import org.mobilitydata.gtfsvalidator.notice.*;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntity;
-import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestSingleFileValidator;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableDescriptor;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
 import org.mobilitydata.gtfsvalidator.validator.GtfsFieldValidator;
@@ -128,7 +128,7 @@ public class AnyTableLoaderTest {
     var testTableDescriptor = new GtfsTestTableDescriptor();
     when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
     when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
-    GtfsTestFileValidator validator = mock(GtfsTestFileValidator.class);
+    GtfsTestSingleFileValidator validator = mock(GtfsTestSingleFileValidator.class);
     ArgumentCaptor<Consumer<Class<? extends FileValidator>>> captor =
         ArgumentCaptor.forClass(Consumer.class);
     when(validatorProvider.createSingleFileValidators(ArgumentMatchers.any(), captor.capture()))

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/AnyTableLoaderTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import com.google.common.collect.ImmutableList;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import org.junit.Before;
@@ -18,6 +19,7 @@ import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntity;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableDescriptor;
+import org.mobilitydata.gtfsvalidator.validator.FileValidator;
 import org.mobilitydata.gtfsvalidator.validator.GtfsFieldValidator;
 import org.mobilitydata.gtfsvalidator.validator.TableHeaderValidator;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorProvider;
@@ -122,10 +124,11 @@ public class AnyTableLoaderTest {
   @Test
   public void parsableTableRows() {
     var testTableDescriptor = new GtfsTestTableDescriptor();
+    List<Class<? extends FileValidator>> validatorsWithParsingErrors = new ArrayList<>();
     when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
     when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
     GtfsTestFileValidator validator = mock(GtfsTestFileValidator.class);
-    when(validatorProvider.createSingleFileValidators(any())).thenReturn(List.of(validator));
+    when(validatorProvider.createSingleFileValidators(any(), validatorsWithParsingErrors::add)).thenReturn(List.of(validator));
     InputStream inputStream = toInputStream("id,stop_lat,_no_name_\n" + "s1, 23.00, no_value\n");
 
     var loadedContainer =

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoaderTest.java
@@ -13,7 +13,7 @@ import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntity;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntityValidator;
-import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestSingleFileValidator;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableContainer;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableDescriptor;
 import org.mobilitydata.gtfsvalidator.testgtfs.WholeFeedValidator;
@@ -26,7 +26,9 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorProvider;
 public class GtfsFeedLoaderTest {
   private static final ImmutableList<Class<?>> VALIDATOR_CLASSES =
       ImmutableList.of(
-          GtfsTestEntityValidator.class, GtfsTestFileValidator.class, WholeFeedValidator.class);
+          GtfsTestEntityValidator.class,
+          GtfsTestSingleFileValidator.class,
+          WholeFeedValidator.class);
 
   private MockGtfs mockGtfs;
   private NoticeContainer noticeContainer = new NoticeContainer();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoaderTest.java
@@ -74,6 +74,7 @@ public class GtfsFeedLoaderTest {
     GtfsTestTableContainer container = feedContainer.getTable(GtfsTestTableContainer.class);
     assertThat(container.getEntities()).isEmpty();
 
-    assertThat(loader.getSkippedValidators()).containsExactly(WholeFeedValidator.class);
+    assertThat(loader.getMultiFileValidatorsWithParsingErrors())
+        .containsExactly(WholeFeedValidator.class);
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestMultiFileValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestMultiFileValidator.java
@@ -17,37 +17,20 @@
 package org.mobilitydata.gtfsvalidator.testgtfs;
 
 import javax.inject.Inject;
-import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
 
-public class GtfsTestFileValidator extends FileValidator {
+public class GtfsTestMultiFileValidator extends FileValidator {
 
   private final GtfsTestTableContainer table;
-  private final CountryCode countryCode;
-  private final CurrentDateTime currentDateTime;
+  private final GtfsTestTableContainer2 unparsableTable;
 
   @Inject
-  public GtfsTestFileValidator(
-      GtfsTestTableContainer table, CountryCode countryCode, CurrentDateTime currentDateTime) {
+  public GtfsTestMultiFileValidator(GtfsTestTableContainer table, GtfsTestTableContainer2 table2) {
     this.table = table;
-    this.countryCode = countryCode;
-    this.currentDateTime = currentDateTime;
+    this.unparsableTable = table2;
   }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {}
-
-  public GtfsTestTableContainer getStopTable() {
-    return table;
-  }
-
-  public CountryCode getCountryCode() {
-    return countryCode;
-  }
-
-  public CurrentDateTime getCurrentDateTime() {
-    return currentDateTime;
-  }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestSingleFileValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestSingleFileValidator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.validator.FileValidator;
+
+public class GtfsTestSingleFileValidator extends FileValidator {
+
+  private final GtfsTestTableContainer table;
+  private final CountryCode countryCode;
+  private final CurrentDateTime currentDateTime;
+
+  @Inject
+  public GtfsTestSingleFileValidator(
+      GtfsTestTableContainer table, CountryCode countryCode, CurrentDateTime currentDateTime) {
+    this.table = table;
+    this.countryCode = countryCode;
+    this.currentDateTime = currentDateTime;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {}
+
+  public GtfsTestTableContainer getStopTable() {
+    return table;
+  }
+
+  public CountryCode getCountryCode() {
+    return countryCode;
+  }
+
+  public CurrentDateTime getCurrentDateTime() {
+    return currentDateTime;
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableContainer2.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableContainer2.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+
+// We need a second test table class to test multi file validators.
+public class GtfsTestTableContainer2 extends GtfsTableContainer<GtfsTestEntity> {
+  private static final ImmutableList<String> KEY_COLUMN_NAMES =
+      ImmutableList.of(GtfsTestEntity.ID_FIELD_NAME);
+
+  private List<GtfsTestEntity> entities;
+
+  private GtfsTestTableContainer2(
+      GtfsTestTableDescriptor2 descriptor, CsvHeader header, List<GtfsTestEntity> entities) {
+    super(descriptor, TableStatus.PARSABLE_HEADERS_AND_ROWS, header);
+    this.entities = entities;
+  }
+
+  public GtfsTestTableContainer2(TableStatus tableStatus) {
+    super(new GtfsTestTableDescriptor2(), tableStatus, CsvHeader.EMPTY);
+    this.entities = new ArrayList<>();
+  }
+
+  @Override
+  public Class<GtfsTestEntity> getEntityClass() {
+    return GtfsTestEntity.class;
+  }
+
+  @Override
+  public String gtfsFilename() {
+    return GtfsTestEntity.FILENAME + "2";
+  }
+
+  @Override
+  public List<GtfsTestEntity> getEntities() {
+    return entities;
+  }
+
+  /** Creates a table with given header and entities */
+  public static GtfsTestTableContainer2 forHeaderAndEntities(
+      GtfsTestTableDescriptor2 descriptor,
+      CsvHeader header,
+      List<GtfsTestEntity> entities,
+      NoticeContainer noticeContainer) {
+    GtfsTestTableContainer2 table = new GtfsTestTableContainer2(descriptor, header, entities);
+    return table;
+  }
+
+  @Override
+  public ImmutableList<String> getKeyColumnNames() {
+    return KEY_COLUMN_NAMES;
+  }
+
+  @Override
+  public Optional<GtfsTestEntity> byTranslationKey(String recordId, String recordSubId) {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableDescriptor2.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableDescriptor2.java
@@ -1,0 +1,115 @@
+package org.mobilitydata.gtfsvalidator.testgtfs;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Optional;
+import org.mobilitydata.gtfsvalidator.annotation.FieldLevelEnum;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
+import org.mobilitydata.gtfsvalidator.parsing.FieldCache;
+import org.mobilitydata.gtfsvalidator.parsing.RowParser;
+import org.mobilitydata.gtfsvalidator.table.*;
+
+// We need a second test table descriptor to test multi file contaioners
+public class GtfsTestTableDescriptor2 extends GtfsTableDescriptor<GtfsTestEntity> {
+  @Override
+  public GtfsTableContainer createContainerForInvalidStatus(
+      GtfsTableContainer.TableStatus tableStatus) {
+    return new GtfsTestTableContainer2(tableStatus);
+  }
+
+  @Override
+  public GtfsTableContainer createContainerForHeaderAndEntities(
+      CsvHeader header, List<GtfsTestEntity> entities, NoticeContainer noticeContainer) {
+    return GtfsTestTableContainer2.forHeaderAndEntities(this, header, entities, noticeContainer);
+  }
+
+  @Override
+  public GtfsEntityBuilder createEntityBuilder() {
+    return new GtfsTestEntity.Builder();
+  }
+
+  @Override
+  public Class getEntityClass() {
+    return GtfsTestEntity.class;
+  }
+
+  @Override
+  public ImmutableList<GtfsColumnDescriptor> getColumns() {
+    ImmutableList.Builder<GtfsColumnDescriptor> builder = ImmutableList.builder();
+    builder.add(
+        GtfsColumnDescriptor.builder()
+            .setColumnName(GtfsTestEntity.ID_FIELD_NAME)
+            .setHeaderRequired(true)
+            .setHeaderRecommended(false)
+            .setFieldLevel(FieldLevelEnum.REQUIRED)
+            .setIsMixedCase(false)
+            .setIsCached(false)
+            .build());
+    builder.add(
+        GtfsColumnDescriptor.builder()
+            .setColumnName(GtfsTestEntity.CODE_FIELD_NAME)
+            .setHeaderRequired(false)
+            .setHeaderRecommended(false)
+            .setFieldLevel(FieldLevelEnum.OPTIONAL)
+            .setIsMixedCase(false)
+            .setIsCached(false)
+            .build());
+    return builder.build();
+  }
+
+  @Override
+  public ImmutableMap<String, GtfsFieldLoader> getFieldLoaders() {
+    ImmutableMap.Builder<String, GtfsFieldLoader> builder = ImmutableMap.builder();
+    builder.put(
+        GtfsTestEntity.ID_FIELD_NAME,
+        new GtfsFieldLoader<GtfsTestEntity.Builder, String>() {
+          @Override
+          public void load(
+              RowParser rowParser,
+              int columnIndex,
+              GtfsColumnDescriptor columnDescriptor,
+              FieldCache<String> fieldCache,
+              GtfsTestEntity.Builder builder) {
+            builder.setId(
+                addToCacheIfPresent(rowParser.asId(columnIndex, columnDescriptor), fieldCache));
+          }
+        });
+    builder.put(
+        GtfsTestEntity.CODE_FIELD_NAME,
+        new GtfsFieldLoader<GtfsTestEntity.Builder, String>() {
+          @Override
+          public void load(
+              RowParser rowParser,
+              int columnIndex,
+              GtfsColumnDescriptor columnDescriptor,
+              FieldCache<String> fieldCache,
+              GtfsTestEntity.Builder builder) {
+            builder.setCode(
+                addToCacheIfPresent(rowParser.asText(columnIndex, columnDescriptor), fieldCache));
+          }
+        });
+    return builder.build();
+  }
+
+  @Override
+  public String gtfsFilename() {
+    return GtfsTestEntity.FILENAME + "2";
+  }
+
+  @Override
+  public boolean isRecommended() {
+    return false;
+  }
+
+  @Override
+  public boolean isRequired() {
+    return true;
+  }
+
+  @Override
+  public Optional<Integer> maxCharsPerColumn() {
+    return Optional.empty();
+  }
+}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
@@ -45,10 +45,10 @@ public class DefaultValidatorProviderTest {
                 .map(Object::getClass))
         .containsExactly(GtfsTestEntityValidator.class);
 
-    List<Class<? extends FileValidator>> validatorsWithParsingErrors = new ArrayList<>();
+    List<Class<? extends FileValidator>> singleFilreValidatorsWithParsingErrors = new ArrayList<>();
     assertThat(
             provider
-                .createSingleFileValidators(tableContainer, validatorsWithParsingErrors::add)
+                .createSingleFileValidators(tableContainer, singleFilreValidatorsWithParsingErrors::add)
                 .stream()
                 .map(Object::getClass))
         .containsExactly(GtfsTestFileValidator.class);
@@ -76,8 +76,8 @@ public class DefaultValidatorProviderTest {
     GtfsTestTableContainer tableContainer = new GtfsTestTableContainer(TableStatus.UNPARSABLE_ROWS);
     GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(tableContainer));
 
-    List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
-    assertThat(provider.createMultiFileValidators(feedContainer, skippedValidators::add)).isEmpty();
-    assertThat(skippedValidators).containsExactly(WholeFeedValidator.class);
+    List<Class<? extends FileValidator>> multiFileValidatorsWithParsingErrors = new ArrayList<>();
+    assertThat(provider.createMultiFileValidators(feedContainer, multiFileValidatorsWithParsingErrors::add)).isEmpty();
+    assertThat(multiFileValidatorsWithParsingErrors).containsExactly(WholeFeedValidator.class);
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
@@ -41,7 +41,8 @@ public class DefaultValidatorProviderTest {
                 .map(Object::getClass))
         .containsExactly(GtfsTestEntityValidator.class);
 
-    assertThat(provider.createSingleFileValidators(tableContainer).stream().map(Object::getClass))
+    List<Class<? extends FileValidator>> validatorsWithParsingErrors = new ArrayList<>();
+    assertThat(provider.createSingleFileValidators(tableContainer, validatorsWithParsingErrors::add).stream().map(Object::getClass))
         .containsExactly(GtfsTestFileValidator.class);
 
     List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
@@ -35,14 +35,22 @@ public class DefaultValidatorProviderTest {
     GtfsTestTableContainer tableContainer =
         new GtfsTestTableContainer(TableStatus.PARSABLE_HEADERS_AND_ROWS);
     GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(tableContainer));
-
+    List<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors =
+        new ArrayList<>();
     assertThat(
-            provider.createSingleEntityValidators(GtfsTestEntity.class).stream()
+            provider
+                .createSingleEntityValidators(
+                    GtfsTestEntity.class, singleEntityValidatorsWithParsingErrors::add)
+                .stream()
                 .map(Object::getClass))
         .containsExactly(GtfsTestEntityValidator.class);
 
     List<Class<? extends FileValidator>> validatorsWithParsingErrors = new ArrayList<>();
-    assertThat(provider.createSingleFileValidators(tableContainer, validatorsWithParsingErrors::add).stream().map(Object::getClass))
+    assertThat(
+            provider
+                .createSingleFileValidators(tableContainer, validatorsWithParsingErrors::add)
+                .stream()
+                .map(Object::getClass))
         .containsExactly(GtfsTestFileValidator.class);
 
     List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
@@ -14,8 +14,10 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntity;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntityValidator;
-import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestMultiFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestSingleFileValidator;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableContainer;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableContainer2;
 import org.mobilitydata.gtfsvalidator.testgtfs.WholeFeedValidator;
 
 @RunWith(JUnit4.class)
@@ -29,7 +31,7 @@ public class DefaultValidatorProviderTest {
             ValidatorLoader.createForClasses(
                 ImmutableList.of(
                     GtfsTestEntityValidator.class,
-                    GtfsTestFileValidator.class,
+                    GtfsTestSingleFileValidator.class,
                     WholeFeedValidator.class)));
 
     GtfsTestTableContainer tableContainer =
@@ -52,7 +54,7 @@ public class DefaultValidatorProviderTest {
                     tableContainer, singleFileValidatorsWithParsingErrors::add)
                 .stream()
                 .map(Object::getClass))
-        .containsExactly(GtfsTestFileValidator.class);
+        .containsExactly(GtfsTestSingleFileValidator.class);
 
     List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
     assertThat(
@@ -70,18 +72,36 @@ public class DefaultValidatorProviderTest {
             ValidatorLoader.createForClasses(
                 ImmutableList.of(
                     GtfsTestEntityValidator.class,
-                    GtfsTestFileValidator.class,
+                    GtfsTestMultiFileValidator.class,
+                    GtfsTestSingleFileValidator.class,
                     WholeFeedValidator.class)));
 
-    // Our table had invalid data!
+    // Create 2 tables, one with errors and the other not.
+    // This will let us test the multi-file validator.
     GtfsTestTableContainer tableContainer = new GtfsTestTableContainer(TableStatus.UNPARSABLE_ROWS);
-    GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(tableContainer));
+    GtfsTestTableContainer2 tableContainer2 =
+        new GtfsTestTableContainer2(TableStatus.PARSABLE_HEADERS_AND_ROWS);
 
-    List<Class<? extends FileValidator>> multiFileValidatorsWithParsingErrors = new ArrayList<>();
-    assertThat(
-            provider.createMultiFileValidators(
-                feedContainer, multiFileValidatorsWithParsingErrors::add))
+    GtfsFeedContainer feedContainer =
+        new GtfsFeedContainer(ImmutableList.of(tableContainer, tableContainer2));
+
+    List<Class<? extends FileValidator>> skippedValidators = new ArrayList<>();
+    // First test the multi file validators. Apparently the FeedContainerValidator is considered a
+    // multi-file validator.
+    // We should not be able to create any validator since the dependant file container has parsing
+    // errors. For the WholeFeedValidator the feedContainer is also in error since one of its
+    // file is in error.
+    assertThat(provider.createMultiFileValidators(feedContainer, skippedValidators::add)).isEmpty();
+    // And the 2 validators should be skipped
+    assertThat(skippedValidators)
+        .containsExactly(WholeFeedValidator.class, GtfsTestMultiFileValidator.class);
+
+    skippedValidators.clear();
+    // Try with the single file validator.  We should not be able to build any validator since the
+    // file has errors.
+    assertThat(provider.createSingleFileValidators(tableContainer, skippedValidators::add))
         .isEmpty();
-    assertThat(multiFileValidatorsWithParsingErrors).containsExactly(WholeFeedValidator.class);
+    // And it should tell us that the single file validator was skipped
+    assertThat(skippedValidators).containsExactly(GtfsTestSingleFileValidator.class);
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProviderTest.java
@@ -45,10 +45,11 @@ public class DefaultValidatorProviderTest {
                 .map(Object::getClass))
         .containsExactly(GtfsTestEntityValidator.class);
 
-    List<Class<? extends FileValidator>> singleFilreValidatorsWithParsingErrors = new ArrayList<>();
+    List<Class<? extends FileValidator>> singleFileValidatorsWithParsingErrors = new ArrayList<>();
     assertThat(
             provider
-                .createSingleFileValidators(tableContainer, singleFilreValidatorsWithParsingErrors::add)
+                .createSingleFileValidators(
+                    tableContainer, singleFileValidatorsWithParsingErrors::add)
                 .stream()
                 .map(Object::getClass))
         .containsExactly(GtfsTestFileValidator.class);
@@ -77,7 +78,10 @@ public class DefaultValidatorProviderTest {
     GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(tableContainer));
 
     List<Class<? extends FileValidator>> multiFileValidatorsWithParsingErrors = new ArrayList<>();
-    assertThat(provider.createMultiFileValidators(feedContainer, multiFileValidatorsWithParsingErrors::add)).isEmpty();
+    assertThat(
+            provider.createMultiFileValidators(
+                feedContainer, multiFileValidatorsWithParsingErrors::add))
+        .isEmpty();
     assertThat(multiFileValidatorsWithParsingErrors).containsExactly(WholeFeedValidator.class);
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -46,7 +46,7 @@ public class ValidatorLoaderTest {
   public void createValidatorWithContext_injectsContext() throws ReflectiveOperationException {
     GtfsTestEntityValidator validator =
         ValidatorLoader.createValidatorWithContext(
-            GtfsTestEntityValidator.class, VALIDATION_CONTEXT);
+            GtfsTestEntityValidator.class, VALIDATION_CONTEXT).validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
     assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
@@ -59,7 +59,8 @@ public class ValidatorLoaderTest {
     GtfsTestFileValidator validator =
         (GtfsTestFileValidator)
             ValidatorLoader.createSingleFileValidator(
-                GtfsTestFileValidator.class, table, VALIDATION_CONTEXT).validator();
+                    GtfsTestFileValidator.class, table, VALIDATION_CONTEXT)
+                .validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
     assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -59,7 +59,7 @@ public class ValidatorLoaderTest {
     GtfsTestFileValidator validator =
         (GtfsTestFileValidator)
             ValidatorLoader.createSingleFileValidator(
-                GtfsTestFileValidator.class, table, VALIDATION_CONTEXT);
+                GtfsTestFileValidator.class, table, VALIDATION_CONTEXT).validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
     assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -27,7 +27,7 @@ import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntityValidator;
-import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestFileValidator;
+import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestSingleFileValidator;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestTableContainer;
 import org.mobilitydata.gtfsvalidator.testgtfs.WholeFeedValidator;
 import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader.ValidatorWithDependencyStatus;
@@ -57,10 +57,10 @@ public class ValidatorLoaderTest {
   public void createSingleFileValidator_injectsTableContainerAndContext()
       throws ReflectiveOperationException {
     GtfsTestTableContainer table = new GtfsTestTableContainer(TableStatus.EMPTY_FILE);
-    GtfsTestFileValidator validator =
-        (GtfsTestFileValidator)
+    GtfsTestSingleFileValidator validator =
+        (GtfsTestSingleFileValidator)
             ValidatorLoader.createSingleFileValidator(
-                    GtfsTestFileValidator.class, table, VALIDATION_CONTEXT)
+                    GtfsTestSingleFileValidator.class, table, VALIDATION_CONTEXT)
                 .validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
@@ -92,9 +92,9 @@ public class ValidatorLoaderTest {
     GtfsTestTableContainer table = new GtfsTestTableContainer(TableStatus.UNPARSABLE_ROWS);
     GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(table));
 
-    ValidatorWithDependencyStatus<GtfsTestFileValidator> validatorWithStatus =
+    ValidatorWithDependencyStatus<GtfsTestSingleFileValidator> validatorWithStatus =
         ValidatorLoader.createMultiFileValidator(
-            GtfsTestFileValidator.class, feedContainer, VALIDATION_CONTEXT);
+            GtfsTestSingleFileValidator.class, feedContainer, VALIDATION_CONTEXT);
 
     assertThat(validatorWithStatus.dependenciesHaveErrors()).isTrue();
     assertThat(validatorWithStatus.validator().getStopTable()).isEqualTo(table);

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -46,7 +46,8 @@ public class ValidatorLoaderTest {
   public void createValidatorWithContext_injectsContext() throws ReflectiveOperationException {
     GtfsTestEntityValidator validator =
         ValidatorLoader.createValidatorWithContext(
-            GtfsTestEntityValidator.class, VALIDATION_CONTEXT).validator();
+                GtfsTestEntityValidator.class, VALIDATION_CONTEXT)
+            .validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
     assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -152,7 +152,7 @@ public class ValidationRunner {
       GtfsFeedLoader loader,
       AnyTableLoader anyTableLoader) {
     final long endNanos = System.nanoTime();
-    List<Class<? extends FileValidator>> skippedValidators =
+    List<Class<? extends FileValidator>> multiFileValidatorsWithParsingErrors =
         loader.getMultiFileValidatorsWithParsingErrors();
     List<Class<? extends FileValidator>> singleFileValidatorsWithParsingErrors =
         anyTableLoader.getValidatorsWithParsingErrors();
@@ -160,16 +160,16 @@ public class ValidationRunner {
         anyTableLoader.getSingleEntityValidatorsWithParsingErrors();
     if (!singleFileValidatorsWithParsingErrors.isEmpty()
         || !singleEntityValidatorsWithParsingErrors.isEmpty()
-        || !skippedValidators.isEmpty()) {
+        || !multiFileValidatorsWithParsingErrors.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
       b.append(" ------------------------------------------------------------------------- \n");
       b.append("|   Some validators were skipped due to parsing problems.   |\n");
       b.append(" ------------------------------------------------------------------------- \n");
       b.append(" Validators with Parsing Errors: ");
-      if (!skippedValidators.isEmpty()) {
+      if (!multiFileValidatorsWithParsingErrors.isEmpty()) {
         b.append(
-            skippedValidators.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
+            multiFileValidatorsWithParsingErrors.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
       }
       if (!singleFileValidatorsWithParsingErrors.isEmpty()) {
         b.append(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -154,30 +154,23 @@ public class ValidationRunner {
     final long endNanos = System.nanoTime();
     List<Class<? extends FileValidator>> skippedValidators =
         loader.getMultiFileValidatorsWithParsingErrors();
-    if (!skippedValidators.isEmpty()) {
-      StringBuilder b = new StringBuilder();
-      b.append("\n");
-      b.append(" ----------------------------------------- \n");
-      b.append("|   Some validators were never invoked.   |\n");
-      b.append(" ----------------------------------------- \n");
-      b.append("Skipped validators: ");
-      b.append(
-          skippedValidators.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
-      logger.atSevere().log(b.toString());
-    }
-
     List<Class<? extends FileValidator>> singleFileValidatorsWithParsingErrors =
         anyTableLoader.getValidatorsWithParsingErrors();
     List<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors =
         anyTableLoader.getSingleEntityValidatorsWithParsingErrors();
     if (!singleFileValidatorsWithParsingErrors.isEmpty()
-        || !singleEntityValidatorsWithParsingErrors.isEmpty()) {
+        || !singleEntityValidatorsWithParsingErrors.isEmpty()
+        || !skippedValidators.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
       b.append(" ------------------------------------------------------------------------- \n");
-      b.append("|   The list of validators that couldn't run due to a parsing problem.   |\n");
+      b.append("|   Some validators were skipped due to parsing problems.   |\n");
       b.append(" ------------------------------------------------------------------------- \n");
       b.append(" Validators with Parsing Errors: ");
+      if (!skippedValidators.isEmpty()) {
+        b.append(
+            skippedValidators.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
+      }
       if (!singleFileValidatorsWithParsingErrors.isEmpty()) {
         b.append(
             singleFileValidatorsWithParsingErrors.stream()
@@ -190,6 +183,7 @@ public class ValidationRunner {
                 .map(Class::getSimpleName)
                 .collect(Collectors.joining(",")));
       }
+
       logger.atSevere().log(b.toString());
     }
     logger.atInfo().log("Validation took %.3f seconds%n", (endNanos - startNanos) / 1e9);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -156,6 +156,8 @@ public class ValidationRunner {
         loader.getMultiFileValidatorsWithParsingErrors();
     List<Class<? extends FileValidator>> singleFileValidatorsWithParsingErrors =
         anyTableLoader.getValidatorsWithParsingErrors();
+    // In theory single entity validators do not depend on files so there should not be any of these
+    // with parsing errors
     List<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors =
         anyTableLoader.getSingleEntityValidatorsWithParsingErrors();
     if (!singleFileValidatorsWithParsingErrors.isEmpty()
@@ -163,27 +165,34 @@ public class ValidationRunner {
         || !multiFileValidatorsWithParsingErrors.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
-      b.append(" ------------------------------------------------------------------------- \n");
-      b.append("|   Some validators were skipped due to parsing problems.   |\n");
-      b.append(" ------------------------------------------------------------------------- \n");
-      b.append(" Validators with Parsing Errors: ");
+      b.append(
+          "---------------------------------------------------------------------------------------- \n");
+      b.append(
+          "| Some validators were skipped because the GTFS files they rely on could not be parsed | \n");
+      b.append(
+          "---------------------------------------------------------------------------------------- \n");
       if (!multiFileValidatorsWithParsingErrors.isEmpty()) {
+        // Add some spaces to the delimiter so the validator names are indented. Easier to read.
+        b.append("Multi-file validators:\n   ");
         b.append(
             multiFileValidatorsWithParsingErrors.stream()
                 .map(Class::getSimpleName)
-                .collect(Collectors.joining(",")));
+                .collect(Collectors.joining("\n   ")));
       }
+
       if (!singleFileValidatorsWithParsingErrors.isEmpty()) {
+        b.append("Single-file validators:\n   ");
         b.append(
             singleFileValidatorsWithParsingErrors.stream()
                 .map(Class::getSimpleName)
-                .collect(Collectors.joining(",")));
+                .collect(Collectors.joining("\n   ")));
       }
       if (!singleEntityValidatorsWithParsingErrors.isEmpty()) {
+        b.append("Single-entity validators:\n   ");
         b.append(
             singleEntityValidatorsWithParsingErrors.stream()
                 .map(Class::getSimpleName)
-                .collect(Collectors.joining(",")));
+                .collect(Collectors.joining("\n   ")));
       }
 
       logger.atSevere().log(b.toString());

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -169,7 +169,9 @@ public class ValidationRunner {
       b.append(" Validators with Parsing Errors: ");
       if (!multiFileValidatorsWithParsingErrors.isEmpty()) {
         b.append(
-            multiFileValidatorsWithParsingErrors.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
+            multiFileValidatorsWithParsingErrors.stream()
+                .map(Class::getSimpleName)
+                .collect(Collectors.joining(",")));
       }
       if (!singleFileValidatorsWithParsingErrors.isEmpty()) {
         b.append(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -173,9 +173,9 @@ public class ValidationRunner {
         || !singleEntityValidatorsWithParsingErrors.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
-      b.append(" ----------------------------------------- \n");
+      b.append(" ------------------------------------------------------------------------- \n");
       b.append("|   The list of validators that couldn't run due to a parsing problem.   |\n");
-      b.append(" ----------------------------------------- \n");
+      b.append(" ------------------------------------------------------------------------- \n");
       b.append(" Validators with Parsing Errors: ");
       if (!validatorsWithParsingErrors.isEmpty()) {
         b.append(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -152,7 +152,8 @@ public class ValidationRunner {
       GtfsFeedLoader loader,
       AnyTableLoader anyTableLoader) {
     final long endNanos = System.nanoTime();
-    List<Class<? extends FileValidator>> skippedValidators = loader.getSkippedValidators();
+    List<Class<? extends FileValidator>> skippedValidators =
+        loader.getMultiFileValidatorsWithParsingErrors();
     if (!skippedValidators.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
@@ -165,11 +166,11 @@ public class ValidationRunner {
       logger.atSevere().log(b.toString());
     }
 
-    List<Class<? extends FileValidator>> validatorsWithParsingErrors =
+    List<Class<? extends FileValidator>> singleFileValidatorsWithParsingErrors =
         anyTableLoader.getValidatorsWithParsingErrors();
     List<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors =
         anyTableLoader.getSingleEntityValidatorsWithParsingErrors();
-    if (!validatorsWithParsingErrors.isEmpty()
+    if (!singleFileValidatorsWithParsingErrors.isEmpty()
         || !singleEntityValidatorsWithParsingErrors.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
@@ -177,9 +178,9 @@ public class ValidationRunner {
       b.append("|   The list of validators that couldn't run due to a parsing problem.   |\n");
       b.append(" ------------------------------------------------------------------------- \n");
       b.append(" Validators with Parsing Errors: ");
-      if (!validatorsWithParsingErrors.isEmpty()) {
+      if (!singleFileValidatorsWithParsingErrors.isEmpty()) {
         b.append(
-            validatorsWithParsingErrors.stream()
+            singleFileValidatorsWithParsingErrors.stream()
                 .map(Class::getSimpleName)
                 .collect(Collectors.joining(",")));
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -19,8 +19,6 @@ package org.mobilitydata.gtfsvalidator.runner;
 import com.google.common.flogger.FluentLogger;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -149,7 +147,10 @@ public class ValidationRunner {
    * @param feedContainer the {@code GtfsFeedContainer}
    */
   public static void printSummary(
-          long startNanos, GtfsFeedContainer feedContainer, GtfsFeedLoader loader, AnyTableLoader anyTableLoader) {
+      long startNanos,
+      GtfsFeedContainer feedContainer,
+      GtfsFeedLoader loader,
+      AnyTableLoader anyTableLoader) {
     final long endNanos = System.nanoTime();
     List<Class<? extends FileValidator>> skippedValidators = loader.getSkippedValidators();
     if (!skippedValidators.isEmpty()) {
@@ -163,16 +164,31 @@ public class ValidationRunner {
           skippedValidators.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
       logger.atSevere().log(b.toString());
     }
-    List<Class<? extends FileValidator>> validatorsWithParsingErrors = anyTableLoader.getValidatorsWithParsingErrors();
-    if (!validatorsWithParsingErrors.isEmpty()) {
+
+    List<Class<? extends FileValidator>> validatorsWithParsingErrors =
+        anyTableLoader.getValidatorsWithParsingErrors();
+    List<Class<? extends SingleEntityValidator>> singleEntityValidatorsWithParsingErrors =
+        anyTableLoader.getSingleEntityValidatorsWithParsingErrors();
+    if (!validatorsWithParsingErrors.isEmpty()
+        || !singleEntityValidatorsWithParsingErrors.isEmpty()) {
       StringBuilder b = new StringBuilder();
       b.append("\n");
       b.append(" ----------------------------------------- \n");
       b.append("|   The list of validators that couldn't run due to a parsing problem.   |\n");
       b.append(" ----------------------------------------- \n");
       b.append(" Validators with Parsing Errors: ");
-      b.append(
-              validatorsWithParsingErrors.stream().map(Class::getSimpleName).collect(Collectors.joining(",")));
+      if (!validatorsWithParsingErrors.isEmpty()) {
+        b.append(
+            validatorsWithParsingErrors.stream()
+                .map(Class::getSimpleName)
+                .collect(Collectors.joining(",")));
+      }
+      if (!singleEntityValidatorsWithParsingErrors.isEmpty()) {
+        b.append(
+            singleEntityValidatorsWithParsingErrors.stream()
+                .map(Class::getSimpleName)
+                .collect(Collectors.joining(",")));
+      }
       logger.atSevere().log(b.toString());
     }
     logger.atInfo().log("Validation took %.3f seconds%n", (endNanos - startNanos) / 1e9);


### PR DESCRIPTION
**Summary:**

Closes #1537 
My solution goes thru both SingleEntityValidators and SingleFileValidators, gathers validators that have dependencies with parsing errors. From my perspectives, we should decouple this problem into two parts. First, get the list of validators that couldn't run due to parsing errors. Second, a new logic could be added into the gtfs-validator - if we don't have this and that text files, then validator A B C should not run. @emmambd I request all dev team for code review. Let me know your opinion on the idea of decoupling this issue.

**Expected behavior:** 

You will see the following info printing out if there's validators that couldn't run due to parsing errors
 ------------------------------------------------------------------------- 
|   Some validators were skipped due to parsing problems.   |
 ------------------------------------------------------------------------- 
 Validators with Parsing Errors: BikesAllowanceValidator,GtfsAttributionRouteIdForeignKeyValidator,GtfsFareLegRuleNetworkIdForeignKeyValidator,GtfsFareRuleRouteIdForeignKeyValidator,GtfsRouteAgencyIdForeignKeyValidator,GtfsTransferFromRouteIdForeignKeyValidator,GtfsTransferToRouteIdForeignKeyValidator,GtfsTripRouteIdForeignKeyValidator,RouteAgencyIdValidator,ShapeToStopMatchingValidator,StopTimeTravelSpeedValidator,TranslationFieldAndReferenceValidator,UrlConsistencyValidator
Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
