### PR TITLE
Fix for deprecated of `set-output` in GH actions

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "[Pull Request] Get commit message"
         if: github.event_name == 'pull_request'
         id: pr_get_commit_message
-        run: echo "pr_commit_message=$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_OUTPUT
+        run: echo "pr_commit_message=\"$(git log --format=%B -n 1 HEAD^2)\"" >> $GITHUB_OUTPUT
 
     # For **Pull Request** events this will resolve to something like "$( [ -z "commit message pr" ] && echo "" || echo "commit message pr" )" which then resolves to just "commit message pr"
     outputs:

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: "[Pull Request] Get commit message"
         if: github.event_name == 'pull_request'
         id: pr_get_commit_message
-        run: echo ::set-output name=pr_commit_message::$(git log --format=%B -n 1 HEAD^2)
+        run: echo "pr_commit_message=$(git log --format=%B -n 1 HEAD^2)" >> $GITHUB_OUTPUT
 
     # For **Pull Request** events this will resolve to something like "$( [ -z "commit message pr" ] && echo "" || echo "commit message pr" )" which then resolves to just "commit message pr"
     outputs:
@@ -117,7 +117,7 @@ jobs:
         run: |
           DATASETS=$(python3 scripts/mobility-database-harvester/harvest_latest_versions.py -d scripts/mobility-database-harvester/datasets_metadata -l gtfs_latest_versions.json)
           echo $DATASETS
-          echo "::set-output name=matrix::$DATASETS"
+          echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist metadata
         if: always()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -93,9 +93,9 @@ jobs:
           fi
           echo "Set DOCKER_TAGS=${DOCKER_TAGS}"
 
-          echo ::set-output name=version::${AXION_VERSION}
-          echo ::set-output name=tags::${DOCKER_TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+          echo "version=${AXION_VERSION}" >> $GITHUB_OUTPUT
+          echo "tags=${DOCKER_TAGS}" >> $GITHUB_OUTPUT
+          echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> $GITHUB_OUTPUT
 
       # Build and push steps are split up in order to test the built contaire image in between
       # - build-args and labels inputs _must_ be kept matching between both to prevent rebuild

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           DATASETS=$(python3 scripts/mobility-database-harvester/harvest_latest_versions.py -d scripts/mobility-database-harvester/datasets_metadata -l gtfs_latest_versions.json -s)
           echo $DATASETS
-          echo "::set-output name=matrix::$DATASETS"
+          echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist metadata
         if: always()
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
GitHub has deprecated set-output and will eventually make it unusable, so this is a preventative fix. See more info here: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/