### PR TITLE
Fix: Removed a dataset that is too big from the list used in PR acceptance test

### DIFF
--- a/scripts/mobility-database-harvester/harvest_latest_versions.py
+++ b/scripts/mobility-database-harvester/harvest_latest_versions.py
@@ -31,7 +31,10 @@ AUTHENTICATION_TYPE = "urls.authentication_type"
 MDB_SOURCE_ID = "mdb_source_id"
 
 # Sources to exclude because they are too big for the workflow.
-SOURCES_TO_EXCLUDE = ["de-unknown-rursee-schifffahrt-kg-gtfs-784"]
+SOURCES_TO_EXCLUDE = [
+    "de-unknown-rursee-schifffahrt-kg-gtfs-784",
+    "de-unknown-ulmer-eisenbahnfreunde-gtfs-1081"
+]
 
 # Google Cloud constants
 URL_PREFIX = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/"

--- a/scripts/mobility-database-harvester/harvest_latest_versions.py
+++ b/scripts/mobility-database-harvester/harvest_latest_versions.py
@@ -33,7 +33,12 @@ MDB_SOURCE_ID = "mdb_source_id"
 # Sources to exclude because they are too big for the workflow.
 SOURCES_TO_EXCLUDE = [
     "de-unknown-rursee-schifffahrt-kg-gtfs-784",
-    "de-unknown-ulmer-eisenbahnfreunde-gtfs-1081"
+    "de-unknown-ulmer-eisenbahnfreunde-gtfs-1081",
+    "no-unknown-agder-kollektivtrafikk-as-gtfs-1078",
+    "hu-unknown-volanbusz-gtfs-1836",
+    "de-baden-wurttemberg-verkehrsverbund-rhein-neckar-gtfs-1173",
+    "de-baden-wurttemberg-db-zugbus-regionalverkehr-alb-bodensee-gtfs-773",
+    "au-new-south-wales-train-replacement-bus-operators-gtfs-1322"
 ]
 
 # Google Cloud constants


### PR DESCRIPTION
**Summary:**

Closes #1587

Removed de-unknown-ulmer-eisenbahnfreunde-gtfs-1081 from the list of files used in the PR validation.
This file has over 40M shapes entries and it's just too big for the changes in https://github.com/MobilityData/gtfs-validator/pull/1553

**Expected behavior:** 

The acceptance tests pass.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
