### PR TITLE
fix: Use csvRowNumber in MissingFeedContactEmailAndUrlNotice for consistency with other notices 

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedContactValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedContactValidator.java
@@ -18,8 +18,10 @@ import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
 public class FeedContactValidator extends SingleEntityValidator<GtfsFeedInfo> {
 
   /**
-   * Best Practices https://gtfs.org/schedule/best-practices/#feed_infotxt suggest providing at
-   * least one of feed_contact_email and feed_contact_url
+   * Only generates a warning when both feed_contact_email and feed_contact_url are unset
+   *
+   * <p>There should be no warning generated when the dataset has one of feed_contact_email and
+   * feed_contact_url.
    *
    * @param entity
    * @param noticeContainer
@@ -34,10 +36,8 @@ public class FeedContactValidator extends SingleEntityValidator<GtfsFeedInfo> {
   }
 
   /**
-   * Only generates a warning when both feed_contact_email and feed_contact_url are unset
-   *
-   * <p>There should be no warning generated when the dataset has one of feed_contact_email and
-   * feed_contact_url.
+   * Best Practices for `feed_info.txt` suggest providing at least one of `feed_contact_email` and
+   * `feed_contact_url`.
    */
   @GtfsValidationNotice(
       severity = WARNING,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedContactValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedContactValidator.java
@@ -26,8 +26,8 @@ public class FeedContactValidator extends SingleEntityValidator<GtfsFeedInfo> {
    */
   @Override
   public void validate(GtfsFeedInfo entity, NoticeContainer noticeContainer) {
-    if (!entity.hasFeedContactEmail() && !entity.hasFeedContactUrl()
-        || entity.feedContactEmail().isBlank() && entity.feedContactUrl().isBlank()) {
+    if ((!entity.hasFeedContactEmail() || entity.feedContactEmail().isBlank())
+        && (!entity.hasFeedContactUrl() || entity.feedContactUrl().isBlank())) {
       noticeContainer.addValidationNotice(
           new MissingFeedContactEmailAndUrlNotice(entity.csvRowNumber()));
     }
@@ -49,10 +49,10 @@ public class FeedContactValidator extends SingleEntityValidator<GtfsFeedInfo> {
       })
   static class MissingFeedContactEmailAndUrlNotice extends ValidationNotice {
     /** The row number of the validated record. */
-    private final int rowNumber;
+    private final int csvRowNumber;
 
-    MissingFeedContactEmailAndUrlNotice(int rowNumber) {
-      this.rowNumber = rowNumber;
+    MissingFeedContactEmailAndUrlNotice(int csvRowNumber) {
+      this.csvRowNumber = csvRowNumber;
     }
   }
 }


### PR DESCRIPTION
`csvRowNumber` is used in every other notice for referencing the csv row number.  This schema change is safe since we haven't published a new release with this change yet.  This PR also swaps the comment for `MissingFeedContactEmailAndUrlNotice` since it seems more appropriate for a documentation string than the existing comment.  Finally, slightly tweak logic in FeedContactValidator.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
