### PR TITLE
ci: aling matrix dimensions to max concurrent jobs

### DIFF
--- a/scripts/mobility-database-harvester/harvest_latest_versions.py
+++ b/scripts/mobility-database-harvester/harvest_latest_versions.py
@@ -42,7 +42,8 @@ URL_PREFIX = "https://storage.googleapis.com/storage/v1/b/mdb-latest/o/"
 URL_SUFFIX = ".zip?alt=media"
 
 # Github constants
-MAX_JOB_NUMBER = 256
+# As per https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration#usage-limits
+MAX_JOB_NUMBER = 60
 
 # json keys
 ROOT = "include"


### PR DESCRIPTION
**Summary:**

Currently, the number of concurrent jobs is limited by the type of account the organization is holding. As a Team account, we have 60 maximum number of jobs that can concurrently be executed at a time. Having 256 rows in the acceptance tests has two main issues. The first only 60 can be executed concurrently so having more than 60 will make the agents wait and don't add any value as a concurrent job. Secondly, the billable time is computed per second, but the minimum billable time is one minute; all the jobs completed before one minute will be charged one minute, `loosing` few seconds per small job.

**Expected behavior:** 

Acceptance tests passes and the resources are more efficient used.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
