### PR TITLE
feat: flex - added `forbidden_same_day_booking_field_value` notice

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BookingRulesEntityValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/BookingRulesEntityValidator.java
@@ -65,9 +65,6 @@ public class BookingRulesEntityValidator extends SingleEntityValidator<GtfsBooki
     if (bookingRule.hasPriorNoticeLastTime()) {
       fields.add(GtfsBookingRules.PRIOR_NOTICE_LAST_TIME_FIELD_NAME);
     }
-    if (bookingRule.hasPriorNoticeStartTime()) {
-      fields.add(GtfsBookingRules.PRIOR_NOTICE_START_TIME_FIELD_NAME);
-    }
     if (bookingRule.hasPriorNoticeServiceId()) {
       fields.add(GtfsBookingRules.PRIOR_NOTICE_SERVICE_ID_FIELD_NAME);
     }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BookingRulesEntityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BookingRulesEntityValidatorTest.java
@@ -104,10 +104,7 @@ public class BookingRulesEntityValidatorTest {
     assertThat(generateNotices(bookingRule))
         .containsExactly(
             new BookingRulesEntityValidator.ForbiddenSameDayBookingFieldValueNotice(
-                bookingRule,
-                List.of(
-                    GtfsBookingRules.PRIOR_NOTICE_LAST_DAY_FIELD_NAME,
-                    GtfsBookingRules.PRIOR_NOTICE_START_TIME_FIELD_NAME)));
+                bookingRule, List.of(GtfsBookingRules.PRIOR_NOTICE_LAST_DAY_FIELD_NAME)));
   }
 
   @Test

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BookingRulesEntityValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/BookingRulesEntityValidatorTest.java
@@ -89,4 +89,36 @@ public class BookingRulesEntityValidatorTest {
                     GtfsBookingRules.PRIOR_NOTICE_START_TIME_FIELD_NAME,
                     GtfsBookingRules.PRIOR_NOTICE_SERVICE_ID_FIELD_NAME)));
   }
+
+  @Test
+  public void sameDayBookingWithForbiddenFieldsShouldGenerateNotice() {
+    GtfsBookingRules bookingRule =
+        new GtfsBookingRules.Builder()
+            .setCsvRowNumber(1)
+            .setBookingRuleId("rule-5")
+            .setBookingType(GtfsBookingType.SAMEDAY)
+            .setPriorNoticeLastDay(2) // Forbidden field
+            .setPriorNoticeStartTime(GtfsTime.fromSecondsSinceMidnight(5000)) // Forbidden field
+            .build();
+
+    assertThat(generateNotices(bookingRule))
+        .containsExactly(
+            new BookingRulesEntityValidator.ForbiddenSameDayBookingFieldValueNotice(
+                bookingRule,
+                List.of(
+                    GtfsBookingRules.PRIOR_NOTICE_LAST_DAY_FIELD_NAME,
+                    GtfsBookingRules.PRIOR_NOTICE_START_TIME_FIELD_NAME)));
+  }
+
+  @Test
+  public void sameDayBookingWithoutForbiddenFieldsShouldNotGenerateNotice() {
+    GtfsBookingRules bookingRule =
+        new GtfsBookingRules.Builder()
+            .setCsvRowNumber(1)
+            .setBookingRuleId("rule-6")
+            .setBookingType(GtfsBookingType.SAMEDAY)
+            .build();
+
+    assertThat(generateNotices(bookingRule)).isEmpty();
+  }
 }


### PR DESCRIPTION
**Summary**

This PR introduces a new validation rule that triggers an `ERROR` severity notice when the following conditions are met:

- `booking_type = 1` (Same-day booking)
- Any of the following fields are present in the booking rule:
  - `prior_notice_last_day`
  - `prior_notice_last_time`
  - `prior_notice_start_time`
  - `prior_notice_service_id`

**Expected Behavior**

A validation notice will be generated if the conditions listed above are met, flagging the presence of restricted fields in a same-day booking rule.

Example using [this test dataset](https://github.com/user-attachments/files/17131804/Archive.zip).

![Screenshot 2024-09-25 at 9 41 42 AM](https://github.com/user-attachments/assets/01bfe506-103c-4807-93e3-a86bd558da21)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
