### PR TITLE
feat: Changed notice migration generation. Added zip file to release.

### DIFF
--- a/.github/workflows/notice_migration_generation.yml
+++ b/.github/workflows/notice_migration_generation.yml
@@ -1,8 +1,11 @@
 name: Update NOTICE_MIGRATION.md
 
 on:
-  release:
-    types: [ prereleased, released ]
+  workflow_dispatch:
+    inputs:
+      NEW_VERSION:
+        description: 'The release version to add to NOTICE_MIGRATION.md. e.g. v5.0.2'
+        required: true
 
 jobs:
   update_notice_migration:
@@ -26,6 +29,7 @@ jobs:
           distribution: 'zulu'
 
       - name: Get previous release version
+        # The script will set the PREVIOUS_VERSION environment variable
         run: python3 scripts/notice-migration-generator/get_previous_release.py
 
       - name: Checkout previous version
@@ -53,7 +57,7 @@ jobs:
       - name: Upload current rules.json
         uses: actions/upload-artifact@v3
         with:
-          name: rules-${{ github.event.release.tag_name }}
+          name: rules-${{ github.event.inputs.NEW_VERSION }}
           path: web/client/static/rules.json
 
       - name: Download all workflow artifacts
@@ -65,7 +69,7 @@ jobs:
       - name: Run update script
         run: |
           echo "CHANGED_NOTICES<<EOF" >> $GITHUB_ENV
-          python3 scripts/notice-migration-generator/notice_migration_generator.py -r ${{ github.event.release.tag_name }} >> $GITHUB_ENV
+          python3 scripts/notice-migration-generator/notice_migration_generator.py -r ${{ github.event.inputs.NEW_VERSION }} >> $GITHUB_ENV
           echo "EOF" >> $GITHUB_ENV
 
       - name: Create PR

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -159,6 +159,13 @@ jobs:
             ${{ env.MACOS_TARGET_DEST_PATH }}/*.pkg
             ${{ env.MACOS_TARGET_DEST_PATH }}/*.deb
 
+      - name: "Create zip files"
+        shell: bash
+        run: |
+          filename=${{ matrix.os }}.zip
+          zip -j "$filename" "app/pkg/build/jpackage/*"
+          mv "$filename" "app/pkg/build/jpackage/"
+
       - name: "Upload assets to release"
         if: github.event_name == 'prerelease' || github.event_name == 'release'
         env:
@@ -176,7 +183,11 @@ jobs:
 
             for (let file of await fs.readdir('./app/pkg/build/jpackage')) {
               const extension = file.split('.').pop()
-              if (extension != "msi" && extension != "dmg" && extension != "pkg" && extension != "deb")
+              if (extension != "msi" 
+                && extension != "dmg"
+                && extension != "pkg" 
+                && extension != "deb"
+                && extension != "zip"
                 continue;
             
               console.log('Uploading', file);

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -162,9 +162,18 @@ jobs:
       - name: "Create zip files"
         shell: bash
         run: |
+          # The created zip file will be uploaded to the release along with installers in app/pkg/build/jpackage in the
+          # next step.
           filename=${{ matrix.os }}.zip
-          zip -j "$filename" "app/pkg/build/jpackage/*"
-          mv "$filename" "app/pkg/build/jpackage/"
+          pushd app/pkg/build/jpackage
+          # The windows runner does not have zip, but has 7zip.
+          if [ "${{ matrix.os }}" == "windows-latest" ]; then
+            7z a -tzip $filename *.msi
+          else
+            # Normally there should be either .deb or (.pkg and .dmg) Just capture all.
+            zip -j $filename *.deb *.dmg *.pkg
+          fi
+          popd
 
       - name: "Upload assets to release"
         if: github.event_name == 'prerelease' || github.event_name == 'release'
@@ -187,7 +196,7 @@ jobs:
                 && extension != "dmg"
                 && extension != "pkg" 
                 && extension != "deb"
-                && extension != "zip"
+                && extension != "zip")
                 continue;
             
               console.log('Uploading', file);

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -6,7 +6,7 @@ Update the [README.md](/README.md) to match the latest developments. The documen
 - [NOTICE_MIGRATION.md](https://github.com/MobilityData/gtfs-validator/blob/master/docs/NOTICE_MIGRATION.md) is a file that is committed in git. To change it, you need a pull request.
 - Modifying the file and creating the PR can be done automatically by executing the `Update NOTICE_MIGRATION.md` GitHub action (found [here](https://github.com/MobilityData/gtfs-validator/actions/workflows/notice_migration_generation.yml)).
 - When running the Github action, you need to specify the new version that will soon be released (e.g. v5.0.2).
-- The action will modify the file and create a pull request
+- The action will modify the file and create a pull request with this title: `docs: Automated update of NOTICE_MIGRATION.md`
 - Examine the pull request and if satisfactory merge it.
 
 ### 2. Do a pre relase

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -2,6 +2,13 @@
 ### 1. Update documentation
 Update the [README.md](/README.md) to match the latest developments. The documentation should accurately reflect the use of the `jar` that is to be released. 
 
+### 2. Update NOTICE_MIGRATION.md file
+- [NOTICE_MIGRATION.md](https://github.com/MobilityData/gtfs-validator/blob/master/docs/NOTICE_MIGRATION.md) is a file that is committed in git. To change it, you need a pull request.
+- Modifying the file and creating the PR can be done automatically by executing the `Update NOTICE_MIGRATION.md` GitHub action (found [here](https://github.com/MobilityData/gtfs-validator/actions/workflows/notice_migration_generation.yml)).
+- When running the Github action, you need to specify the new version that will soon be released (e.g. v5.0.2).
+- The action will modify the file and create a pull request
+- Examine the pull request and if satisfactory merge it.
+
 ### 2. Do a pre relase
 1. Go to the release section of GitHub ![step 1](https://user-images.githubusercontent.com/35747326/99820876-567dd600-2b1f-11eb-87d2-eef132b3016a.png)
 


### PR DESCRIPTION
**Summary:**
Closes #1719 

This issue has 2 parts:

* Include automated Github action of Notice Migration updates when the release is official

The new process is:

1. Manually run the notice migration GH action (manually specifying the version) -> this adds to the NOTICE_MIGRATION.md file and creates the PR
2. Merge the PR
3. Release

- Upload the .zip installers to the release assets.



**Expected behavior:** 
Follow the new section `2. Update NOTICE_MIGRATION.md file` in docs/RELEASE.md. 
After running the github action, a new PR should have been created with the notice migration data for the specified release.

For the upload zip installers task , create a fake draft release and verify that the 3 installer zip files are present as release artefacts.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
