### PR TITLE
feat: added @ForeignKeys for holds an array of @ForeignKey annotations

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFareLegRuleSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFareLegRuleSchema.java
@@ -21,6 +21,7 @@ import static org.mobilitydata.gtfsvalidator.annotation.TranslationRecordIdType.
 import org.mobilitydata.gtfsvalidator.annotation.FieldType;
 import org.mobilitydata.gtfsvalidator.annotation.FieldTypeEnum;
 import org.mobilitydata.gtfsvalidator.annotation.ForeignKey;
+import org.mobilitydata.gtfsvalidator.annotation.ForeignKeys;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
 import org.mobilitydata.gtfsvalidator.annotation.Index;
 import org.mobilitydata.gtfsvalidator.annotation.PrimaryKey;
@@ -34,7 +35,10 @@ public interface GtfsFareLegRuleSchema extends GtfsEntity {
 
   @FieldType(FieldTypeEnum.ID)
   @PrimaryKey(translationRecordIdType = UNSUPPORTED)
-  @ForeignKey(table = "routes.txt", field = "network_id")
+  @ForeignKeys({
+    @ForeignKey(table = "routes.txt", field = "network_id"),
+    @ForeignKey(table = "networks.txt", field = "network_id")
+  })
   String networkId();
 
   @FieldType(FieldTypeEnum.ID)

--- a/model/src/main/java/org/mobilitydata/gtfsvalidator/annotation/ForeignKeys.java
+++ b/model/src/main/java/org/mobilitydata/gtfsvalidator/annotation/ForeignKeys.java
@@ -1,0 +1,21 @@
+package org.mobilitydata.gtfsvalidator.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies multiple references to foreign keys. A validator for data integrity will be generated
+ * automatically for each foreign key.
+ *
+ * <p>Note that {@code @ForeignKeys} does not imply that the field is required and you need to put
+ * an extra {@code @Required} annotation in this case.
+ *
+ * <p>Example.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface ForeignKeys {
+  ForeignKey[] value();
+}


### PR DESCRIPTION
**Summary:**
Closes #1756
Closes #1764

**Expected behavior:** 

Only raise a foreign key violation error when network_id is missing from both networks.txt and routes.txt. The validation report should not give a foreign_key_violation error using the test file in #1756 
Before the fix:
![image](https://github.com/MobilityData/gtfs-validator/assets/5789435/786fc1a9-fc6e-4046-934b-cc0ee24f3e4a)
After the fix:
![image](https://github.com/MobilityData/gtfs-validator/assets/5789435/bedd90ba-c08b-4ef9-b16e-fc0a872bf4b9)

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
