### PR TITLE
Updated actions/setup-node action to v3.8.1 to use node 16

### DIFF
--- a/.github/workflows/create_issue_if_referencemd_changes.yml
+++ b/.github/workflows/create_issue_if_referencemd_changes.yml
@@ -18,7 +18,7 @@ jobs:
           token: ${{ secrets.GENERIC_ACTION_REPO_SCOPE }} 
 
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3.8.1
         with:
           node-version: '16.x'
 


### PR DESCRIPTION
Upped the version of actions/setup-node to v3.8.1 to use node 16. Following warning from GH:

```
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/setup-node@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
```