### PR TITLE
fix: 1707 web validator waits for validation forever

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -102,7 +102,8 @@ public class ValidationRunner {
     GtfsFeedContainer feedContainer;
     GtfsInput gtfsInput = null;
     try {
-      gtfsInput = createGtfsInput(config, versionInfo.currentVersion().orElse(null), noticeContainer);
+      gtfsInput =
+          createGtfsInput(config, versionInfo.currentVersion().orElse(null), noticeContainer);
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
       noticeContainer.addSystemError(new IOError(e));

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -102,7 +102,7 @@ public class ValidationRunner {
     GtfsFeedContainer feedContainer;
     GtfsInput gtfsInput = null;
     try {
-      gtfsInput = createGtfsInput(config, versionInfo.currentVersion().get(), noticeContainer);
+      gtfsInput = createGtfsInput(config, versionInfo.currentVersion().orElse(null), noticeContainer);
     } catch (IOException e) {
       logger.atSevere().withCause(e).log("Cannot load GTFS feed");
       noticeContainer.addSystemError(new IOError(e));

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionInfo.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionInfo.java
@@ -1,27 +1,42 @@
 package org.mobilitydata.gtfsvalidator.util;
 
-import com.google.auto.value.AutoValue;
 import java.util.Optional;
 
 /** Version information about the validator. */
-@AutoValue
-public abstract class VersionInfo {
+public class VersionInfo {
 
-  /** The version of the currently running validator instance. */
-  public abstract Optional<String> currentVersion();
+  private Optional<String> currentVersion;
+  private Optional<String> latestReleaseVersion;
 
-  /** The latest released version of the validator. */
-  public abstract Optional<String> latestReleaseVersion();
+  public VersionInfo(Optional<String> currentVersion, Optional<String> latestReleaseVersion) {
+    this.currentVersion = currentVersion;
+    this.latestReleaseVersion = latestReleaseVersion;
+  }
+
+  public Optional<String> currentVersion() {
+    return currentVersion;
+  }
+
+  public void setCurrentVersion(Optional<String> currentVersion) {
+    this.currentVersion = currentVersion;
+  }
+
+  public Optional<String> latestReleaseVersion() {
+    return latestReleaseVersion;
+  }
+
+  public void setLatestReleaseVersion(Optional<String> latestReleaseVersion) {
+    this.latestReleaseVersion = latestReleaseVersion;
+  }
 
   public boolean updateAvailable() {
-    if (currentVersion().isEmpty() || latestReleaseVersion().isEmpty()) {
+    if (currentVersion.isEmpty() || latestReleaseVersion.isEmpty()) {
       return false;
     }
-    // We don't trigger an update if the user is running a development snapshot.
-    if (currentVersion().get().endsWith("SNAPSHOT")) {
+    if (currentVersion.get().endsWith("SNAPSHOT")) {
       return false;
     }
-    return !latestReleaseVersion().get().equals(currentVersion().get());
+    return !latestReleaseVersion.get().equals(currentVersion.get());
   }
 
   public static VersionInfo empty() {
@@ -30,6 +45,6 @@ public abstract class VersionInfo {
 
   public static VersionInfo create(
       Optional<String> currentVersion, Optional<String> latestReleaseVersion) {
-    return new AutoValue_VersionInfo(currentVersion, latestReleaseVersion);
+    return new VersionInfo(currentVersion, latestReleaseVersion);
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionInfo.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionInfo.java
@@ -47,4 +47,35 @@ public class VersionInfo {
       Optional<String> currentVersion, Optional<String> latestReleaseVersion) {
     return new VersionInfo(currentVersion, latestReleaseVersion);
   }
+
+  public String toString() {
+    return "VersionInfo{"
+        + "currentVersion="
+        + currentVersion
+        + ", "
+        + "latestReleaseVersion="
+        + latestReleaseVersion
+        + "}";
+  }
+
+  public boolean equals(Object o) {
+    if (o == this) {
+      return true;
+    }
+    if (o instanceof VersionInfo) {
+      VersionInfo that = (VersionInfo) o;
+      return this.currentVersion.equals(that.currentVersion())
+          && this.latestReleaseVersion.equals(that.latestReleaseVersion());
+    }
+    return false;
+  }
+
+  public int hashCode() {
+    int h$ = 1;
+    h$ *= 1000003;
+    h$ ^= currentVersion.hashCode();
+    h$ *= 1000003;
+    h$ ^= latestReleaseVersion.hashCode();
+    return h$;
+  }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
@@ -102,6 +102,7 @@ public class VersionResolver {
             logger.atSevere().withCause(ex).log("Error resolving version info");
           }
           VersionInfo info = VersionInfo.create(currentVersion, latestReleaseVersion);
+          Thread.sleep(5100);
           resolvedVersionInfo.set(info);
           return info;
         }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
@@ -62,7 +62,7 @@ public class VersionResolver {
     try {
       versionInfo = resolvedVersionInfo.get(timeout.toMillis(), TimeUnit.MILLISECONDS);
     } catch (Throwable ex) {
-      logger.atSevere().withCause(ex).log("Error resolving release version");
+      logger.atSevere().withCause(ex).log("Error obtaining release version");
     }
     return versionInfo;
   }
@@ -110,10 +110,9 @@ public class VersionResolver {
               var version = resolveLatestReleaseVersion(versionInfo.currentVersion());
               versionInfo.setLatestReleaseVersion(version);
             } catch (Throwable ex) {
-              logger.atSevere().withCause(ex).log("Error obtaining release version info");
+              logger.atSevere().withCause(ex).log("Error obtaining release version info from endpoint");
             }
           }
-          Thread.sleep(5100);
           resolvedVersionInfo.set(versionInfo);
           return versionInfo;
         });

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
@@ -91,20 +91,22 @@ public class VersionResolver {
 
     executor.submit(
         () -> {
+          Optional<String> currentVersion = Optional.empty();
+          Optional<String> latestReleaseVersion = Optional.empty();
           try {
-            Optional<String> currentVersion = resolveCurrentVersion();
-            Optional<String> latestReleaseVersion = Optional.empty();
+            currentVersion = resolveCurrentVersion();
             if (!skipValidatorUpdate) {
               latestReleaseVersion = resolveLatestReleaseVersion(currentVersion);
             }
-            VersionInfo info = VersionInfo.create(currentVersion, latestReleaseVersion);
-            resolvedVersionInfo.set(info);
-            return info;
           } catch (Throwable ex) {
             logger.atSevere().withCause(ex).log("Error resolving version info");
           }
-          return VersionInfo.empty();
-        });
+          VersionInfo info = VersionInfo.create(currentVersion, latestReleaseVersion);
+          resolvedVersionInfo.set(info);
+          return info;
+        }
+    );
+
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java
@@ -110,7 +110,8 @@ public class VersionResolver {
               var version = resolveLatestReleaseVersion(versionInfo.currentVersion());
               versionInfo.setLatestReleaseVersion(version);
             } catch (Throwable ex) {
-              logger.atSevere().withCause(ex).log("Error obtaining release version info from endpoint");
+              logger.atSevere().withCause(ex).log(
+                  "Error obtaining release version info from endpoint");
             }
           }
           resolvedVersionInfo.set(versionInfo);


### PR DESCRIPTION
**Summary:**

Closes #1707 

If there is no timeout on the version endpoint, this PR changes nothing.
Changed the code so it does not generate an exception when the version endpoint is called but times out.
Another problem was that the current version (obtained from the jar files) was discarded if there was a time out calling the version endpoint. 

**Expected behavior:** 

Web validator does not hang forever if there is a timeout while calling the version endpoint.
If the timeout happens, the version is still correct in report.html

** Testing tips **

The timeout is intermittent, and probably only occurs when the validator service is brought up.
To test this, you could add a delay in  [VersionResolver.java](https://github.com/MobilityData/gtfs-validator/blob/dee5802afc2f0e37b0299a5d6dca192c08ee4af8/main/src/main/java/org/mobilitydata/gtfsvalidator/util/VersionResolver.java#L150), e.g.  Thread.sleep(5100) to simulate that the endpoint takes a long time to respond. The delay should be above 5000 ms, since it's the time used for the timeout.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
