### PR TITLE
feat: update `missing_trip_edge` for flex feed

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidator.java
@@ -56,37 +56,43 @@ public class MissingTripEdgeValidator extends FileValidator {
       List<GtfsStopTime> stopTimesForTrip = entry.getValue();
       GtfsStopTime tripFirstStop = stopTimesForTrip.get(0);
       GtfsStopTime tripLastStop = stopTimesForTrip.get(stopTimesForTrip.size() - 1);
-      if (!tripFirstStop.hasArrivalTime()) {
-        noticeContainer.addValidationNotice(
-            new MissingTripEdgeNotice(
-                tripFirstStop.csvRowNumber(),
-                tripFirstStop.stopSequence(),
-                tripId,
-                ARRIVAL_TIME_FIELD_NAME));
+      if (!tripFirstStop.hasStartPickupDropOffWindow()
+          && !tripFirstStop.hasEndPickupDropOffWindow()) {
+        if (!tripFirstStop.hasArrivalTime()) {
+          noticeContainer.addValidationNotice(
+              new MissingTripEdgeNotice(
+                  tripFirstStop.csvRowNumber(),
+                  tripFirstStop.stopSequence(),
+                  tripId,
+                  ARRIVAL_TIME_FIELD_NAME));
+        }
+        if (!tripFirstStop.hasDepartureTime()) {
+          noticeContainer.addValidationNotice(
+              new MissingTripEdgeNotice(
+                  tripFirstStop.csvRowNumber(),
+                  tripFirstStop.stopSequence(),
+                  tripId,
+                  DEPARTURE_TIME_FIELD_NAME));
+        }
       }
-      if (!tripFirstStop.hasDepartureTime()) {
-        noticeContainer.addValidationNotice(
-            new MissingTripEdgeNotice(
-                tripFirstStop.csvRowNumber(),
-                tripFirstStop.stopSequence(),
-                tripId,
-                DEPARTURE_TIME_FIELD_NAME));
-      }
-      if (!tripLastStop.hasArrivalTime()) {
-        noticeContainer.addValidationNotice(
-            new MissingTripEdgeNotice(
-                tripLastStop.csvRowNumber(),
-                tripLastStop.stopSequence(),
-                tripId,
-                ARRIVAL_TIME_FIELD_NAME));
-      }
-      if (!tripLastStop.hasDepartureTime()) {
-        noticeContainer.addValidationNotice(
-            new MissingTripEdgeNotice(
-                tripLastStop.csvRowNumber(),
-                tripLastStop.stopSequence(),
-                tripId,
-                DEPARTURE_TIME_FIELD_NAME));
+      if (!tripLastStop.hasStartPickupDropOffWindow()
+          && !tripLastStop.hasEndPickupDropOffWindow()) {
+        if (!tripLastStop.hasArrivalTime()) {
+          noticeContainer.addValidationNotice(
+              new MissingTripEdgeNotice(
+                  tripLastStop.csvRowNumber(),
+                  tripLastStop.stopSequence(),
+                  tripId,
+                  ARRIVAL_TIME_FIELD_NAME));
+        }
+        if (!tripLastStop.hasDepartureTime()) {
+          noticeContainer.addValidationNotice(
+              new MissingTripEdgeNotice(
+                  tripLastStop.csvRowNumber(),
+                  tripLastStop.stopSequence(),
+                  tripId,
+                  DEPARTURE_TIME_FIELD_NAME));
+        }
       }
     }
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingTripEdgeValidatorTest.java
@@ -46,6 +46,26 @@ public class MissingTripEdgeValidatorTest {
         .build();
   }
 
+  public static GtfsStopTime createStopTimeWithPickupDropOffWindow(
+      int csvRowNumber,
+      String tripId,
+      GtfsTime arrivalTime,
+      GtfsTime departureTime,
+      int stopSequence,
+      GtfsTime startPickupDropOffWindow,
+      GtfsTime endPickupDropOffWindow) {
+    return new GtfsStopTime.Builder()
+        .setCsvRowNumber(csvRowNumber)
+        .setTripId(tripId)
+        .setArrivalTime(arrivalTime)
+        .setDepartureTime(departureTime)
+        .setStopSequence(stopSequence)
+        .setStopId("stop id")
+        .setStartPickupDropOffWindow(startPickupDropOffWindow)
+        .setEndPickupDropOffWindow(endPickupDropOffWindow)
+        .build();
+  }
+
   public static GtfsTrip createTrip(int csvRowNumber, String tripId) {
     return new GtfsTrip.Builder()
         .setCsvRowNumber(csvRowNumber)
@@ -153,6 +173,30 @@ public class MissingTripEdgeValidatorTest {
                         GtfsTime.fromSecondsSinceMidnight(456),
                         GtfsTime.fromSecondsSinceMidnight(3556467),
                         4))))
+        .isEmpty();
+  }
+
+  @Test
+  public void tripWithPickupDropOffWindowShouldNotGenerateNotice() {
+    assertThat(
+            generateNotices(
+                ImmutableList.of(
+                    createStopTimeWithPickupDropOffWindow(
+                        2,
+                        "trip id value",
+                        null,
+                        null,
+                        1,
+                        GtfsTime.fromSecondsSinceMidnight(1),
+                        GtfsTime.fromSecondsSinceMidnight(2)),
+                    createStopTimeWithPickupDropOffWindow(
+                        3,
+                        "trip id value 2",
+                        null,
+                        null,
+                        1,
+                        GtfsTime.fromSecondsSinceMidnight(1),
+                        GtfsTime.fromSecondsSinceMidnight(2)))))
         .isEmpty();
   }
 }


### PR DESCRIPTION
**Summary:**

This update modifies the `missing_trip_edge` notice to ensure it is not triggered if the `GtfsStopTime` entity has *either* the `startPickupDropOffWindow` or `endPickupDropOffWindow` column defined.

**Expected Behavior:**  
The `missing_trip_edge` notice will no longer be triggered in cases where one of the above columns is present. For example, using [this dataset](https://data.trilliumtransit.com/gtfs/islandtransit-wa-us/islandtransit-wa-us--flex-v2-TEST.zip), the notice is no longer triggered, as shown below:

<img width="1595" alt="Screenshot 2024-09-23 at 2 53 21 PM" src="https://github.com/user-attachments/assets/93d05dbc-12a2-4a49-bc77-3eacfe32c1bb">


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
