### PR TITLE
refactor: Replace CurrentDateTime with DateForValidation and use LocalDate

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/DateForValidation.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/DateForValidation.java
@@ -16,19 +16,19 @@
 
 package org.mobilitydata.gtfsvalidator.input;
 
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 
-/** Represents the current date and time */
-public class CurrentDateTime {
+/** The date to be used for validation rules. */
+public class DateForValidation {
 
-  private final ZonedDateTime now;
+  private final LocalDate date;
 
-  public CurrentDateTime(ZonedDateTime now) {
-    this.now = now;
+  public DateForValidation(LocalDate date) {
+    this.date = date;
   }
 
-  public ZonedDateTime getNow() {
-    return now;
+  public LocalDate getDate() {
+    return date;
   }
 
   @Override
@@ -36,14 +36,14 @@ public class CurrentDateTime {
     if (this == other) {
       return true;
     }
-    if (other instanceof CurrentDateTime) {
-      return this.now.equals(((CurrentDateTime) other).now);
+    if (other instanceof DateForValidation) {
+      return this.date.equals(((DateForValidation) other).date);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return now.hashCode();
+    return date.hashCode();
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/testing/LoadingHelper.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/testing/LoadingHelper.java
@@ -18,13 +18,13 @@ package org.mobilitydata.gtfsvalidator.testing;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.AnyTableLoader;
@@ -41,7 +41,7 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorProvider;
 public class LoadingHelper {
 
   private CountryCode countryCode = CountryCode.forStringOrUnknown("ca");
-  private ZonedDateTime currentTime = ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
+  private LocalDate dateForValidation = LocalDate.of(2021, 1, 1);
 
   private NoticeContainer noticeContainer = new NoticeContainer();
 
@@ -68,7 +68,7 @@ public class LoadingHelper {
     ValidationContext context =
         ValidationContext.builder()
             .setCountryCode(countryCode)
-            .setCurrentDateTime(new CurrentDateTime(currentTime))
+            .setDateForValidation(new DateForValidation(dateForValidation))
             .build();
     ValidatorProvider provider = new DefaultValidatorProvider(context, validatorLoader);
     return (Y) AnyTableLoader.load(tableDescriptor, provider, in, noticeContainer);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/testing/LoadingHelper.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/testing/LoadingHelper.java
@@ -19,7 +19,6 @@ import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidationContext.java
@@ -18,7 +18,7 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import com.google.common.collect.ImmutableMap;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 
 /**
  * A read-only context passed to particular validator objects. It gives information relevant for
@@ -57,8 +57,8 @@ public class ValidationContext {
    *
    * @return The time when validation started as @code{ZonedDateTime}
    */
-  public CurrentDateTime currentDateTime() {
-    return get(CurrentDateTime.class);
+  public DateForValidation dateForValidation() {
+    return get(DateForValidation.class);
   }
 
   /** Returns a member of the context with requested class. */
@@ -82,8 +82,8 @@ public class ValidationContext {
     }
 
     /** Sets the current time. */
-    public Builder setCurrentDateTime(CurrentDateTime currentDateTime) {
-      return set(CurrentDateTime.class, currentDateTime);
+    public Builder setDateForValidation(DateForValidation dateForValidation) {
+      return set(DateForValidation.class, dateForValidation);
     }
 
     /** Sets a member of the context with requested class. */

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/TestUtils.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/TestUtils.java
@@ -5,10 +5,10 @@ import static java.util.stream.Collectors.toList;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.validator.ValidationContext;
@@ -32,7 +32,7 @@ public class TestUtils {
   public static ValidationContext contextForTest() {
     return ValidationContext.builder()
         .setCountryCode(CountryCode.forStringOrUnknown("ca"))
-        .setCurrentDateTime(new CurrentDateTime(ZonedDateTime.now()))
+        .setDateForValidation(new DateForValidation(LocalDate.now()))
         .build();
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/DateForValidationTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/DateForValidationTest.java
@@ -18,26 +18,23 @@ package org.mobilitydata.gtfsvalidator.input;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import org.junit.Test;
 
-public class CurrentDateTimeTest {
-  private static final ZonedDateTime TEST_NOW =
-      ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
-  private static final ZonedDateTime OTHER_DATE_TIME =
-      ZonedDateTime.of(2021, 4, 1, 14, 30, 0, 0, ZoneOffset.UTC);
+public class DateForValidationTest {
+  private static final LocalDate TEST_NOW = LocalDate.of(2021, 1, 1);
+  private static final LocalDate OTHER_DATE_TIME = LocalDate.of(2021, 4, 1);
 
   @Test
-  public void getNow() {
-    CurrentDateTime currentDateTime = new CurrentDateTime(TEST_NOW);
-    assertThat(currentDateTime.getNow()).isEqualTo(TEST_NOW);
+  public void getDate() {
+    DateForValidation dateForValidation = new DateForValidation(TEST_NOW);
+    assertThat(dateForValidation.getDate()).isEqualTo(TEST_NOW);
   }
 
   @Test
   public void testEquals() {
-    assertThat(new CurrentDateTime(TEST_NOW).equals(new CurrentDateTime(TEST_NOW))).isTrue();
-    assertThat(new CurrentDateTime(TEST_NOW).equals(new CurrentDateTime(OTHER_DATE_TIME)))
+    assertThat(new DateForValidation(TEST_NOW).equals(new DateForValidation(TEST_NOW))).isTrue();
+    assertThat(new DateForValidation(TEST_NOW).equals(new DateForValidation(OTHER_DATE_TIME)))
         .isFalse();
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
@@ -78,16 +78,13 @@ public class GtfsInputTest {
   }
 
   @Test
-  public void urlInputHasNoSubfolderWithGtfsFile() throws IOException {
-    URL url = new URL(VALID_URL);
-    assertFalse(GtfsInput.hasSubfolderWithGtfsFile(url));
-  }
-
-  @Test
   public void createFromUrl_valid_success() throws IOException, URISyntaxException {
     try (GtfsInput underTest =
         GtfsInput.createFromUrl(
-            new URL(VALID_URL), tmpDir.getRoot().toPath().resolve("storage"), noticeContainer)) {
+            new URL(VALID_URL),
+            tmpDir.getRoot().toPath().resolve("storage"),
+            noticeContainer,
+            "1.0.1")) {
       assertThat(underTest instanceof GtfsZipFileInput);
     }
   }
@@ -100,13 +97,14 @@ public class GtfsInputTest {
             GtfsInput.createFromUrl(
                 new URL(INVALID_URL),
                 tmpDir.getRoot().toPath().resolve("storage"),
-                noticeContainer));
+                noticeContainer,
+                "1.0.1"));
   }
 
   @Test
   public void createFromUrlInMemory_valid_success() throws IOException, URISyntaxException {
     try (GtfsInput underTest =
-        GtfsInput.createFromUrlInMemory(new URL(VALID_URL), noticeContainer)) {
+        GtfsInput.createFromUrlInMemory(new URL(VALID_URL), noticeContainer, "1.0.1")) {
       assertThat(underTest instanceof GtfsZipFileInput);
     }
   }
@@ -115,6 +113,6 @@ public class GtfsInputTest {
   public void createFromUrlInMemory_invalid_throwsException() {
     assertThrows(
         IOException.class,
-        () -> GtfsInput.createFromUrlInMemory(new URL(INVALID_URL), noticeContainer));
+        () -> GtfsInput.createFromUrlInMemory(new URL(INVALID_URL), noticeContainer, "1.0.1"));
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestEntityValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestEntityValidator.java
@@ -18,18 +18,18 @@ package org.mobilitydata.gtfsvalidator.testgtfs;
 
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.validator.SingleEntityValidator;
 
 public class GtfsTestEntityValidator extends SingleEntityValidator<GtfsTestEntity> {
   private final CountryCode countryCode;
-  private final CurrentDateTime currentDateTime;
+  private final DateForValidation dateForValidation;
 
   @Inject
-  public GtfsTestEntityValidator(CountryCode countryCode, CurrentDateTime currentDateTime) {
+  public GtfsTestEntityValidator(CountryCode countryCode, DateForValidation dateForValidation) {
     this.countryCode = countryCode;
-    this.currentDateTime = currentDateTime;
+    this.dateForValidation = dateForValidation;
   }
 
   @Override
@@ -39,7 +39,7 @@ public class GtfsTestEntityValidator extends SingleEntityValidator<GtfsTestEntit
     return countryCode;
   }
 
-  public CurrentDateTime getCurrentDateTime() {
-    return currentDateTime;
+  public DateForValidation getDateForValidation() {
+    return dateForValidation;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestSingleFileValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/GtfsTestSingleFileValidator.java
@@ -18,7 +18,7 @@ package org.mobilitydata.gtfsvalidator.testgtfs;
 
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
 
@@ -26,14 +26,14 @@ public class GtfsTestSingleFileValidator extends FileValidator {
 
   private final GtfsTestTableContainer table;
   private final CountryCode countryCode;
-  private final CurrentDateTime currentDateTime;
+  private final DateForValidation dateForValidation;
 
   @Inject
   public GtfsTestSingleFileValidator(
-      GtfsTestTableContainer table, CountryCode countryCode, CurrentDateTime currentDateTime) {
+      GtfsTestTableContainer table, CountryCode countryCode, DateForValidation dateForValidation) {
     this.table = table;
     this.countryCode = countryCode;
-    this.currentDateTime = currentDateTime;
+    this.dateForValidation = dateForValidation;
   }
 
   @Override
@@ -47,7 +47,7 @@ public class GtfsTestSingleFileValidator extends FileValidator {
     return countryCode;
   }
 
-  public CurrentDateTime getCurrentDateTime() {
-    return currentDateTime;
+  public DateForValidation getDateForValidation() {
+    return dateForValidation;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/WholeFeedValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/WholeFeedValidator.java
@@ -18,7 +18,7 @@ package org.mobilitydata.gtfsvalidator.testgtfs;
 
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.validator.FileValidator;
@@ -27,14 +27,14 @@ public class WholeFeedValidator extends FileValidator {
   private final GtfsFeedContainer feedContainer;
   private final CountryCode countryCode;
 
-  private final CurrentDateTime currentDateTime;
+  private final DateForValidation dateForValidation;
 
   @Inject
   public WholeFeedValidator(
-      GtfsFeedContainer feedContainer, CountryCode countryCode, CurrentDateTime currentDateTime) {
+      GtfsFeedContainer feedContainer, CountryCode countryCode, DateForValidation dateForValidation) {
     this.feedContainer = feedContainer;
     this.countryCode = countryCode;
-    this.currentDateTime = currentDateTime;
+    this.dateForValidation = dateForValidation;
   }
 
   @Override
@@ -48,7 +48,7 @@ public class WholeFeedValidator extends FileValidator {
     return countryCode;
   }
 
-  public CurrentDateTime getCurrentDateTime() {
-    return currentDateTime;
+  public DateForValidation getDateForValidation() {
+    return dateForValidation;
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/WholeFeedValidator.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/testgtfs/WholeFeedValidator.java
@@ -31,7 +31,9 @@ public class WholeFeedValidator extends FileValidator {
 
   @Inject
   public WholeFeedValidator(
-      GtfsFeedContainer feedContainer, CountryCode countryCode, DateForValidation dateForValidation) {
+      GtfsFeedContainer feedContainer,
+      CountryCode countryCode,
+      DateForValidation dateForValidation) {
     this.feedContainer = feedContainer;
     this.countryCode = countryCode;
     this.dateForValidation = dateForValidation;

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidationContextTest.java
@@ -19,23 +19,22 @@ package org.mobilitydata.gtfsvalidator.validator;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 
 @RunWith(JUnit4.class)
 public final class ValidationContextTest {
   private static final CountryCode COUNTRY_CODE = CountryCode.forStringOrUnknown("AU");
-  private static final CurrentDateTime CURRENT_DATE_TIME =
-      new CurrentDateTime(ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC));
+  private static final DateForValidation CURRENT_DATE =
+      new DateForValidation(LocalDate.of(2021, 1, 1));
   private static final ValidationContext VALIDATION_CONTEXT =
       ValidationContext.builder()
           .setCountryCode(COUNTRY_CODE)
-          .setCurrentDateTime(CURRENT_DATE_TIME)
+          .setDateForValidation(CURRENT_DATE)
           .build();
 
   @Test
@@ -44,14 +43,14 @@ public final class ValidationContextTest {
   }
 
   @Test
-  public void get_currentDateTime_successful() {
-    assertThat(VALIDATION_CONTEXT.get(CurrentDateTime.class)).isEqualTo(CURRENT_DATE_TIME);
+  public void get_dateForValidation_successful() {
+    assertThat(VALIDATION_CONTEXT.get(DateForValidation.class)).isEqualTo(CURRENT_DATE);
   }
 
   @Test
   public void get_unsupported_throws() {
     assertThrows(
-        IllegalArgumentException.class, () -> VALIDATION_CONTEXT.get(ChildCurrentDateTime.class));
+        IllegalArgumentException.class, () -> VALIDATION_CONTEXT.get(ChildDateForValidation.class));
   }
 
   @Test
@@ -64,10 +63,10 @@ public final class ValidationContextTest {
         .isEqualTo(10);
   }
 
-  private static class ChildCurrentDateTime extends CurrentDateTime {
+  private static class ChildDateForValidation extends DateForValidation {
 
-    public ChildCurrentDateTime(ZonedDateTime now) {
-      super(now);
+    public ChildDateForValidation(LocalDate date) {
+      super(date);
     }
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoaderTest.java
@@ -19,11 +19,10 @@ package org.mobilitydata.gtfsvalidator.validator;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
 import org.mobilitydata.gtfsvalidator.testgtfs.GtfsTestEntityValidator;
@@ -34,12 +33,12 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorLoader.ValidatorWithDep
 
 public class ValidatorLoaderTest {
   private static final CountryCode COUNTRY_CODE = CountryCode.forStringOrUnknown("AU");
-  private static final CurrentDateTime CURRENT_DATE_TIME =
-      new CurrentDateTime(ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC));
+  private static final DateForValidation CURRENT_DATE =
+      new DateForValidation(LocalDate.of(2021, 1, 1));
   private static final ValidationContext VALIDATION_CONTEXT =
       ValidationContext.builder()
           .setCountryCode(COUNTRY_CODE)
-          .setCurrentDateTime(CURRENT_DATE_TIME)
+          .setDateForValidation(CURRENT_DATE)
           .build();
 
   @Test
@@ -51,7 +50,7 @@ public class ValidatorLoaderTest {
             .validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
-    assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
+    assertThat(validator.getDateForValidation()).isEqualTo(VALIDATION_CONTEXT.dateForValidation());
   }
 
   @Test
@@ -65,7 +64,7 @@ public class ValidatorLoaderTest {
                 .validator();
 
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
-    assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
+    assertThat(validator.getDateForValidation()).isEqualTo(VALIDATION_CONTEXT.dateForValidation());
     assertThat(validator.getStopTable()).isEqualTo(table);
   }
 
@@ -83,7 +82,7 @@ public class ValidatorLoaderTest {
 
     WholeFeedValidator validator = validatorWithStatus.validator();
     assertThat(validator.getCountryCode()).isEqualTo(VALIDATION_CONTEXT.countryCode());
-    assertThat(validator.getCurrentDateTime()).isEqualTo(VALIDATION_CONTEXT.currentDateTime());
+    assertThat(validator.getDateForValidation()).isEqualTo(VALIDATION_CONTEXT.dateForValidation());
     assertThat(validator.getFeedContainer()).isEqualTo(feedContainer);
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -102,7 +102,7 @@ public class ValidationRunner {
     GtfsFeedContainer feedContainer;
     GtfsInput gtfsInput = null;
     try {
-      gtfsInput = createGtfsInput(config);
+      gtfsInput = createGtfsInput(config, versionInfo.currentVersion().get());
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
       noticeContainer.addSystemError(new IOError(e));
@@ -305,11 +305,12 @@ public class ValidationRunner {
    * Creates a {@code GtfsInput}
    *
    * @param config used to retrieve information needed to the creation of the {@code GtfsInput}
+   * @param validatorVersion version of the validator
    * @return the {@code GtfsInput} generated after
    * @throws IOException in case of error while loading a file
    * @throws URISyntaxException in case of error in the {@code URL} syntax
    */
-  public static GtfsInput createGtfsInput(ValidationRunnerConfig config)
+  public static GtfsInput createGtfsInput(ValidationRunnerConfig config, String validatorVersion)
       throws IOException, URISyntaxException {
     URI source = config.gtfsSource();
     if (source.getScheme().equals("file")) {
@@ -317,12 +318,13 @@ public class ValidationRunner {
     }
 
     if (config.storageDirectory().isEmpty()) {
-      return GtfsInput.createFromUrlInMemory(source.toURL(), noticeContainer);
+      return GtfsInput.createFromUrlInMemory(source.toURL(), noticeContainer, validatorVersion);
     } else {
       return GtfsInput.createFromUrl(
           source.toURL(),
           config.storageDirectory().get().resolve(GTFS_ZIP_FILENAME),
-          noticeContainer);
+          noticeContainer,
+          validatorVersion);
     }
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -27,12 +27,11 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.time.Duration;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.IOError;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -121,7 +120,7 @@ public class ValidationRunner {
     ValidationContext validationContext =
         ValidationContext.builder()
             .setCountryCode(config.countryCode())
-            .setCurrentDateTime(new CurrentDateTime(ZonedDateTime.now(ZoneId.systemDefault())))
+            .setDateForValidation(new DateForValidation(LocalDate.now()))
             .build();
     try {
       feedContainer =

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidator.java
@@ -24,7 +24,7 @@ import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.UrlRef;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.*;
@@ -37,27 +37,26 @@ public class ExpiredCalendarValidator extends FileValidator {
 
   private final GtfsCalendarDateTableContainer calendarDateTable;
 
-  private final CurrentDateTime currentDateTime;
+  private final DateForValidation dateForValidation;
 
   @Inject
   ExpiredCalendarValidator(
-      CurrentDateTime currentDateTime,
+      DateForValidation dateForValidation,
       GtfsCalendarTableContainer calendarTable,
       GtfsCalendarDateTableContainer calendarDateTable) {
-    this.currentDateTime = currentDateTime;
+    this.dateForValidation = dateForValidation;
     this.calendarTable = calendarTable;
     this.calendarDateTable = calendarDateTable;
   }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    LocalDate now = currentDateTime.getNow().toLocalDate();
     final Map<String, SortedSet<LocalDate>> servicePeriodMap =
         CalendarUtil.servicePeriodToServiceDatesMap(
             CalendarUtil.buildServicePeriodMap(calendarTable, calendarDateTable));
     for (var serviceId : servicePeriodMap.keySet()) {
       SortedSet<LocalDate> serviceDates = servicePeriodMap.get(serviceId);
-      if (!serviceDates.isEmpty() && serviceDates.last().isBefore(now)) {
+      if (!serviceDates.isEmpty() && serviceDates.last().isBefore(dateForValidation.getDate())) {
         int csvRowNumber = calendarTable.byServiceId(serviceId).get().csvRowNumber();
         noticeContainer.addValidationNotice(new ExpiredCalendarNotice(csvRowNumber, serviceId));
       }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -18,13 +18,12 @@ package org.mobilitydata.gtfsvalidator.validator;
 import static org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef.BEST_PRACTICES_DATASET_PUBLISHING;
 import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
 
-import java.time.LocalDate;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRefs;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -46,20 +45,19 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 @GtfsValidator
 public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedInfo> {
 
-  private final CurrentDateTime currentDateTime;
+  private final DateForValidation dateForValidation;
 
   @Inject
-  FeedExpirationDateValidator(CurrentDateTime currentDateTime) {
-    this.currentDateTime = currentDateTime;
+  FeedExpirationDateValidator(DateForValidation dateForValidation) {
+    this.dateForValidation = dateForValidation;
   }
 
   @Override
   public void validate(GtfsFeedInfo entity, NoticeContainer noticeContainer) {
     if (entity.hasFeedEndDate()) {
-      LocalDate now = currentDateTime.getNow().toLocalDate();
-      GtfsDate currentDate = GtfsDate.fromLocalDate(now);
-      GtfsDate currentDatePlusSevenDays = GtfsDate.fromLocalDate(now.plusDays(7));
-      GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(now.plusDays(30));
+      GtfsDate currentDate = GtfsDate.fromLocalDate(dateForValidation.getDate());
+      GtfsDate currentDatePlusSevenDays = GtfsDate.fromLocalDate(dateForValidation.getDate().plusDays(7));
+      GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(dateForValidation.getDate().plusDays(30));
       if (entity.feedEndDate().compareTo(currentDatePlusSevenDays) <= 0) {
         noticeContainer.addValidationNotice(
             new FeedExpirationDate7DaysNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -56,8 +56,10 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
   public void validate(GtfsFeedInfo entity, NoticeContainer noticeContainer) {
     if (entity.hasFeedEndDate()) {
       GtfsDate currentDate = GtfsDate.fromLocalDate(dateForValidation.getDate());
-      GtfsDate currentDatePlusSevenDays = GtfsDate.fromLocalDate(dateForValidation.getDate().plusDays(7));
-      GtfsDate currentDatePlusThirtyDays = GtfsDate.fromLocalDate(dateForValidation.getDate().plusDays(30));
+      GtfsDate currentDatePlusSevenDays =
+          GtfsDate.fromLocalDate(dateForValidation.getDate().plusDays(7));
+      GtfsDate currentDatePlusThirtyDays =
+          GtfsDate.fromLocalDate(dateForValidation.getDate().plusDays(30));
       if (entity.feedEndDate().compareTo(currentDatePlusSevenDays) <= 0) {
         noticeContainer.addValidationNotice(
             new FeedExpirationDate7DaysNotice(

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadataTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadataTest.java
@@ -7,14 +7,13 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.input.GtfsInput;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.*;
@@ -27,7 +26,7 @@ public class FeedMetadataTest {
   ValidationContext validationContext =
       ValidationContext.builder()
           .setCountryCode(CountryCode.forStringOrUnknown("CA"))
-          .setCurrentDateTime(new CurrentDateTime(ZonedDateTime.now(ZoneId.systemDefault())))
+          .setDateForValidation(new DateForValidation(LocalDate.now()))
           .build();
   ValidatorLoader validatorLoader;
   File rootDir;

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
@@ -30,7 +30,8 @@ public class ValidationRunnerTest {
 
     // We are testing path parsing here only. We expect a FileNotFoundException but NOT a
     // InvalidPathException. This should catch issues such as #1158.
-    assertThrows(FileNotFoundException.class, () -> ValidationRunner.createGtfsInput(config));
+    assertThrows(
+        FileNotFoundException.class, () -> ValidationRunner.createGtfsInput(config, "1.1.0"));
   }
 
   @Test
@@ -39,6 +40,7 @@ public class ValidationRunnerTest {
 
     // We are testing path parsing here only. We expect a FileNotFoundException but NOT a
     // InvalidPathException. This should catch issues such as #1158.
-    assertThrows(FileNotFoundException.class, () -> ValidationRunner.createGtfsInput(config));
+    assertThrows(
+        FileNotFoundException.class, () -> ValidationRunner.createGtfsInput(config, "1.1.0"));
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidatorTest.java
@@ -7,14 +7,12 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.*;
@@ -24,20 +22,19 @@ import org.mobilitydata.gtfsvalidator.util.CalendarUtilTest;
 
 @RunWith(JUnit4.class)
 public class DateTripsValidatorTest {
-  private static final ZonedDateTime TEST_NOW =
-      ZonedDateTime.of(2022, 12, 1, 8, 30, 0, 0, ZoneOffset.UTC);
+  private static final LocalDate TEST_NOW = LocalDate.of(2022, 12, 1);
 
   @Test
   public void serviceWindowEndingBefore7DaysFromNowShouldGenerateNotice() {
 
-    var serviceWindowStart = TEST_NOW.toLocalDate();
-    var serviceWindowEnd = TEST_NOW.toLocalDate().plusDays(6);
+    var serviceWindowStart = TEST_NOW;
+    var serviceWindowEnd = TEST_NOW.plusDays(6);
 
     var notices = validateSimpleServiceWindow(serviceWindowStart, serviceWindowEnd);
     assertThat(notices)
         .containsExactly(
             new TripCoverageNotActiveForNext7DaysNotice(
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
+                GtfsDate.fromLocalDate(TEST_NOW),
                 GtfsDate.fromLocalDate(serviceWindowStart),
                 GtfsDate.fromLocalDate(serviceWindowEnd)));
   }
@@ -45,13 +42,13 @@ public class DateTripsValidatorTest {
   @Test
   public void serviceWindowStartingAfterNowShouldGenerateNotice() {
 
-    var serviceWindowStart = TEST_NOW.toLocalDate().plusDays(1);
-    var serviceWindowEnd = TEST_NOW.toLocalDate().plusDays(7);
+    var serviceWindowStart = TEST_NOW.plusDays(1);
+    var serviceWindowEnd = TEST_NOW.plusDays(7);
     var notices = validateSimpleServiceWindow(serviceWindowStart, serviceWindowEnd);
     assertThat(notices)
         .containsExactly(
             new TripCoverageNotActiveForNext7DaysNotice(
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
+                GtfsDate.fromLocalDate(TEST_NOW),
                 GtfsDate.fromLocalDate(serviceWindowStart),
                 GtfsDate.fromLocalDate(serviceWindowEnd)));
   }
@@ -59,8 +56,8 @@ public class DateTripsValidatorTest {
   @Test
   public void serviceWindowStartingNowAndEndingIn7DaysShouldNotGenerateNotice() {
 
-    var serviceWindowStart = TEST_NOW.toLocalDate();
-    var serviceWindowEnd = TEST_NOW.toLocalDate().plusDays(7);
+    var serviceWindowStart = TEST_NOW;
+    var serviceWindowEnd = TEST_NOW.plusDays(7);
     var notices = validateSimpleServiceWindow(serviceWindowStart, serviceWindowEnd);
     assertThat(notices).isEmpty();
   }
@@ -68,8 +65,8 @@ public class DateTripsValidatorTest {
   @Test
   public void serviceWindowStartingBeforeNowAndEndingAfter7DaysShouldNotGenerateNotice() {
 
-    var serviceWindowStart = TEST_NOW.toLocalDate().minusDays(1);
-    var serviceWindowEnd = TEST_NOW.toLocalDate().plusDays(8);
+    var serviceWindowStart = TEST_NOW.minusDays(1);
+    var serviceWindowEnd = TEST_NOW.plusDays(8);
     var notices = validateSimpleServiceWindow(serviceWindowStart, serviceWindowEnd);
     assertThat(notices).isEmpty();
   }
@@ -94,7 +91,7 @@ public class DateTripsValidatorTest {
 
     var validator =
         new DateTripsValidator(
-            new CurrentDateTime(TEST_NOW), dateTable, calendarTable, tripContainer, frequencyTable);
+            new DateForValidation(TEST_NOW), dateTable, calendarTable, tripContainer, frequencyTable);
 
     validator.validate(noticeContainer);
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/DateTripsValidatorTest.java
@@ -91,7 +91,11 @@ public class DateTripsValidatorTest {
 
     var validator =
         new DateTripsValidator(
-            new DateForValidation(TEST_NOW), dateTable, calendarTable, tripContainer, frequencyTable);
+            new DateForValidation(TEST_NOW),
+            dateTable,
+            calendarTable,
+            tripContainer,
+            frequencyTable);
 
     validator.validate(noticeContainer);
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
@@ -21,14 +21,13 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.time.DayOfWeek;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Set;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.*;
 import org.mobilitydata.gtfsvalidator.table.GtfsTableContainer.TableStatus;
@@ -44,8 +43,7 @@ public class ExpiredCalendarValidatorTest {
           DayOfWeek.WEDNESDAY,
           DayOfWeek.THURSDAY,
           DayOfWeek.FRIDAY);
-  private static final ZonedDateTime TEST_NOW =
-      ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
+  private static final LocalDate TEST_NOW = LocalDate.of(2021, 1, 1);
 
   @Test
   public void calendarEndDateOneDayAgoShouldGenerateNotice() {
@@ -56,8 +54,8 @@ public class ExpiredCalendarValidatorTest {
             new GtfsCalendar.Builder()
                 .setCsvRowNumber(2)
                 .setServiceId("WEEK")
-                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(1)))
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(1)))
                 .setMonday(1)
                 .setTuesday(1)
                 .setWednesday(1)
@@ -68,7 +66,7 @@ public class ExpiredCalendarValidatorTest {
         GtfsCalendarTableContainer.forEntities(calendars, container);
 
     var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
-    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+    new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices())
         .containsExactly(new ExpiredCalendarValidator.ExpiredCalendarNotice(2, "WEEK"));
@@ -83,8 +81,8 @@ public class ExpiredCalendarValidatorTest {
             new GtfsCalendar.Builder()
                 .setCsvRowNumber(2)
                 .setServiceId("WEEK")
-                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW))
                 .setMonday(1)
                 .setTuesday(1)
                 .setWednesday(1)
@@ -95,7 +93,7 @@ public class ExpiredCalendarValidatorTest {
         GtfsCalendarTableContainer.forEntities(calendars, container);
 
     var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
-    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+    new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
   }
@@ -109,8 +107,8 @@ public class ExpiredCalendarValidatorTest {
             new GtfsCalendar.Builder()
                 .setCsvRowNumber(2)
                 .setServiceId("WEEK")
-                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(1)))
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.plusDays(1)))
                 .setMonday(1)
                 .setTuesday(1)
                 .setWednesday(1)
@@ -121,7 +119,7 @@ public class ExpiredCalendarValidatorTest {
         GtfsCalendarTableContainer.forEntities(calendars, container);
 
     var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
-    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+    new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
   }
@@ -135,8 +133,8 @@ public class ExpiredCalendarValidatorTest {
             new GtfsCalendar.Builder()
                 .setCsvRowNumber(2)
                 .setServiceId("WEEK")
-                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(1)))
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(1)))
                 .setMonday(1)
                 .setTuesday(1)
                 .setWednesday(1)
@@ -152,11 +150,11 @@ public class ExpiredCalendarValidatorTest {
                 new GtfsCalendarDate.Builder()
                     .setCsvRowNumber(2)
                     .setServiceId("WEEK")
-                    .setDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                    .setDate(GtfsDate.fromLocalDate(TEST_NOW))
                     .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_ADDED)
                     .build()),
             container);
-    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+    new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
   }
@@ -170,8 +168,8 @@ public class ExpiredCalendarValidatorTest {
             new GtfsCalendar.Builder()
                 .setCsvRowNumber(2)
                 .setServiceId("WEEK")
-                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW))
                 .setMonday(1)
                 .setTuesday(1)
                 .setWednesday(1)
@@ -187,11 +185,11 @@ public class ExpiredCalendarValidatorTest {
                 new GtfsCalendarDate.Builder()
                     .setCsvRowNumber(2)
                     .setServiceId("WEEK")
-                    .setDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                    .setDate(GtfsDate.fromLocalDate(TEST_NOW))
                     .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_REMOVED)
                     .build()),
             container);
-    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+    new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices())
         .containsExactly(new ExpiredCalendarValidator.ExpiredCalendarNotice(2, "WEEK"));
@@ -206,14 +204,14 @@ public class ExpiredCalendarValidatorTest {
             new GtfsCalendar.Builder()
                 .setCsvRowNumber(2)
                 .setServiceId("WEEK")
-                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().minusDays(7)))
-                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()))
+                .setStartDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                .setEndDate(GtfsDate.fromLocalDate(TEST_NOW))
                 .build());
 
     GtfsCalendarTableContainer calendarTable =
         GtfsCalendarTableContainer.forEntities(calendars, container);
     var dateTable = GtfsCalendarDateTableContainer.forStatus(TableStatus.EMPTY_FILE);
-    new ExpiredCalendarValidator(new CurrentDateTime(TEST_NOW), calendarTable, dateTable)
+    new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, dateTable)
         .validate(container);
     assertThat(container.getValidationNotices()).isEmpty();
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -51,9 +51,7 @@ public class FeedExpirationDateValidatorTest {
 
   @Test
   public void feedExpiringInFiveDaysFromNowShouldGenerateNotice() {
-    assertThat(
-            validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(3)))))
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(3)))))
         .containsExactly(
             new FeedExpirationDate7DaysNotice(
                 1,
@@ -64,9 +62,7 @@ public class FeedExpirationDateValidatorTest {
 
   @Test
   public void feedExpiringInSevenDaysFromNowShouldGenerateNotice() {
-    assertThat(
-            validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(7)))))
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(7)))))
         .containsExactly(
             new FeedExpirationDate7DaysNotice(
                 1,
@@ -77,9 +73,7 @@ public class FeedExpirationDateValidatorTest {
 
   @Test
   public void feedExpiring7to30DaysFromNowShouldGenerateNotice() {
-    assertThat(
-            validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(23)))))
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(23)))))
         .containsExactly(
             new FeedExpirationDate30DaysNotice(
                 1,
@@ -90,9 +84,7 @@ public class FeedExpirationDateValidatorTest {
 
   @Test
   public void feedExpiring30DaysFromNowShouldGenerateNotice() {
-    assertThat(
-            validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)))))
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)))))
         .containsExactly(
             new FeedExpirationDate30DaysNotice(
                 1,
@@ -103,9 +95,7 @@ public class FeedExpirationDateValidatorTest {
 
   @Test
   public void feedExpiringInMoreThan30DaysFromNowShouldNotGenerateNotice() {
-    assertThat(
-            validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(45)))))
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(45)))))
         .isEmpty();
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -18,12 +18,11 @@ package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Locale;
 import org.junit.Test;
-import org.mobilitydata.gtfsvalidator.input.CurrentDateTime;
+import org.mobilitydata.gtfsvalidator.input.DateForValidation;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedInfo;
@@ -32,12 +31,11 @@ import org.mobilitydata.gtfsvalidator.validator.FeedExpirationDateValidator.Feed
 import org.mobilitydata.gtfsvalidator.validator.FeedExpirationDateValidator.FeedExpirationDate7DaysNotice;
 
 public class FeedExpirationDateValidatorTest {
-  private static final ZonedDateTime TEST_NOW =
-      ZonedDateTime.of(2021, 1, 1, 14, 30, 0, 0, ZoneOffset.UTC);
+  private static final LocalDate TEST_NOW = LocalDate.of(2021, 1, 1);
 
   private List<ValidationNotice> validateFeedInfo(GtfsFeedInfo feedInfo) {
     NoticeContainer container = new NoticeContainer();
-    new FeedExpirationDateValidator(new CurrentDateTime(TEST_NOW)).validate(feedInfo, container);
+    new FeedExpirationDateValidator(new DateForValidation(TEST_NOW)).validate(feedInfo, container);
     return container.getValidationNotices();
   }
 
@@ -55,59 +53,59 @@ public class FeedExpirationDateValidatorTest {
   public void feedExpiringInFiveDaysFromNowShouldGenerateNotice() {
     assertThat(
             validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(3)))))
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(3)))))
         .containsExactly(
             new FeedExpirationDate7DaysNotice(
                 1,
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(3)),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7))));
+                GtfsDate.fromLocalDate(TEST_NOW),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(3)),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(7))));
   }
 
   @Test
   public void feedExpiringInSevenDaysFromNowShouldGenerateNotice() {
     assertThat(
             validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7)))))
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(7)))))
         .containsExactly(
             new FeedExpirationDate7DaysNotice(
                 1,
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7)),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(7))));
+                GtfsDate.fromLocalDate(TEST_NOW),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(7)),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(7))));
   }
 
   @Test
   public void feedExpiring7to30DaysFromNowShouldGenerateNotice() {
     assertThat(
             validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(23)))))
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(23)))))
         .containsExactly(
             new FeedExpirationDate30DaysNotice(
                 1,
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(23)),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30))));
+                GtfsDate.fromLocalDate(TEST_NOW),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(23)),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(30))));
   }
 
   @Test
   public void feedExpiring30DaysFromNowShouldGenerateNotice() {
     assertThat(
             validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30)))))
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)))))
         .containsExactly(
             new FeedExpirationDate30DaysNotice(
                 1,
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate()),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30)),
-                GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(30))));
+                GtfsDate.fromLocalDate(TEST_NOW),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(30))));
   }
 
   @Test
   public void feedExpiringInMoreThan30DaysFromNowShouldNotGenerateNotice() {
     assertThat(
             validateFeedInfo(
-                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.toLocalDate().plusDays(45)))))
+                createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(45)))))
         .isEmpty();
   }
 }


### PR DESCRIPTION
**Summary:**

Preparation to make PR #1628 for issue #1292 clearer.

Several rules compare dates in the feed to a reference date, which is usually today. The object that stores the date is called CurrentDateTime and it wraps a ZonedDateTime object. But only the date is ever used (not the time), and the date can be overridden in tests to use specific dates other than today.

This refactor renames the object DateForValidation and wraps a LocalDate object instead. This simplifies the code in several places and will allow PR #1628 to be clearer.

**Expected behavior:** 

No change in behavior. Internally a LocalDate will be used instead of a ZonedDateTime.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [X ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [X ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
