### PR TITLE
feat: Make GtfsTableDescriptor.required a mutable property

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
@@ -80,7 +80,10 @@ public class GtfsFeedContainer {
   public String tableTotalsText() {
     List<String> totalList = new ArrayList<>();
     for (GtfsTableContainer<?> table : tables.values()) {
-      if (table.getTableStatus() == TableStatus.MISSING_FILE && !table.isRequired()) continue;
+      if (table.getTableStatus() == TableStatus.MISSING_FILE
+          && !table.getDescriptor().isRequired()) {
+        continue;
+      }
       totalList.add(
           table.gtfsFilename()
               + "\t"

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -33,13 +33,21 @@ import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
  */
 public abstract class GtfsTableContainer<T extends GtfsEntity> {
 
+  private final GtfsTableDescriptor<T> descriptor;
+
   private final TableStatus tableStatus;
 
   private final CsvHeader header;
 
-  public GtfsTableContainer(TableStatus tableStatus, CsvHeader header) {
+  public GtfsTableContainer(
+      GtfsTableDescriptor<T> descriptor, TableStatus tableStatus, CsvHeader header) {
+    this.descriptor = descriptor;
     this.tableStatus = tableStatus;
     this.header = header;
+  }
+
+  public GtfsTableDescriptor<T> getDescriptor() {
+    return descriptor;
   }
 
   public TableStatus getTableStatus() {
@@ -97,24 +105,6 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
   }
 
   /**
-   * Tells if the file is recommended according to GTFS.
-   *
-   * <p>Note that a recommended file may be empty.
-   *
-   * @return true if the file is recommended, false otherwise
-   */
-  public abstract boolean isRecommended();
-
-  /**
-   * Tells if the file is required according to GTFS.
-   *
-   * <p>Note that a required file may be empty.
-   *
-   * @return true if the file is required, false otherwise
-   */
-  public abstract boolean isRequired();
-
-  /**
    * Tells if the file was successfully parsed.
    *
    * <p>If all files in the feed were successfully parsed, then file validators may be executed.
@@ -135,7 +125,7 @@ public abstract class GtfsTableContainer<T extends GtfsEntity> {
       case PARSABLE_HEADERS_AND_ROWS:
         return true;
       case MISSING_FILE:
-        return !isRequired();
+        return !descriptor.isRequired();
       default:
         return false;
     }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableDescriptor.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableDescriptor.java
@@ -8,6 +8,10 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 
 public abstract class GtfsTableDescriptor<T extends GtfsEntity> {
+
+  // True if the specified file is required in a feed.
+  private boolean required;
+
   public abstract GtfsTableContainer createContainerForInvalidStatus(
       GtfsTableContainer.TableStatus tableStatus);
 
@@ -24,7 +28,13 @@ public abstract class GtfsTableDescriptor<T extends GtfsEntity> {
 
   public abstract boolean isRecommended();
 
-  public abstract boolean isRequired();
+  public boolean isRequired() {
+    return this.required;
+  }
+
+  public void setRequired(boolean required) {
+    this.required = required;
+  }
 
   public abstract Optional<Integer> maxCharsPerColumn();
 

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableContainer.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableContainer.java
@@ -30,13 +30,14 @@ public class GtfsTestTableContainer extends GtfsTableContainer<GtfsTestEntity> {
 
   private List<GtfsTestEntity> entities;
 
-  private GtfsTestTableContainer(CsvHeader header, List<GtfsTestEntity> entities) {
-    super(TableStatus.PARSABLE_HEADERS_AND_ROWS, header);
+  private GtfsTestTableContainer(
+      GtfsTestTableDescriptor descriptor, CsvHeader header, List<GtfsTestEntity> entities) {
+    super(descriptor, TableStatus.PARSABLE_HEADERS_AND_ROWS, header);
     this.entities = entities;
   }
 
   public GtfsTestTableContainer(TableStatus tableStatus) {
-    super(tableStatus, CsvHeader.EMPTY);
+    super(new GtfsTestTableDescriptor(), tableStatus, CsvHeader.EMPTY);
     this.entities = new ArrayList<>();
   }
 
@@ -51,34 +52,18 @@ public class GtfsTestTableContainer extends GtfsTableContainer<GtfsTestEntity> {
   }
 
   @Override
-  public boolean isRecommended() {
-    return false;
-  }
-
-  @Override
-  public boolean isRequired() {
-    return true;
-  }
-
-  @Override
   public List<GtfsTestEntity> getEntities() {
     return entities;
   }
 
   /** Creates a table with given header and entities */
   public static GtfsTestTableContainer forHeaderAndEntities(
-      CsvHeader header, List<GtfsTestEntity> entities, NoticeContainer noticeContainer) {
-    GtfsTestTableContainer table = new GtfsTestTableContainer(header, entities);
+      GtfsTestTableDescriptor descriptor,
+      CsvHeader header,
+      List<GtfsTestEntity> entities,
+      NoticeContainer noticeContainer) {
+    GtfsTestTableContainer table = new GtfsTestTableContainer(descriptor, header, entities);
     return table;
-  }
-
-  /**
-   * Creates a table with given entities and empty header. This method is intended to be used in
-   * tests.
-   */
-  public static GtfsTestTableContainer forEntities(
-      List<GtfsTestEntity> entities, NoticeContainer noticeContainer) {
-    return forHeaderAndEntities(CsvHeader.EMPTY, entities, noticeContainer);
   }
 
   @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableDescriptor.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestTableDescriptor.java
@@ -21,7 +21,7 @@ public class GtfsTestTableDescriptor extends GtfsTableDescriptor<GtfsTestEntity>
   @Override
   public GtfsTableContainer createContainerForHeaderAndEntities(
       CsvHeader header, List<GtfsTestEntity> entities, NoticeContainer noticeContainer) {
-    return GtfsTestTableContainer.forHeaderAndEntities(header, entities, noticeContainer);
+    return GtfsTestTableContainer.forHeaderAndEntities(this, header, entities, noticeContainer);
   }
 
   @Override

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidatorTest.java
@@ -18,6 +18,7 @@ import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.*;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
 
@@ -85,8 +86,8 @@ public class DateTripsValidatorTest {
             ImmutableSet.copyOf(DayOfWeek.values()));
     var calendarTable =
         GtfsCalendarTableContainer.forEntities(ImmutableList.of(calendar), noticeContainer);
-    var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
-    var frequencyTable = new GtfsFrequencyTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
+    var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
+    var frequencyTable = GtfsFrequencyTableContainer.forStatus(TableStatus.EMPTY_FILE);
 
     var tripBlock = createTripBlock(serviceId, 6, "b1");
     var tripContainer = GtfsTripTableContainer.forEntities(tripBlock, noticeContainer);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
@@ -31,6 +31,7 @@ import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.*;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 
 @RunWith(JUnit4.class)
@@ -66,7 +67,7 @@ public class ExpiredCalendarValidatorTest {
     GtfsCalendarTableContainer calendarTable =
         GtfsCalendarTableContainer.forEntities(calendars, container);
 
-    var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
+    var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
     new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices())
@@ -93,7 +94,7 @@ public class ExpiredCalendarValidatorTest {
     GtfsCalendarTableContainer calendarTable =
         GtfsCalendarTableContainer.forEntities(calendars, container);
 
-    var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
+    var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
     new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
@@ -119,7 +120,7 @@ public class ExpiredCalendarValidatorTest {
     GtfsCalendarTableContainer calendarTable =
         GtfsCalendarTableContainer.forEntities(calendars, container);
 
-    var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
+    var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
     new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
@@ -211,7 +212,7 @@ public class ExpiredCalendarValidatorTest {
 
     GtfsCalendarTableContainer calendarTable =
         GtfsCalendarTableContainer.forEntities(calendars, container);
-    var dateTable = new GtfsCalendarDateTableContainer(GtfsTableContainer.TableStatus.EMPTY_FILE);
+    var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
     new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MatchingFeedAndAgencyLangValidatorTest.java
@@ -77,8 +77,8 @@ public class MatchingFeedAndAgencyLangValidatorTest {
   public void noFeedInfoShouldNotGenerateNotice() {
     assertThat(
             generateNotices(
-                new GtfsAgencyTableContainer(TableStatus.EMPTY_FILE),
-                new GtfsFeedInfoTableContainer(TableStatus.EMPTY_FILE)))
+                GtfsAgencyTableContainer.forStatus(TableStatus.EMPTY_FILE),
+                GtfsFeedInfoTableContainer.forStatus(TableStatus.EMPTY_FILE)))
         .isEmpty();
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingCalendarAndCalendarDateValidatorTest.java
@@ -118,8 +118,8 @@ public class MissingCalendarAndCalendarDateValidatorTest {
   public void bothMissingFilesShouldGenerateNotice() {
     assertThat(
             generateNotices(
-                new GtfsCalendarTableContainer(TableStatus.MISSING_FILE),
-                new GtfsCalendarDateTableContainer(TableStatus.MISSING_FILE)))
+                GtfsCalendarTableContainer.forStatus(TableStatus.MISSING_FILE),
+                GtfsCalendarDateTableContainer.forStatus(TableStatus.MISSING_FILE)))
         .containsExactly(new MissingCalendarAndCalendarDateFilesNotice());
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TimepointTimeValidatorTest.java
@@ -38,6 +38,7 @@ import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableDescriptor;
 import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 import org.mobilitydata.gtfsvalidator.validator.TimepointTimeValidator.MissingTimepointValueNotice;
 import org.mobilitydata.gtfsvalidator.validator.TimepointTimeValidator.StopTimeTimepointWithoutTimesNotice;
@@ -46,7 +47,8 @@ public class TimepointTimeValidatorTest {
 
   private static GtfsStopTimeTableContainer createTable(
       CsvHeader header, List<GtfsStopTime> stopTimes, NoticeContainer noticeContainer) {
-    return GtfsStopTimeTableContainer.forHeaderAndEntities(header, stopTimes, noticeContainer);
+    return GtfsStopTimeTableContainer.forHeaderAndEntities(
+        new GtfsStopTimeTableDescriptor(), header, stopTimes, noticeContainer);
   }
 
   private static List<ValidationNotice> generateNotices(

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidatorTest.java
@@ -37,6 +37,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTranslation;
 import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTranslationTableDescriptor;
 import org.mobilitydata.gtfsvalidator.validator.TranslationFieldAndReferenceValidator.TranslationForeignKeyViolationNotice;
 import org.mobilitydata.gtfsvalidator.validator.TranslationFieldAndReferenceValidator.TranslationUnexpectedValueNotice;
 import org.mobilitydata.gtfsvalidator.validator.TranslationFieldAndReferenceValidator.TranslationUnknownTableNameNotice;
@@ -65,7 +66,7 @@ public final class TranslationFieldAndReferenceValidatorTest {
     NoticeContainer noticeContainer = new NoticeContainer();
     GtfsTranslationTableContainer translationTable =
         GtfsTranslationTableContainer.forHeaderAndEntities(
-            translationHeader, translations, noticeContainer);
+            new GtfsTranslationTableDescriptor(), translationHeader, translations, noticeContainer);
     new TranslationFieldAndReferenceValidator(
             translationTable,
             new GtfsFeedContainer(

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerGenerator.java
@@ -31,6 +31,7 @@ import org.mobilitydata.gtfsvalidator.annotation.Generated;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTableDescriptor;
 
 /**
  * Generates code for a container for a loaded GTFS table.
@@ -43,10 +44,15 @@ public class TableContainerGenerator {
   private final GtfsEntityClasses classNames;
   private final TableContainerIndexGenerator indexGenerator;
 
+  private final ParameterizedTypeName tableDescriptorType;
+
   public TableContainerGenerator(GtfsFileDescriptor fileDescriptor) {
     this.fileDescriptor = fileDescriptor;
     this.classNames = new GtfsEntityClasses(fileDescriptor);
     this.indexGenerator = new TableContainerIndexGenerator(fileDescriptor);
+    this.tableDescriptorType =
+        ParameterizedTypeName.get(
+            ClassName.get(GtfsTableDescriptor.class), classNames.entityImplementationTypeName());
   }
 
   public JavaFile generateGtfsContainerJavaFile() {
@@ -78,22 +84,6 @@ public class TableContainerGenerator {
             .addStatement("return $T.FILENAME", classNames.entityImplementationTypeName())
             .build());
 
-    typeSpec.addMethod(
-        MethodSpec.methodBuilder("isRecommended")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .returns(boolean.class)
-            .addStatement("return $L", fileDescriptor.recommended())
-            .build());
-
-    typeSpec.addMethod(
-        MethodSpec.methodBuilder("isRequired")
-            .addAnnotation(Override.class)
-            .addModifiers(Modifier.PUBLIC)
-            .returns(boolean.class)
-            .addStatement("return $L", fileDescriptor.required())
-            .build());
-
     typeSpec.addField(
         ParameterizedTypeName.get(ClassName.get(List.class), gtfsEntityType),
         "entities",
@@ -111,6 +101,7 @@ public class TableContainerGenerator {
     typeSpec.addMethod(generateConstructorWithStatus());
     typeSpec.addMethod(generateForHeaderAndEntitiesMethod());
     typeSpec.addMethod(generateForEntitiesMethod());
+    typeSpec.addMethod(generateForStatusMethod());
 
     indexGenerator.generateMethods(typeSpec);
 
@@ -120,12 +111,13 @@ public class TableContainerGenerator {
   private MethodSpec generateConstructorWithEntities() {
     return MethodSpec.constructorBuilder()
         .addModifiers(Modifier.PRIVATE)
+        .addParameter(tableDescriptorType, "descriptor")
         .addParameter(CsvHeader.class, "header")
         .addParameter(
             ParameterizedTypeName.get(
                 ClassName.get(List.class), classNames.entityImplementationTypeName()),
             "entities")
-        .addStatement("super(TableStatus.PARSABLE_HEADERS_AND_ROWS, header)")
+        .addStatement("super(descriptor, TableStatus.PARSABLE_HEADERS_AND_ROWS, header)")
         .addStatement("this.entities = entities")
         .build();
   }
@@ -133,8 +125,9 @@ public class TableContainerGenerator {
   private MethodSpec generateConstructorWithStatus() {
     return MethodSpec.constructorBuilder()
         .addModifiers(Modifier.PUBLIC)
+        .addParameter(tableDescriptorType, "descriptor")
         .addParameter(GtfsTableContainer.TableStatus.class, "tableStatus")
-        .addStatement("super(tableStatus, $T.EMPTY)", CsvHeader.class)
+        .addStatement("super(descriptor, tableStatus, $T.EMPTY)", CsvHeader.class)
         .addStatement("this.entities = new $T<>()", ArrayList.class)
         .build();
   }
@@ -145,6 +138,7 @@ public class TableContainerGenerator {
         .returns(tableContainerTypeName)
         .addJavadoc("Creates a table with given header and entities")
         .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addParameter(tableDescriptorType, "descriptor")
         .addParameter(CsvHeader.class, "header")
         .addParameter(
             ParameterizedTypeName.get(
@@ -152,7 +146,9 @@ public class TableContainerGenerator {
             "entities")
         .addParameter(NoticeContainer.class, "noticeContainer")
         .addStatement(
-            "$T table = new $T(header, entities)", tableContainerTypeName, tableContainerTypeName)
+            "$T table = new $T(descriptor, header, entities)",
+            tableContainerTypeName,
+            tableContainerTypeName)
         .addStatement("table.setupIndices(noticeContainer)")
         .addStatement("return table")
         .build();
@@ -172,7 +168,25 @@ public class TableContainerGenerator {
             "entities")
         .addParameter(NoticeContainer.class, "noticeContainer")
         .addStatement(
-            "return forHeaderAndEntities($T.EMPTY, entities, noticeContainer)", CsvHeader.class)
+            "return forHeaderAndEntities(new $T(), $T.EMPTY, entities, noticeContainer)",
+            classNames.tableDescriptorTypeName(),
+            CsvHeader.class)
+        .build();
+  }
+
+  private MethodSpec generateForStatusMethod() {
+    TypeName tableContainerTypeName = classNames.tableContainerTypeName();
+    return MethodSpec.methodBuilder("forStatus")
+        .returns(tableContainerTypeName)
+        .addJavadoc(
+            "Creates a table with the given TableStatus. This method is intended to be"
+                + " used in tests.")
+        .addModifiers(Modifier.PUBLIC, Modifier.STATIC)
+        .addParameter(GtfsTableContainer.TableStatus.class, "tableStatus")
+        .addStatement(
+            "return new $T(new $T(), tableStatus)",
+            tableContainerTypeName,
+            classNames.tableDescriptorTypeName())
         .build();
   }
 }

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableDescriptorGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableDescriptorGenerator.java
@@ -105,6 +105,8 @@ public class TableDescriptorGenerator {
             .addAnnotation(Generated.class)
             .addModifiers(Modifier.PUBLIC, Modifier.FINAL);
 
+    typeSpec.addMethod(generateConstructor());
+
     typeSpec.addMethod(generateCreateContainerForInvalidStatusMethod());
     typeSpec.addMethod(generateCreateContainerForHeaderAndEntitiesMethod());
     typeSpec.addMethod(generateCreateEntityBuilderMethod());
@@ -114,10 +116,16 @@ public class TableDescriptorGenerator {
 
     typeSpec.addMethod(generateGtfsFilenameMethod());
     typeSpec.addMethod(generateIsRecommendedMethod());
-    typeSpec.addMethod(generateIsRequiredMethod());
     typeSpec.addMethod(generateMaxCharsPerColumnMethod());
 
     return typeSpec.build();
+  }
+
+  private MethodSpec generateConstructor() {
+    return MethodSpec.constructorBuilder()
+        .addModifiers(Modifier.PUBLIC)
+        .addStatement("setRequired($L)", fileDescriptor.required())
+        .build();
   }
 
   private MethodSpec generateCreateContainerForHeaderAndEntitiesMethod() {
@@ -132,7 +140,7 @@ public class TableDescriptorGenerator {
         .addParameter(NoticeContainer.class, "noticeContainer")
         .returns(GtfsTableContainer.class)
         .addStatement(
-            "return $T.forHeaderAndEntities(header, entities, noticeContainer)",
+            "return $T.forHeaderAndEntities(this, header, entities, noticeContainer)",
             classNames.tableContainerTypeName())
         .build();
   }
@@ -143,7 +151,7 @@ public class TableDescriptorGenerator {
         .addModifiers(Modifier.PUBLIC)
         .addParameter(GtfsTableContainer.TableStatus.class, "tableStatus")
         .returns(GtfsTableContainer.class)
-        .addStatement("return new $T(tableStatus)", classNames.tableContainerTypeName())
+        .addStatement("return new $T(this, tableStatus)", classNames.tableContainerTypeName())
         .build();
   }
 
@@ -300,15 +308,6 @@ public class TableDescriptorGenerator {
         .returns(boolean.class)
         .addAnnotation(Override.class)
         .addStatement("return $L", fileDescriptor.recommended())
-        .build();
-  }
-
-  private MethodSpec generateIsRequiredMethod() {
-    return MethodSpec.methodBuilder("isRequired")
-        .addModifiers(Modifier.PUBLIC)
-        .returns(boolean.class)
-        .addAnnotation(Override.class)
-        .addStatement("return $L", fileDescriptor.required())
         .build();
   }
 


### PR DESCRIPTION
Per discussion in #1564, I'm looking to add base API support for changing the "required" status of some GTFS files/tables at run-time, as opposed to compile time.  This PR achieves that by making "required" a mutable field in GtfsTableDescriptor to support dynamic configuration.  Additionally, this PR consolidates some duplicate "isRequired" methods from GtfsTableContainer to make GtfsTableDescriptor the sole source of this info.

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
