### PR TITLE
feat: display ERRORS first on validator documentation

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/ReportSummary.java
@@ -42,7 +42,7 @@ public class ReportSummary {
             .collect(
                 Collectors.groupingBy(
                     NoticeView::getSeverityLevel,
-                    () -> new TreeMap<>(Comparator.comparingInt(SeverityLevel::getOrder)),
+                    () -> new TreeMap<>(Comparator.reverseOrder()),
                     Collectors.groupingBy(NoticeView::getCode, TreeMap::new, Collectors.toList())));
     this.versionInfo = versionInfo;
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/ReportSummary.java
@@ -16,10 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.report.model;
 
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
@@ -45,7 +42,7 @@ public class ReportSummary {
             .collect(
                 Collectors.groupingBy(
                     NoticeView::getSeverityLevel,
-                    LinkedHashMap::new,
+                    () -> new TreeMap<>(Comparator.comparingInt(SeverityLevel::getOrder)),
                     Collectors.groupingBy(NoticeView::getCode, TreeMap::new, Collectors.toList())));
     this.versionInfo = versionInfo;
   }

--- a/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/SeverityLevel.java
+++ b/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/SeverityLevel.java
@@ -39,17 +39,4 @@ public enum SeverityLevel {
    * (https://tools.ietf.org/html/rfc2119) to interpret the language in the GTFS spec.
    */
   ERROR;
-
-  public static int getOrder(SeverityLevel severityLevel) {
-    switch (severityLevel) {
-      case INFO:
-        return 2;
-      case WARNING:
-        return 1;
-      case ERROR:
-        return 0;
-      default:
-        throw new IllegalStateException("Unexpected value: " + severityLevel);
-    }
-  }
 }

--- a/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/SeverityLevel.java
+++ b/model/src/main/java/org/mobilitydata/gtfsvalidator/notice/SeverityLevel.java
@@ -38,5 +38,18 @@ public enum SeverityLevel {
    * (e.g., using the language "must"). The validator uses RFC2119
    * (https://tools.ietf.org/html/rfc2119) to interpret the language in the GTFS spec.
    */
-  ERROR
+  ERROR;
+
+  public static int getOrder(SeverityLevel severityLevel) {
+    switch (severityLevel) {
+      case INFO:
+        return 2;
+      case WARNING:
+        return 1;
+      case ERROR:
+        return 0;
+      default:
+        throw new IllegalStateException("Unexpected value: " + severityLevel);
+    }
+  }
 }

--- a/web/client/src/routes/rules.html/+page.svelte
+++ b/web/client/src/routes/rules.html/+page.svelte
@@ -1,13 +1,19 @@
 <script>
   import { marked } from 'marked';
   import { page } from '$app/stores';
-  import _ from 'lodash';
+  import _, {fromPairs} from 'lodash';
 
   import SectionRefLink from './SectionRefLink.svelte';
 
   const rules = $page.data.rules;
 
-  $: categories = _.groupBy(rules, 'severityLevel');
+  // Group rules by severity level
+  $: categories = _.chain(rules)
+    .groupBy('severityLevel')
+    .toPairs()
+    .sortBy(([severityLevel]) => ['ERROR', 'WARNING', 'INFO'].indexOf(severityLevel))
+    .fromPairs()
+    .value();
 
   /** @param {string} filename */
   function getSpecRef(filename) {


### PR DESCRIPTION
**Summary:**
Closes #1605 

**Expected behavior:** 
`ERROR` notices are displayed first, followed by `WARNING` and then `INFO` in both the documentation and validation report.

<img width="1252" alt="Screenshot 2024-02-09 at 2 33 56 PM" src="https://github.com/MobilityData/gtfs-validator/assets/60586858/a533b0e5-8d4c-462c-83be-2f7e54020ea7">

![Screenshot 2024-02-27 at 1 34 49 PM](https://github.com/MobilityData/gtfs-validator/assets/60586858/f32a5bcf-cbf9-4029-b319-2eb10aacb23e)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
