### PR TITLE
feat: Update references to Dataset Publishing Guidelines from #1601 

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
@@ -23,7 +23,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
       @UrlRef(
           label = "Best Practices for All Files",
           url =
-              "https://gtfs.org/schedule/best-practices/#practice-recommendations-organized-by-file")
+              "https://gtfs.org/schedule/reference/#file-requirements")
     })
 public class MixedCaseRecommendedFieldNotice extends ValidationNotice {
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/MixedCaseRecommendedFieldNotice.java
@@ -22,8 +22,7 @@ import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
     urls = {
       @UrlRef(
           label = "Best Practices for All Files",
-          url =
-              "https://gtfs.org/schedule/reference/#file-requirements")
+          url = "https://gtfs.org/schedule/reference/#file-requirements")
     })
 public class MixedCaseRecommendedFieldNotice extends ValidationNotice {
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
@@ -75,7 +75,7 @@ public class ExpiredCalendarValidator extends FileValidator {
       urls = {
         @UrlRef(
             label = "Dataset Publishing & General Practices",
-            url = "https://gtfs.org/schedule/best-practices/#dataset-publishing-general-practices")
+            url = "https://gtfs.org/schedule/reference/#dataset-publishing-general-practices")
       })
   static class ExpiredCalendarNotice extends ValidationNotice {
 

--- a/web/client/src/routes/rules.html/SectionRefLink.svelte
+++ b/web/client/src/routes/rules.html/SectionRefLink.svelte
@@ -13,7 +13,7 @@
     },
     'dataset-publishing-general-practices': {
       label: 'Dataset Publishing & General Practices',
-      url: 'https://gtfs.org/schedule/best-practices/#dataset-publishing-general-practices',
+      url: 'https://gtfs.org/schedule/reference/#dataset-publishing-general-practices',
     },
     'field-definitions': {
       label: 'Field Definitions',


### PR DESCRIPTION
**Summary:**

Dataset Publishing Guidelines and All Files Recommendations were moved from the best practices section of the spec to the reference file, and as referenced in #1601. This PR updates the links to the References sections of the corresponding rules so no links break.

**Expected behavior:** 

[mixed_case_recommended_field](https://gtfs-validator.mobilitydata.org/rules.html#mixed_case_recommended_field-rule)
[expired_calendar](https://gtfs-validator.mobilitydata.org/rules.html#expired_calendar-rule) 

both link to https://gtfs.org/schedule/reference/.
