### PR TITLE
feat: Support injection of arbitrary types via ValidationContext

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
@@ -93,7 +93,7 @@ public class DefaultValidatorProvider implements ValidatorProvider {
         } else {
           validators.add((SingleEntityValidator<T>) validatorWithDependencyStatus.validator());
         }
-      } catch (ReflectiveOperationException e) {
+      } catch (ReflectiveOperationException | ValidatorLoaderException e) {
         logger.atSevere().withCause(e).log(
             "Cannot instantiate validator %s", validatorClass.getCanonicalName());
       }
@@ -117,7 +117,7 @@ public class DefaultValidatorProvider implements ValidatorProvider {
         } else {
           validators.add(validatorWithStatus.validator());
         }
-      } catch (ReflectiveOperationException e) {
+      } catch (ReflectiveOperationException | ValidatorLoaderException e) {
         logger.atSevere().withCause(e).log(
             "Cannot instantiate validator %s", validatorClass.getCanonicalName());
       }
@@ -139,7 +139,7 @@ public class DefaultValidatorProvider implements ValidatorProvider {
         } else {
           validators.add(validatorWithStatus.validator());
         }
-      } catch (ReflectiveOperationException e) {
+      } catch (ReflectiveOperationException | ValidatorLoaderException e) {
         logger.atSevere().withCause(e).log(
             "Cannot instantiate validator %s", validatorClass.getCanonicalName());
       }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
@@ -36,9 +36,9 @@ public class ValidationContext {
   }
 
   /**
-   * Represents a name of a GTFS feed, such as "nl-openov".
+   * Represents the country code of a GTFS feed, such as US or NL.
    *
-   * @return the @code{GtfsFeedName} representing the feed's name
+   * @return the @code{CountryCode} representing the feed's country code
    */
   public CountryCode countryCode() {
     return get(CountryCode.class);

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
@@ -54,6 +54,16 @@ public final class ValidationContextTest {
         IllegalArgumentException.class, () -> VALIDATION_CONTEXT.get(ChildCurrentDateTime.class));
   }
 
+  @Test
+  public void get_extraIntegerObject_successful() {
+    assertThat(
+            ValidationContext.builder()
+                .set(Integer.class, new Integer(10))
+                .build()
+                .get(Integer.class))
+        .isEqualTo(10);
+  }
+
   private static class ChildCurrentDateTime extends CurrentDateTime {
 
     public ChildCurrentDateTime(ZonedDateTime now) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -43,7 +43,8 @@ public class ValidatorLoaderTest {
           .build();
 
   @Test
-  public void createValidatorWithContext_injectsContext() throws ReflectiveOperationException {
+  public void createValidatorWithContext_injectsContext()
+      throws ReflectiveOperationException, ValidatorLoaderException {
     GtfsTestEntityValidator validator =
         ValidatorLoader.createValidatorWithContext(
                 GtfsTestEntityValidator.class, VALIDATION_CONTEXT)
@@ -55,7 +56,7 @@ public class ValidatorLoaderTest {
 
   @Test
   public void createSingleFileValidator_injectsTableContainerAndContext()
-      throws ReflectiveOperationException {
+      throws ReflectiveOperationException, ValidatorLoaderException {
     GtfsTestTableContainer table = new GtfsTestTableContainer(TableStatus.EMPTY_FILE);
     GtfsTestSingleFileValidator validator =
         (GtfsTestSingleFileValidator)
@@ -70,7 +71,7 @@ public class ValidatorLoaderTest {
 
   @Test
   public void createMultiFileValidator_injectsFeedContainerAndContext()
-      throws ReflectiveOperationException {
+      throws ReflectiveOperationException, ValidatorLoaderException {
     GtfsTestTableContainer stopTable =
         new GtfsTestTableContainer(TableStatus.PARSABLE_HEADERS_AND_ROWS);
     GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(stopTable));
@@ -88,7 +89,7 @@ public class ValidatorLoaderTest {
 
   @Test
   public void createMultiFileValidator_singleContainer_dependenciesHaveErrors()
-      throws ReflectiveOperationException {
+      throws ReflectiveOperationException, ValidatorLoaderException {
     GtfsTestTableContainer table = new GtfsTestTableContainer(TableStatus.UNPARSABLE_ROWS);
     GtfsFeedContainer feedContainer = new GtfsFeedContainer(ImmutableList.of(table));
 


### PR DESCRIPTION
ValidationContext is used to inject params to constructors of *Validator classes. ValidationContext initially supported only CountryCode and CurrentDateTime, e.g.:

  @Inject
  ExpiredCalendarValidator(
      CurrentDateTime currentDateTime, // Injected from ValidationContext
      GtfsCalendarTableContainer calendarTable,
      GtfsCalendarDateTableContainer calendarDateTable) {...}

This change allows the user to inject any types required for custom validation logic.