### PR TITLE
Corrected a problem with the acceptance test action.

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -33,7 +33,10 @@ jobs:
       - name: "[Pull Request] Get commit message"
         if: github.event_name == 'pull_request'
         id: pr_get_commit_message
-        run: echo "pr_commit_message=\"$(git log --format=%B -n 1 HEAD^2)\"" >> $GITHUB_OUTPUT
+        # Obtain the last commit from the branch to merge (hence the HEAD^2).
+        # In case of multi-line commit messages, remove any \n, because the GITHUB_OUTPUT method
+        # of sending data to other jobs does not like them.
+        run: echo "pr_commit_message=\"$(git log --format=%B -n 1 HEAD^2 | tr '\n' ' '))\"" >> $GITHUB_OUTPUT
 
     # For **Pull Request** events this will resolve to something like "$( [ -z "commit message pr" ] && echo "" || echo "commit message pr" )" which then resolves to just "commit message pr"
     outputs:


### PR DESCRIPTION
acceptance_test.yml did not run properly.
It seems the replacement for ::set-output (i.e. >> $GITHUB_OUTPUT) does not accept newlines in the data.
This was a problem with multi-line commit messages.
Just replaced newlines by spaces.


