### PR TITLE
docs: Clarified below threshold language in notices

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ShapeIncreasingDistanceValidator.java
@@ -239,11 +239,11 @@ public class ShapeIncreasingDistanceValidator extends FileValidator {
 
   /**
    * Two consecutive points have equal `shape_dist_traveled` and different lat/lon coordinates in
-   * `shapes.txt` and the distance between the two points is less than 1.11m.
+   * `shapes.txt` and the distance between the two points is greater than 0 but less than 1.11m.
    *
    * <p>When sorted by `shape.shape_pt_sequence`, the values for `shape_dist_traveled` must increase
    * along a shape. Two consecutive points with equal values for `shape_dist_traveled` and small
-   * difference of coordinates (less than 1.11 m distance) result in a warning.
+   * difference of coordinates (greater than 0 but less than 1.11 m distance) result in a warning.
    */
   @GtfsValidationNotice(
       severity = WARNING,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidator.java
@@ -139,7 +139,7 @@ public class TripAndShapeDistanceValidator extends FileValidator {
   }
 
   /**
-   * The distance between the last shape point and last stop point is less than the 11.1m threshold.
+   * The distance between the last shape point and last stop point is greater than 0 but less than the 11.1m threshold.
    */
   @GtfsValidationNotice(
       severity = WARNING,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidator.java
@@ -139,7 +139,8 @@ public class TripAndShapeDistanceValidator extends FileValidator {
   }
 
   /**
-   * The distance between the last shape point and last stop point is greater than 0 but less than the 11.1m threshold.
+   * The distance between the last shape point and last stop point is greater than 0 but less than
+   * the 11.1m threshold.
    */
   @GtfsValidationNotice(
       severity = WARNING,


### PR DESCRIPTION
**Summary:**

We received some user feedback that the `trip_distance_exceeds_shape_distance_below_threshold` and `equal_shape_distance_diff_coordinates_below_threshold` notice language was confusing. Added description about the value being greater than 0 but below the threshold to more clearly convey this.

**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).


Please make sure these boxes are checked before submitting your pull request - thanks!

- [X ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
