### PR TITLE
feat: modified stop_too_far_from_shape so it only checks stop times record with a stop_id

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeToStopMatchingValidator.java
@@ -174,6 +174,10 @@ public class ShapeToStopMatchingValidator extends FileValidator {
       Set<String> reportedStopIds,
       NoticeContainer noticeContainer) {
     for (Problem problem : problems) {
+      if (problem.getStopTime().stopId().isEmpty()) {
+        // Ignore stop times without a stop_id
+        continue;
+      }
       if (problem.getType().equals(ProblemType.STOP_TOO_FAR_FROM_SHAPE)
           && !reportedStopIds.add(problem.getStopTime().stopId())) {
         // Ignore stops already reported before.


### PR DESCRIPTION
**Summary:**
Closes #1881 

**Expected behavior:** 
modified stop_too_far_from_shape so it only checks stop times records that have a stop_id. It should ignore stop times that don't have a stop_id.

Before:
<img width="1707" alt="image" src="https://github.com/user-attachments/assets/41893aca-060e-4809-ad2a-86919bd4c101">
After:
<img width="1708" alt="image" src="https://github.com/user-attachments/assets/1f67e00c-5b78-4768-9c03-6e49631ccf1a">

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
