### PR TITLE
feat: modify `stops.txt` to be conditionally required

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsStopSchema.java
@@ -20,7 +20,7 @@ import java.time.ZoneId;
 import org.mobilitydata.gtfsvalidator.annotation.*;
 
 @GtfsTable("stops.txt")
-@Required
+@ConditionallyRequired
 public interface GtfsStopSchema extends GtfsEntity {
   @FieldType(FieldTypeEnum.ID)
   @PrimaryKey

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidator.java
@@ -1,12 +1,10 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
+import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.table.*;
-
-import javax.inject.Inject;
-
 
 @GtfsValidator
 public class MissingStopsFileValidator extends FileValidator {
@@ -15,7 +13,8 @@ public class MissingStopsFileValidator extends FileValidator {
   private final GtfsGeojsonFeaturesContainer geojsonFeaturesContainer;
 
   @Inject
-  MissingStopsFileValidator(GtfsStopTableContainer table, GtfsGeojsonFeaturesContainer geojsonFeaturesContainer) {
+  MissingStopsFileValidator(
+      GtfsStopTableContainer table, GtfsGeojsonFeaturesContainer geojsonFeaturesContainer) {
     this.stopTableContainer = table;
     this.geojsonFeaturesContainer = geojsonFeaturesContainer;
   }
@@ -23,8 +22,7 @@ public class MissingStopsFileValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     if (stopTableContainer.isMissingFile() && geojsonFeaturesContainer.isMissingFile()) {
-        noticeContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+      noticeContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
     }
   }
-
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidator.java
@@ -1,0 +1,30 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.*;
+
+import javax.inject.Inject;
+
+
+@GtfsValidator
+public class MissingStopsFileValidator extends FileValidator {
+
+  private final GtfsStopTableContainer stopTableContainer;
+  private final GtfsGeojsonFeaturesContainer geojsonFeaturesContainer;
+
+  @Inject
+  MissingStopsFileValidator(GtfsStopTableContainer table, GtfsGeojsonFeaturesContainer geojsonFeaturesContainer) {
+    this.stopTableContainer = table;
+    this.geojsonFeaturesContainer = geojsonFeaturesContainer;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    if (stopTableContainer.isMissingFile() && geojsonFeaturesContainer.isMissingFile()) {
+        noticeContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+    }
+  }
+
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidatorTest.java
@@ -1,5 +1,8 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
@@ -8,33 +11,33 @@ import org.mobilitydata.gtfsvalidator.table.GtfsGeojsonFileDescriptor;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
 import org.mobilitydata.gtfsvalidator.table.TableStatus;
 
-import java.util.ArrayList;
-
-import static com.google.common.truth.Truth.assertThat;
-
 public class MissingStopsFileValidatorTest {
-    @Test
-    public void stopsTxtMissingFileShouldGenerateNotice() {
-        // If stops.txt is missing and locations.geojson is missing, a notice should be generated
-        NoticeContainer noticeContainer = new NoticeContainer();
-        GtfsGeojsonFileDescriptor descriptor = new GtfsGeojsonFileDescriptor();
-        GtfsGeojsonFeaturesContainer geoJsonFeaturesContainer = descriptor.createContainerForInvalidStatus(TableStatus.MISSING_FILE);
-        GtfsStopTableContainer stopTableContainer = GtfsStopTableContainer.forStatus(TableStatus.MISSING_FILE);
-        new MissingStopsFileValidator(stopTableContainer, geoJsonFeaturesContainer).validate(noticeContainer);
-        assertThat(noticeContainer.getValidationNotices())
-            .containsExactly(new MissingRequiredFileNotice("stops.txt"));
-    }
+  @Test
+  public void stopsTxtMissingFileShouldGenerateNotice() {
+    // If stops.txt is missing and locations.geojson is missing, a notice should be generated
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsGeojsonFileDescriptor descriptor = new GtfsGeojsonFileDescriptor();
+    GtfsGeojsonFeaturesContainer geoJsonFeaturesContainer =
+        descriptor.createContainerForInvalidStatus(TableStatus.MISSING_FILE);
+    GtfsStopTableContainer stopTableContainer =
+        GtfsStopTableContainer.forStatus(TableStatus.MISSING_FILE);
+    new MissingStopsFileValidator(stopTableContainer, geoJsonFeaturesContainer)
+        .validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(new MissingRequiredFileNotice("stops.txt"));
+  }
 
-    @Test
-    public void stopsTxtMissingFileShouldNotGenerateNotice() {
-        // If stops.txt is missing, but locations.geojson is present, no notice should be generated
-        NoticeContainer noticeContainer = new NoticeContainer();
-        GtfsGeojsonFileDescriptor descriptor = new GtfsGeojsonFileDescriptor();
-        GtfsGeojsonFeaturesContainer geoJsonFeaturesContainer = descriptor.createContainerForEntities(
-            new ArrayList<>(), noticeContainer
-        );
-        GtfsStopTableContainer stopTableContainer = GtfsStopTableContainer.forStatus(TableStatus.MISSING_FILE);
-        new MissingStopsFileValidator(stopTableContainer, geoJsonFeaturesContainer).validate(noticeContainer);
-        assertThat(noticeContainer.getValidationNotices()).isEmpty();
-    }
+  @Test
+  public void stopsTxtMissingFileShouldNotGenerateNotice() {
+    // If stops.txt is missing, but locations.geojson is present, no notice should be generated
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsGeojsonFileDescriptor descriptor = new GtfsGeojsonFileDescriptor();
+    GtfsGeojsonFeaturesContainer geoJsonFeaturesContainer =
+        descriptor.createContainerForEntities(new ArrayList<>(), noticeContainer);
+    GtfsStopTableContainer stopTableContainer =
+        GtfsStopTableContainer.forStatus(TableStatus.MISSING_FILE);
+    new MissingStopsFileValidator(stopTableContainer, geoJsonFeaturesContainer)
+        .validate(noticeContainer);
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/MissingStopsFileValidatorTest.java
@@ -1,0 +1,40 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFileNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsGeojsonFeaturesContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsGeojsonFileDescriptor;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
+import org.mobilitydata.gtfsvalidator.table.TableStatus;
+
+import java.util.ArrayList;
+
+import static com.google.common.truth.Truth.assertThat;
+
+public class MissingStopsFileValidatorTest {
+    @Test
+    public void stopsTxtMissingFileShouldGenerateNotice() {
+        // If stops.txt is missing and locations.geojson is missing, a notice should be generated
+        NoticeContainer noticeContainer = new NoticeContainer();
+        GtfsGeojsonFileDescriptor descriptor = new GtfsGeojsonFileDescriptor();
+        GtfsGeojsonFeaturesContainer geoJsonFeaturesContainer = descriptor.createContainerForInvalidStatus(TableStatus.MISSING_FILE);
+        GtfsStopTableContainer stopTableContainer = GtfsStopTableContainer.forStatus(TableStatus.MISSING_FILE);
+        new MissingStopsFileValidator(stopTableContainer, geoJsonFeaturesContainer).validate(noticeContainer);
+        assertThat(noticeContainer.getValidationNotices())
+            .containsExactly(new MissingRequiredFileNotice("stops.txt"));
+    }
+
+    @Test
+    public void stopsTxtMissingFileShouldNotGenerateNotice() {
+        // If stops.txt is missing, but locations.geojson is present, no notice should be generated
+        NoticeContainer noticeContainer = new NoticeContainer();
+        GtfsGeojsonFileDescriptor descriptor = new GtfsGeojsonFileDescriptor();
+        GtfsGeojsonFeaturesContainer geoJsonFeaturesContainer = descriptor.createContainerForEntities(
+            new ArrayList<>(), noticeContainer
+        );
+        GtfsStopTableContainer stopTableContainer = GtfsStopTableContainer.forStatus(TableStatus.MISSING_FILE);
+        new MissingStopsFileValidator(stopTableContainer, geoJsonFeaturesContainer).validate(noticeContainer);
+        assertThat(noticeContainer.getValidationNotices()).isEmpty();
+    }
+}


### PR DESCRIPTION
**Summary:**

Modifies `stops.txt` to be conditionally required.
Logic: If `stops.txt` doesn't exist, only trigger a `missing_required_file` notice if `locations.geojson` also doesn't exist.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
