### PR TITLE
fix: table not properly rendered in notices

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/DuplicateRouteNameValidator.java
@@ -81,12 +81,23 @@ public class DuplicateRouteNameValidator extends FileValidator {
    *
    * <p>Example of bad data:
    *
-   * <pre>
-   * | `route_id` 	| `route_short_name` 	| `route_long_name` 	|
-   * |------------	|--------------------	|-------------------	|
-   * | route1     	| U1                 	| Southern          	|
-   * | route2     	| U1                 	| Southern          	|
-   * </pre>
+   * <table style="table-layout:auto; width:auto;">
+   *   <tr>
+   *     <th><code>route_id</code></th>
+   *     <th><code>route_short_name</code></th>
+   *     <th><code>route_long_name</code></th>
+   *   </tr>
+   *   <tr>
+   *     <td>route1</td>
+   *     <td>U1</td>
+   *     <td>Southern</td>
+   *   </tr>
+   *   <tr>
+   *     <td>route2</td>
+   *     <td>U1</td>
+   *     <td>Southern</td>
+   *   </tr>
+   * </table>
    */
   @GtfsValidationNotice(
       severity = WARNING,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -340,21 +340,68 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
    *
    * <p>The speed threshold depends on route type:
    *
-   * <pre>
-   * | Route type | Description | Threshold, km/h |
-   * |------------|-------------|-----------------|
-   * | 0          | Light rail  | 100             |
-   * | 1          | Subway      | 150             |
-   * | 2          | Rail        | 500             |
-   * | 3          | Bus         | 150             |
-   * | 4          | Ferry       |  80             |
-   * | 5          | Cable tram  |  30             |
-   * | 6          | Aerial lift |  50             |
-   * | 7          | Funicular   |  50             |
-   * | 11         | Trolleybus  | 150             |
-   * | 12         | Monorail    | 150             |
-   * | -          | Unknown     | 200             |
-   * </pre>
+   * <table style="width: auto; table-layout: auto;">
+   *      <tr>
+   *        <th>Route type</th>
+   *        <th>Description</th>
+   *        <th>Threshold, km/h</th>
+   *      </tr>
+   *      <tr>
+   *        <td>0</td>
+   *        <td>Light rail</td>
+   *        <td>100</td>
+   *      </tr>
+   *      <tr>
+   *        <td>1</td>
+   *        <td>Subway</td>
+   *        <td>150</td>
+   *      </tr>
+   *      <tr>
+   *        <td>2</td>
+   *        <td>Rail</td>
+   *        <td>500</td>
+   *      </tr>
+   *      <tr>
+   *        <td>3</td>
+   *        <td>Bus</td>
+   *        <td>150</td>
+   *      </tr>
+   *      <tr>
+   *        <td>4</td>
+   *        <td>Ferry</td>
+   *        <td>80</td>
+   *      </tr>
+   *      <tr>
+   *        <td>5</td>
+   *        <td>Cable tram</td>
+   *        <td>30</td>
+   *      </tr>
+   *      <tr>
+   *        <td>6</td>
+   *        <td>Aerial lift</td>
+   *        <td>50</td>
+   *      </tr>
+   *      <tr>
+   *        <td>7</td>
+   *        <td>Funicular</td>
+   *        <td>50</td>
+   *      </tr>
+   *      <tr>
+   *        <td>11</td>
+   *        <td>Trolleybus</td>
+   *        <td>150</td>
+   *      </tr>
+   *      <tr>
+   *        <td>12</td>
+   *        <td>Monorail</td>
+   *        <td>150</td>
+   *      </tr>
+   *      <tr>
+   *        <td>-</td>
+   *        <td>Unknown</td>
+   *        <td>200</td>
+   *      </tr>
+   *    </table>
    */
   @GtfsValidationNotice(
       severity = WARNING,


### PR DESCRIPTION
**Summary:**
Closes #1672 
Tables in Markdown format do not properly render for notices `fast_travel_between_consecutive_stops` and `duplicate_route_name`. To address the issue I simply used HTML formatting like it was done for the `route_long_name_contains_short_name` notice.


**Expected behavior:** 
- For `fast_travel_between_consecutive_stops`:
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/0469966e-b5e4-43e8-bb50-163ad06a534d)
- For `duplicate_route_name`:
![image](https://github.com/MobilityData/gtfs-validator/assets/60586858/d5472a55-283b-4998-b5be-b31df48f7ab3)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
