### PR TITLE
fix: Add label to step that creates an issue

### DIFF
--- a/.github/workflows/create_issue_if_referencemd_changes.yml
+++ b/.github/workflows/create_issue_if_referencemd_changes.yml
@@ -108,4 +108,5 @@ jobs:
           title: ${{ steps.dates.outputs.today }} — ${{ steps.process_json.outputs.commits_length }} new commit(s) made to `reference.md` in Google Transit's repo
           body: |
             ${{ steps.process_json.outputs.extracted_data }}
+          labels: 'status: Needs triage'
           assignees: ${{ steps.git-setup.outputs.assigned }}


### PR DESCRIPTION
Added label "status: needs triage" to newly created issues with the script, as requested here: https://github.com/MobilityData/gtfs-validator/issues/1080#issuecomment-1826364054