### PR TITLE
fix: Display empty values for feed_start_date and feed_end_date if there's…

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
@@ -311,12 +311,14 @@ public class FeedMetadata {
         FEED_INFO_FEED_LANGUAGE, info == null ? "N/A" : info.feedLang().getDisplayLanguage());
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_START_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedStartDate().getLocalDate();
-      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
+      String displayDate =
+          localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
       feedInfo.put(FEED_INFO_FEED_START_DATE, info == null ? "N/A" : displayDate);
     }
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_END_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedEndDate().getLocalDate();
-      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
+      String displayDate =
+          localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
       feedInfo.put(FEED_INFO_FEED_END_DATE, info == null ? "N/A" : displayDate);
     }
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
@@ -3,7 +3,6 @@ package org.mobilitydata.gtfsvalidator.report.model;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.vladsch.flexmark.util.misc.Pair;
-
 import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
@@ -313,16 +312,12 @@ public class FeedMetadata {
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_START_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedStartDate().getLocalDate();
       String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "" : localDate.toString();
-      feedInfo.put(
-          FEED_INFO_FEED_START_DATE,
-          info == null ? "N/A" : displayDate);
+      feedInfo.put(FEED_INFO_FEED_START_DATE, info == null ? "N/A" : displayDate);
     }
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_END_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedEndDate().getLocalDate();
       String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "" : localDate.toString();
-      feedInfo.put(
-          FEED_INFO_FEED_END_DATE,
-          info == null ? "N/A" : displayDate);
+      feedInfo.put(FEED_INFO_FEED_END_DATE, info == null ? "N/A" : displayDate);
     }
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
@@ -311,12 +311,12 @@ public class FeedMetadata {
         FEED_INFO_FEED_LANGUAGE, info == null ? "N/A" : info.feedLang().getDisplayLanguage());
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_START_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedStartDate().getLocalDate();
-      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "" : localDate.toString();
+      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
       feedInfo.put(FEED_INFO_FEED_START_DATE, info == null ? "N/A" : displayDate);
     }
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_END_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedEndDate().getLocalDate();
-      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "" : localDate.toString();
+      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
       feedInfo.put(FEED_INFO_FEED_END_DATE, info == null ? "N/A" : displayDate);
     }
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
@@ -312,13 +312,13 @@ public class FeedMetadata {
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_START_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedStartDate().getLocalDate();
       String displayDate =
-          localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
+          localDate.equals(GtfsFeedInfo.DEFAULT_FEED_START_DATE) ? "N/A" : localDate.toString();
       feedInfo.put(FEED_INFO_FEED_START_DATE, info == null ? "N/A" : displayDate);
     }
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_END_DATE_FIELD_NAME)) {
       LocalDate localDate = info.feedEndDate().getLocalDate();
       String displayDate =
-          localDate.equals(LocalDate.of(1970, 1, 1)) ? "N/A" : localDate.toString();
+          localDate.equals(GtfsFeedInfo.DEFAULT_FEED_END_DATE) ? "N/A" : localDate.toString();
       feedInfo.put(FEED_INFO_FEED_END_DATE, info == null ? "N/A" : displayDate);
     }
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/report/model/FeedMetadata.java
@@ -3,6 +3,8 @@ package org.mobilitydata.gtfsvalidator.report.model;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedSet;
 import com.vladsch.flexmark.util.misc.Pair;
+
+import java.time.LocalDate;
 import java.util.*;
 import java.util.function.Function;
 import org.mobilitydata.gtfsvalidator.table.*;
@@ -309,14 +311,18 @@ public class FeedMetadata {
     feedInfo.put(
         FEED_INFO_FEED_LANGUAGE, info == null ? "N/A" : info.feedLang().getDisplayLanguage());
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_START_DATE_FIELD_NAME)) {
+      LocalDate localDate = info.feedStartDate().getLocalDate();
+      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "" : localDate.toString();
       feedInfo.put(
           FEED_INFO_FEED_START_DATE,
-          info == null ? "N/A" : info.feedStartDate().getLocalDate().toString());
+          info == null ? "N/A" : displayDate);
     }
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_END_DATE_FIELD_NAME)) {
+      LocalDate localDate = info.feedEndDate().getLocalDate();
+      String displayDate = localDate.equals(LocalDate.of(1970, 1, 1)) ? "" : localDate.toString();
       feedInfo.put(
           FEED_INFO_FEED_END_DATE,
-          info == null ? "N/A" : info.feedEndDate().getLocalDate().toString());
+          info == null ? "N/A" : displayDate);
     }
   }
 


### PR DESCRIPTION
**Summary:**
Closes #1790 
<img width="1688" alt="image" src="https://github.com/user-attachments/assets/8de9165b-b2c6-49f6-9f5c-c396126c0979">

**Expected behavior:** 

Display empty values for feed_start_date and feed_end_date if there's no data for these two fields.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
