### PR TITLE
bug: initialized tooltip in the report.html

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/NoticeView.java
@@ -69,7 +69,11 @@ public class NoticeView {
    * @return description text
    */
   public String getCommentForField(String field) {
-    return comments.getFieldComment(field);
+    if (field.isBlank()) {
+      return field;
+    } else {
+      return comments.getFieldComment(field);
+    }
   }
   /**
    * Returns the description text for the notice.

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -4,6 +4,12 @@
     <title>GTFS Schedule Validation Report</title>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8; width=device-width, initial-scale=1"/>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+    <script>
+      $(document).ready(function () {
+        $(document).tooltip();
+      });
+    </script>
     <style>
     body {
         font-family: Helvetica, Arial, sans-serif;
@@ -122,7 +128,6 @@
     }
 
     .tooltip .tooltiptext {
-        visibility: hidden;
         background-color: #555;
         color: #fff;
         text-align: center;


### PR DESCRIPTION
initialize tooltip in report.html
return non-empty string when getting comment for field in NoticeView

**Summary:**

Closes #1561 

**Expected behavior:** 
<img width="1728" alt="Screenshot 2023-09-18 at 1 28 00 PM" src="https://github.com/MobilityData/gtfs-validator/assets/5789435/6a9da1fd-381b-4dce-80dd-8b021803d158">
<img width="1728" alt="Screenshot 2023-09-18 at 1 22 11 PM" src="https://github.com/MobilityData/gtfs-validator/assets/5789435/21a458be-6c6d-4d4c-97bd-3152a31e3d03">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
