### PR TITLE
feat: removed route name and agency information components

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
@@ -142,9 +142,7 @@ public class FeedMetadata {
   }
 
   private void loadSpecFeaturesBasedOnFieldPresence(GtfsFeedContainer feedContainer) {
-    loadRouteNamesComponent(feedContainer);
     loadRouteColorsComponent(feedContainer);
-    loadAgencyInformationComponent(feedContainer);
     loadHeadsignsComponent(feedContainer);
     loadWheelchairAccessibilityComponent(feedContainer);
     loadTTSComponent(feedContainer);
@@ -295,17 +293,6 @@ public class FeedMetadata {
                 List.of((Function<GtfsStopTime, Boolean>) GtfsStopTime::hasStopHeadsign)));
   }
 
-  private void loadAgencyInformationComponent(GtfsFeedContainer feedContainer) {
-    specFeatures.put(
-        "Agency Information",
-        hasAtLeastOneRecordForFields(
-            feedContainer,
-            GtfsAgency.FILENAME,
-            List.of(
-                GtfsAgency::hasAgencyEmail,
-                (Function<GtfsAgency, Boolean>) GtfsAgency::hasAgencyPhone)));
-  }
-
   private void loadRouteColorsComponent(GtfsFeedContainer feedContainer) {
     specFeatures.put(
         "Route Colors",
@@ -317,17 +304,6 @@ public class FeedMetadata {
                 feedContainer,
                 GtfsRoute.FILENAME,
                 List.of((Function<GtfsRoute, Boolean>) GtfsRoute::hasRouteTextColor)));
-  }
-
-  private void loadRouteNamesComponent(GtfsFeedContainer feedContainer) {
-    specFeatures.put(
-        "Route Names",
-        hasAtLeastOneRecordForFields(
-            feedContainer,
-            GtfsRoute.FILENAME,
-            List.of(
-                GtfsRoute::hasRouteShortName,
-                (Function<GtfsRoute, Boolean>) GtfsRoute::hasRouteLongName)));
   }
 
   private void loadZoneBasedComponent(GtfsFeedContainer feedContainer) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadataTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadataTest.java
@@ -69,58 +69,6 @@ public class FeedMetadataTest {
   }
 
   @Test
-  public void containsRouteNamesComponentTest() throws IOException, InterruptedException {
-    String routesContent =
-        "route_id,agency_id,route_short_name,route_long_name,route_type\n"
-            + "1,1,Short Name,Long Name,1\n"
-            + "2,1,,,1\n";
-    createDataFile("routes.txt", routesContent);
-    validateSpecFeature(
-        "Route Names",
-        true,
-        ImmutableList.of(GtfsRouteTableDescriptor.class, GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void omitsRouteNamesComponentTest1() throws IOException, InterruptedException {
-    String routesContent =
-        "route_id,agency_id,route_short_name,route_long_name,route_type\n"
-            + "1,1,,,1\n"
-            + "2,1,,,1\n";
-    createDataFile("routes.txt", routesContent);
-    validateSpecFeature(
-        "Route Names",
-        false,
-        ImmutableList.of(GtfsRouteTableDescriptor.class, GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void omitsRouteNamesComponentTest2() throws IOException, InterruptedException {
-    String routesContent =
-        "route_id,agency_id,route_short_name,route_long_name,route_type\n"
-            + "1,1,Short Name,,1\n"
-            + "2,1,,,1\n";
-    createDataFile("routes.txt", routesContent);
-    validateSpecFeature(
-        "Route Names",
-        false,
-        ImmutableList.of(GtfsRouteTableDescriptor.class, GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void omitsRouteNamesComponentTest3() throws IOException, InterruptedException {
-    String routesContent =
-        "route_id,agency_id,route_short_name,route_long_name,route_type\n"
-            + "1,1,,Long Name,1\n"
-            + "2,1,,,1\n";
-    createDataFile("routes.txt", routesContent);
-    validateSpecFeature(
-        "Route Names",
-        false,
-        ImmutableList.of(GtfsRouteTableDescriptor.class, GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
   /**
    * This method is to test when both route_color and route_text_color are present in routes.txt,
    * and they each have two records
@@ -248,10 +196,6 @@ public class FeedMetadataTest {
         "Pathways (basic)",
         false,
         ImmutableList.of(GtfsPathwayTableDescriptor.class, GtfsAgencyTableDescriptor.class));
-    validateSpecFeature(
-        "Route Names",
-        false,
-        ImmutableList.of(GtfsRouteTableDescriptor.class, GtfsAgencyTableDescriptor.class));
     validateSpecFeature(
         "Shapes",
         false,
@@ -421,48 +365,6 @@ public class FeedMetadataTest {
         "Zone-Based Fares",
         false,
         ImmutableList.of(GtfsStopAreaTableDescriptor.class, GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void containsAgencyInformationComponent() throws IOException, InterruptedException {
-    tmpDir.delete();
-    rootDir = tmpDir.newFolder("data");
-    String agencyContent =
-        "agency_id, agency_name, agency_url, agency_timezone, agency_phone, agency_email\n"
-            + "1, name, https://dummy.ca, America/Los_Angeles, 1234567890, dummy@dummy.ca\n";
-    createDataFile(GtfsAgency.FILENAME, agencyContent);
-    validateSpecFeature(
-        "Agency Information", true, ImmutableList.of(GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void omitsAgencyInformationComponent1() throws IOException, InterruptedException {
-    tmpDir.delete();
-    rootDir = tmpDir.newFolder("data");
-    String agencyContent =
-        "agency_id, agency_name, agency_url, agency_timezone, agency_phone, agency_email\n"
-            + "1, name, https://dummy.ca, America/Los_Angeles, , dummy@dummy.ca\n";
-    createDataFile(GtfsAgency.FILENAME, agencyContent);
-    validateSpecFeature(
-        "Agency Information", false, ImmutableList.of(GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void omitsAgencyInformationComponent2() throws IOException, InterruptedException {
-    tmpDir.delete();
-    rootDir = tmpDir.newFolder("data");
-    String agencyContent =
-        "agency_id, agency_name, agency_url, agency_timezone, agency_phone, agency_email\n"
-            + "1, name, https://dummy.ca, America/Los_Angeles, 1234567890, \n";
-    createDataFile(GtfsAgency.FILENAME, agencyContent);
-    validateSpecFeature(
-        "Agency Information", false, ImmutableList.of(GtfsAgencyTableDescriptor.class));
-  }
-
-  @Test
-  public void omitsAgencyInformationComponent3() throws IOException, InterruptedException {
-    validateSpecFeature(
-        "Agency Information", false, ImmutableList.of(GtfsAgencyTableDescriptor.class));
   }
 
   @Test


### PR DESCRIPTION
**Summary:**
Part 2 of #1640
Remove route name and agency information from GTFS components

**Expected behavior:** 
![image](https://github.com/MobilityData/gtfs-validator/assets/5789435/784c2256-6f23-4228-ac10-2887746ed36c)
![image](https://github.com/MobilityData/gtfs-validator/assets/5789435/a9a513f1-b603-40d9-bb82-44dde50654a3)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
