### PR TITLE
fix: only display service window on HTML report, not start/end date

### DIFF
--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -265,19 +265,21 @@
                 <hr />
                 <dl>
                     <div th:each="info: ${metadata.feedInfo}">
-                        <dd th:if="${info.key != 'Service Window Start' and info.key != 'Service Window End'}" th:text="${info.key} + ':'" />
-                        <dt th:if="${info.key != 'Service Window Start' and info.key != 'Service Window End'}">
-                        <span th:if="${info.key.contains('URL') and info.value != 'N/A'}">
-                            <a th:href="${info.value}" target="_blank" th:text="${info.value}" />
-                        </span>
-                            <span th:if="${info.key.contains('URL') and info.value == 'N/A'}" th:text="${info.value}"></span>
-                            <span th:unless="${info.key.contains('URL')}" th:text="${info.value}"/>
-                            <span th:if="${info.key == 'Service Window'}" >
-                                 <a href="#" class="tooltip" onclick="event.preventDefault();"><span>(?)</span>
-                                    <span class="tooltiptext" style="transform: translateX(-100%)">The range of service dates covered by the feed, based on trips with an associated service_id in calendar.txt and/or calendar_dates.txt</span>
-                                </a>
+                        <div th:with="isNotServiceWindow=${info.key != 'Service Window Start' and info.key != 'Service Window End'}">
+                            <dd th:if="${isNotServiceWindow}" th:text="${info.key} + ':'" />
+                            <dt th:if="${isNotServiceWindow}">
+                            <span th:if="${info.key.contains('URL') and info.value != 'N/A'}">
+                                <a th:href="${info.value}" target="_blank" th:text="${info.value}" />
                             </span>
-                        </dt>
+                                <span th:if="${info.key.contains('URL') and info.value == 'N/A'}" th:text="${info.value}"></span>
+                                <span th:unless="${info.key.contains('URL')}" th:text="${info.value}"/>
+                                <span th:if="${info.key == 'Service Window'}" >
+                                     <a href="#" class="tooltip" onclick="event.preventDefault();"><span>(?)</span>
+                                        <span class="tooltiptext" style="transform: translateX(-100%)">The range of service dates covered by the feed, based on trips with an associated service_id in calendar.txt and/or calendar_dates.txt</span>
+                                    </a>
+                                </span>
+                            </dt>
+                        </div>
                     </div>
                 </dl>
             </div>

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -265,14 +265,14 @@
                 <hr />
                 <dl>
                     <div th:each="info: ${metadata.feedInfo}">
-                        <dd th:text="${info.key} + ':'" />
-                        <dt>
+                        <dd th:if="${info.key != 'Service Window Start' and info.key != 'Service Window End'}" th:text="${info.key} + ':'" />
+                        <dt th:if="${info.key != 'Service Window Start' and info.key != 'Service Window End'}">
                         <span th:if="${info.key.contains('URL') and info.value != 'N/A'}">
                             <a th:href="${info.value}" target="_blank" th:text="${info.value}" />
                         </span>
                             <span th:if="${info.key.contains('URL') and info.value == 'N/A'}" th:text="${info.value}"></span>
                             <span th:unless="${info.key.contains('URL')}" th:text="${info.value}"/>
-                            <span th:if="${info.key.contains('Service Window')}" >
+                            <span th:if="${info.key == 'Service Window'}" >
                                  <a href="#" class="tooltip" onclick="event.preventDefault();"><span>(?)</span>
                                     <span class="tooltiptext" style="transform: translateX(-100%)">The range of service dates covered by the feed, based on trips with an associated service_id in calendar.txt and/or calendar_dates.txt</span>
                                 </a>


### PR DESCRIPTION
**Summary:**

Closes #1854 
only display service window on HTML report, not start/end date

**Expected behavior:** 
<img width="1710" alt="image" src="https://github.com/user-attachments/assets/17a63457-c9f6-406c-82ac-7e46590cd056">

<img width="1081" alt="image" src="https://github.com/user-attachments/assets/f4524f42-a482-428c-abda-4f1f2145f554">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
