### PR TITLE
fix: decreasing_or_equal_stop_time_distance includes prevShapeDistTraveled

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeIncreasingDistanceValidator.java
@@ -101,7 +101,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
      * Actual distance traveled along the shape from the first shape point to the previous stop
      * time.
      */
-    private final double prevStopTimeDistTraveled;
+    private final double prevShapeDistTraveled;
 
     /** The previous record's `stop_times.stop_sequence`. */
     private final int prevStopSequence;
@@ -113,7 +113,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
         double shapeDistTraveled,
         int stopSequence,
         long prevCsvRowNumber,
-        double prevStopTimeDistTraveled,
+        double prevShapeDistTraveled,
         int prevStopSequence) {
       this.tripId = tripId;
       this.stopId = stopId;
@@ -121,7 +121,7 @@ public class StopTimeIncreasingDistanceValidator extends FileValidator {
       this.shapeDistTraveled = shapeDistTraveled;
       this.stopSequence = stopSequence;
       this.prevCsvRowNumber = prevCsvRowNumber;
-      this.prevStopTimeDistTraveled = prevStopTimeDistTraveled;
+      this.prevShapeDistTraveled = prevShapeDistTraveled;
       this.prevStopSequence = prevStopSequence;
     }
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
@@ -133,7 +133,6 @@ public class NoticeFieldsTest {
             "prevShapeDistTraveled",
             "prevShapePtSequence",
             "prevStopSequence",
-            "prevStopTimeDistTraveled",
             "recordId",
             "recordSubId",
             "routeColor",


### PR DESCRIPTION
**Summary:**
decreasing_or_equal_stop_time_distance includes prevShapeDistTraveled, not prevStopTimeDistTraveled

Closes #1556  

**Expected behavior:** 
The name of the field in the report in now replaced from `prevStopTimeDistTraveled` to `prevShapeDistTraveled` in the report. 
Note: the logic was already implemented - it was `prevShapeDistTraveled` that was in the report but under the name `prevStopTimeDistTraveled`.

Using [this feed](https://storage.googleapis.com/storage/v1/b/mdb-latest/o/us-oregon-benton-area-transportation-gtfs-126.zip?alt=media), we get:
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/981bf2c9-a5dc-40ac-8dc5-d6005ff47bb4)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
