### PR TITLE
feat: threshold of 1.11m on `equal_shape_distance_diff_coordinates`

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -72,8 +72,12 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
         }
         // equal shape_dist_traveled and different coordinates
         if (!(curr.shapePtLon() == prev.shapePtLon() && curr.shapePtLat() == prev.shapePtLat())) {
-          noticeContainer.addValidationNotice(
-              new EqualShapeDistanceDiffCoordinatesNotice(prev, curr));
+          double distanceBetweenShapePoints =
+              getDistanceMeters(curr.shapePtLatLon(), prev.shapePtLatLon());
+          if (distanceBetweenShapePoints > 1.11) {
+            noticeContainer.addValidationNotice(
+                new EqualShapeDistanceDiffCoordinatesNotice(prev, curr));
+          }
         } else {
           // equal shape_dist_traveled and same coordinates
           noticeContainer.addValidationNotice(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -41,13 +41,14 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopSchema;
  *   <li>{@link DecreasingShapeDistanceNotice}
  *   <li>{@link EqualShapeDistanceSameCoordinatesNotice}
  *   <li>{@link EqualShapeDistanceDiffCoordinatesNotice}
+ *   <li>{@link EqualShapeDistanceDiffCoordinatesWarningNotice}
  * </ul>
  */
 @GtfsValidator
 public class ShapeIncreasingDistanceValidator extends FileValidator {
 
   private final GtfsShapeTableContainer table;
-  private final double distanceThreshold = 1.11;
+  private final double DISTANCE_THRESHOLD = 1.11;
 
   @Inject
   ShapeIncreasingDistanceValidator(GtfsShapeTableContainer table) {
@@ -75,7 +76,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
         if (!(curr.shapePtLon() == prev.shapePtLon() && curr.shapePtLat() == prev.shapePtLat())) {
           double distanceBetweenShapePoints =
               getDistanceMeters(curr.shapePtLatLon(), prev.shapePtLatLon());
-          if (distanceBetweenShapePoints > distanceThreshold) {
+          if (distanceBetweenShapePoints >= DISTANCE_THRESHOLD) {
             noticeContainer.addValidationNotice(
                 new EqualShapeDistanceDiffCoordinatesNotice(prev, curr));
           } else if (distanceBetweenShapePoints > 0) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -242,8 +242,8 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
    * `shapes.txt` and the distance between the two points is less than 1.11m.
    *
    * <p>When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase
-   * along a shape. Two consecutive points with equal values for `shape_dist_traveled` and different
-   * coordinates indicate an error.
+   * along a shape. Two consecutive points with equal values for `shape_dist_traveled` and small
+   * difference of coordinates (less than 1.11 m distance) result in a warning.
    */
   @GtfsValidationNotice(
       severity = WARNING,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -78,7 +78,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
           if (distanceBetweenShapePoints > distanceThreshold) {
             noticeContainer.addValidationNotice(
                 new EqualShapeDistanceDiffCoordinatesNotice(prev, curr));
-          } else {
+          } else if (distanceBetweenShapePoints > 0) {
             noticeContainer.addValidationNotice(
                 new EqualShapeDistanceDiffCoordinatesWarningNotice(prev, curr));
           }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -41,7 +41,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopSchema;
  *   <li>{@link DecreasingShapeDistanceNotice}
  *   <li>{@link EqualShapeDistanceSameCoordinatesNotice}
  *   <li>{@link EqualShapeDistanceDiffCoordinatesNotice}
- *   <li>{@link EqualShapeDistanceDiffCoordinatesWarningNotice}
+ *   <li>{@link EqualShapeDistanceDiffCoordinatesDistanceBelowThresholdNotice}
  * </ul>
  */
 @GtfsValidator
@@ -81,7 +81,7 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
                 new EqualShapeDistanceDiffCoordinatesNotice(prev, curr));
           } else if (distanceBetweenShapePoints > 0) {
             noticeContainer.addValidationNotice(
-                new EqualShapeDistanceDiffCoordinatesWarningNotice(prev, curr));
+                new EqualShapeDistanceDiffCoordinatesDistanceBelowThresholdNotice(prev, curr));
           }
         } else {
           // equal shape_dist_traveled and same coordinates
@@ -246,7 +246,8 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
   @GtfsValidationNotice(
       severity = WARNING,
       files = @FileRefs({GtfsShapeSchema.class, GtfsStopSchema.class}))
-  static class EqualShapeDistanceDiffCoordinatesWarningNotice extends ValidationNotice {
+  static class EqualShapeDistanceDiffCoordinatesDistanceBelowThresholdNotice
+      extends ValidationNotice {
 
     /** The id of the faulty shape. */
     private final String shapeId;
@@ -274,7 +275,8 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
      */
     private final double actualDistanceBetweenShapePoints;
 
-    EqualShapeDistanceDiffCoordinatesWarningNotice(GtfsShape previous, GtfsShape current) {
+    EqualShapeDistanceDiffCoordinatesDistanceBelowThresholdNotice(
+        GtfsShape previous, GtfsShape current) {
       this.shapeId = current.shapeId();
       this.csvRowNumber = current.csvRowNumber();
       this.shapeDistTraveled = current.shapeDistTraveled();

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -218,8 +218,10 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
     /** The previous record's `shapes.shape_pt_sequence`. */
     private final int prevShapePtSequence;
 
-    // Actual distance traveled along the shape from the first shape point to the previous shape
-    /** point. */
+    /**
+     * Actual distance traveled along the shape from the first shape point to the previous shape
+     * point.
+     */
     private final double actualDistanceBetweenShapePoints;
 
     EqualShapeDistanceDiffCoordinatesNotice(GtfsShape previous, GtfsShape current) {
@@ -271,7 +273,8 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
     private final int prevShapePtSequence;
 
     /**
-     * Actual distance traveled along the shape from the first shape point to the previous shape.
+     * Actual distance traveled along the shape from the first shape point to the previous shape
+     * point.
      */
     private final double actualDistanceBetweenShapePoints;
 

--- a/output-comparator/src/main/java/org/mobilitydata/gtfsvalidator/outputcomparator/cli/ValidationReportComparator.java
+++ b/output-comparator/src/main/java/org/mobilitydata/gtfsvalidator/outputcomparator/cli/ValidationReportComparator.java
@@ -164,7 +164,7 @@ public class ValidationReportComparator {
     if (args.getRunId().isPresent()) {
       b.append(
           String.format(
-              "Download the full acceptance test report [here](%s/%s) (report will disappear after 90 days).\n",
+              "Download the full acceptance test report [here](%s/%s#artifacts) (report will disappear after 90 days).\n",
               "https://github.com/MobilityData/gtfs-validator/actions/runs",
               args.getRunId().get()));
     }

--- a/output-comparator/src/main/java/org/mobilitydata/gtfsvalidator/outputcomparator/cli/ValidationReportComparator.java
+++ b/output-comparator/src/main/java/org/mobilitydata/gtfsvalidator/outputcomparator/cli/ValidationReportComparator.java
@@ -164,7 +164,7 @@ public class ValidationReportComparator {
     if (args.getRunId().isPresent()) {
       b.append(
           String.format(
-              "Download the full acceptance test report [here](%s/%s#artifacts) (report will disappear after 90 days).\n",
+              "Download the full acceptance test report [here](%s/%s) (report will disappear after 90 days).\n",
               "https://github.com/MobilityData/gtfs-validator/actions/runs",
               args.getRunId().get()));
     }


### PR DESCRIPTION
**Summary:**
Closes #1638 
Closes #1678 
Concerns have been raised about the `equal_shape_dist_diff_coordinates` error's sensitivity to minor coordinate discrepancies. [Historical discussions](https://github.com/MobilityData/gtfs-validator/pull/1675#issuecomment-1951619648) proposed a $1.11 m$ threshold to distinguish between `ERROR` ($\ge 1.11m$) and `WARNING` ($\lt 1.11 m$) levels. Given the expansion of the Mobility Database since these initial discussions, reevaluating this threshold with current data offers a chance to refine the rule's sensitivity.

**Expected behavior:** 
- Introduces a 1.11m threshold for `equal_shape_distance_diff_coordinates`, triggering an `ERROR` for distances $\geq 1.11m$.
- Creates a new notice, `equal_shape_distance_diff_coordinates_below_threshold`, with `WARNING` severity for distances $<1.11m$.

**Acceptance tests results:**
The acceptance tests [results](https://github.com/MobilityData/gtfs-validator/pull/1675#issuecomment-1952912555) show a 6% reduction (93 notices) in `ERROR` notices. Additionally, 166 new `WARNING` notices were generated. This is because certain datasets exhibited distances between coordinates that were both greater than and less than $1.11m$, thus qualifying for both `WARNING` and `ERROR` notices.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
