### PR TITLE
fix: Correct links to rule documentation by adding -rule

### DIFF
--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -331,7 +331,7 @@
                             <h3 th:text="${noticesByCode.key}" />
                             <p th:utext="${noticesByCode.value[0].description}" />
                             <p> You can see more about this notice <a
-                                    th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key}}">here</a>.
+                                    th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key} + '-rule'}">here</a>.
                             </p>
                              <p th:if="${noticesByCode.value.size > 50}">Only the first 50 of <span th:text="${noticesByCode.value.size}"></span> affected records are displayed below.</p>
                             <table>


### PR DESCRIPTION
**Summary:**

Resolves issue #1608 and duplicate issue #1626.

Links are currently broken. They go to the right web page but not to the individual rule on the page. This corrects the links, which just need "-rule" added to them.

**Expected behavior:** 

The generated report.html file should have a correct link for each rule it lists, going directly to that rule's section of the documentation.

I tested on a sample report and confirmed the new links work.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [X ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
