### PR TITLE
Fix: replace GitRunners with GitHub's own runners

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -133,8 +133,7 @@ jobs:
     needs: [ fetch-urls, pack-master, pack-snapshot ]
     # We use machines with more memory to run validation, as large feeds
     # can consume too much heap for default machine instances (see #1304).
-    runs-on: gitrunners-ubuntu-2204-x64-4vcpu
-    ## ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-4-cores
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -63,8 +63,7 @@ jobs:
           name: gtfs-validator-snapshot
           path: cli/build/libs/gtfs-validator-*-cli.jar
   fetch-urls:
-    runs-on: gitrunners-ubuntu-2204-x64-4vcpu
-    ## ubuntu-latest-4-cores
+    runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v3


### PR DESCRIPTION
**Summary:**

GitRunners are closing up shop, we need to revert back to the built-in runners offered by GitHub.

Email received from GitRunners on Feb 2, 2024:

```
Hello everyone,

This is a sad mail to write for me but it is actually better to face
reality and go on.
It has been one year we launched GitRunners and many things have
happened during this time, unfortunately none of them were good enough
to keep the service continuing operating.

We have tried hard since the start to acquire customers but we
struggled finding a key to convince people to switch to our service:
cost is not a major reason to switch for many companies and apparently
neither is faster hardware. The current growth rate is too low and it
is hard to justify focusing on the product to improve the service and
provide more features. In the meantime other competitors jumped in
this already small market and it seems like nobody is finding a good
value proposition apart from cutting down prices which I think is bad
from a business perspective.

The service will stop operating as soon as possible, we'll just wait
for the users to switch back to Github or to any of the other
competitors in the market. As a deadline at the end of the month our
Github App will be terminated and the last invoice will be issued.

I'll be happy to answer any questions in the next few days.

Maurizio
https://gitrunners.com/
```