### PR TITLE
feat: Use a github variable containing 1password secret references

### DIFF
--- a/.github/actions/extract-1password-secret/action.yml
+++ b/.github/actions/extract-1password-secret/action.yml
@@ -1,0 +1,51 @@
+name: 'Extract secrets from 1Password'
+description: 'Extracts secrets from 1Password using a Github variable containing multiple secret references'
+inputs:
+  VARIABLES_TO_EXTRACT:
+    description: 'A list of comma separated secrets to extract'
+    required: true
+    type: string
+  ONE_PASSWORD_SECRET_REFERENCES:
+    description: 'The contents of the ONE_PASSWORD_SECRET_REFERENCES variable, containing key-value pairs of secret references'
+    required: true
+    type: string
+  OP_SERVICE_ACCOUNT_TOKEN:
+    description: 'The 1Password service account token'
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Extract value for specific key
+      id: extract_value
+      shell: bash
+      # One possible error is that the specified variable name does not exist in the ONE_PASSWORD_SECRET_REFERENCES variable
+      # In that case just go over it
+      continue-on-error: true
+      run: |
+        # Replace command with spaces to it's easier to iterate over the key-value pairs
+        keys=$(echo "${{ inputs.VARIABLES_TO_EXTRACT }}" | tr ',' ' ')
+        for key in $keys; do
+           # Remove leading and trailing spaces 
+           variable_name=$(echo "$key" | sed 's/^ *//;s/ *$//')
+           value=$(echo "${{ inputs.ONE_PASSWORD_SECRET_REFERENCES }}" | grep "^$variable_name *=" | cut -d'=' -f2- | sed 's/^ *//;s/[ \r]*$//')
+           # For each variable to extract create an env variable with the secret reference as a value
+           echo "$variable_name=$value" >> $GITHUB_ENV
+           echo "$variable_name=$value"
+        done
+
+    - name: Load secrets from 1Password
+      id: onepw_secrets
+      uses: 1password/load-secrets-action@v2.0.0
+      with:
+        export-env: true # Export loaded secrets as environment variables
+      env:
+        # 1password/load-secrets-action will take any defined env variable and try to get the secret value from 1Password
+        # I think it does this only for variables that start with op://
+        # That means all variables defined in the previous step will be loaded from 1Password if they exist.
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }} # This is required to connect to the vault in our 1Password account.
+
+# After the previous step all variables specified in VARIABLES_TO_EXTRACT should have an env variable with the
+# secret as a value. If they don't exist in 1Password they will be left as is, meaning that will still contain the
+# secret reference.

--- a/.github/actions/extract-1password-secret/action.yml
+++ b/.github/actions/extract-1password-secret/action.yml
@@ -24,7 +24,7 @@ runs:
       # In that case just go over it
       continue-on-error: true
       run: |
-        # Replace commas with spaces to it's easier to iterate over the key-value pairs
+        # Replace commas with spaces so it's easier to iterate over the key-value pairs
         keys=$(echo "${{ inputs.VARIABLES_TO_EXTRACT }}" | tr ',' ' ')
         for key in $keys; do
            # Remove leading and trailing spaces 

--- a/.github/actions/extract-1password-secret/action.yml
+++ b/.github/actions/extract-1password-secret/action.yml
@@ -17,10 +17,10 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Extract value for specific key
-      id: extract_value
+    - name: Extract 1password secret references for specific variables
+      id: extract_secret_references
       shell: bash
-      # One possible error is that the specified variable name does not exist in the ONE_PASSWORD_SECRET_REFERENCES variable
+      # One possible error is that the specified variable name does not exist in the ONE_PASSWORD_SECRET_REFERENCES variable.
       # In that case just go over it
       continue-on-error: true
       run: |

--- a/.github/actions/extract-1password-secret/action.yml
+++ b/.github/actions/extract-1password-secret/action.yml
@@ -24,7 +24,7 @@ runs:
       # In that case just go over it
       continue-on-error: true
       run: |
-        # Replace command with spaces to it's easier to iterate over the key-value pairs
+        # Replace commas with spaces to it's easier to iterate over the key-value pairs
         keys=$(echo "${{ inputs.VARIABLES_TO_EXTRACT }}" | tr ',' ' ')
         for key in $keys; do
            # Remove leading and trailing spaces 

--- a/.github/workflows/publish_assets.yml
+++ b/.github/workflows/publish_assets.yml
@@ -11,9 +11,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-
+      # Get the version from the commit. This will depend on the trigger of the workflow
+      # If the trigger is release, the version will be the tag on the commit.
+      # If the trigger is a workflow_dispatch, the version will be the branch name, which is
+      # not really useful.
       - id: get_version
         uses: battila7/get-version-action@v2
+
+      - name: printVersion
+        run: echo "The version extracted from github.ref is ${{ steps.get_version.outputs.version }}"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -83,19 +89,15 @@ jobs:
 
       - name: Load secrets from 1Password
         id: onepw_secrets
-        uses: 1password/load-secrets-action@v2.0.0
+        uses: ./.github/actions/extract-1password-secret
         with:
-          export-env: true # Export loaded secrets as environment variables
-        env:
           OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }} # This is required to connect to the vault in our 1Password account.
-          MAVEN_GPG_PRIVATE_KEY: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/yztcx47yzp4vizjyaq7ulvkgoi/Private Key"
-          MAVEN_GPG_PASSPHRASE: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/yztcx47yzp4vizjyaq7ulvkgoi/password"
+          VARIABLES_TO_EXTRACT: 'MAVEN_GPG_PASSPHRASE, MAVEN_GPG_PRIVATE_KEY, SONATYPE_TOKEN_USERNAME, SONATYPE_TOKEN_PASSWORD'
+          ONE_PASSWORD_SECRET_REFERENCES: ${{ vars.ONE_PASSWORD_SECRET_REFERENCES }}
 
       - name: Build and Publish to Sonatype
         run: |
           # The gradle java verifying plugin does not work with java 17.
           # Don't verify since it has already been done when the PR was created.
-          ./gradlew publish -x verifyGoogleJavaFormat
-        env:
-          SONATYPE_USERNAME: ${{secrets.SONATYPE_USERNAME}}
-          SONATYPE_PASSWORD: ${{secrets.SONATYPE_PASSWORD}}
+          ./gradlew publish --rerun-tasks -x verifyGoogleJavaFormat
+

--- a/.github/workflows/stg_web_svc_merge.yml
+++ b/.github/workflows/stg_web_svc_merge.yml
@@ -56,16 +56,16 @@ jobs:
 
       - name: Load secrets from 1Password to be used for sending notification
         id: onepw_secrets
-        uses: 1password/load-secrets-action@v2.0.0
+        uses: ./.github/actions/extract-1password-secret
         with:
-          export-env: true # Export loaded secrets as environment variables
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }} # This is required to connect to the vault in our 1Password account.
+          VARIABLES_TO_EXTRACT: 'GITHUB_GENERIC_ACTION_CREDENTIALS'
+          ONE_PASSWORD_SECRET_REFERENCES: ${{ vars.ONE_PASSWORD_SECRET_REFERENCES }}
+
 
       - name: Send a notification to mobility-feed-api
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ env.CREDENTIALS }}
+          token: ${{ env.GITHUB_GENERIC_ACTION_CREDENTIALS }}
           repository: MobilityData/mobility-feed-api
           event-type: gtfs-validator-update-stg

--- a/.github/workflows/web_release.yml
+++ b/.github/workflows/web_release.yml
@@ -54,16 +54,15 @@ jobs:
 
       - name: Load secrets from 1Password to be used for sending notification
         id: onepw_secrets
-        uses: 1password/load-secrets-action@v2.0.0
+        uses: ./.github/actions/extract-1password-secret
         with:
-          export-env: true # Export loaded secrets as environment variables
-        env:
-          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-          CREDENTIALS: "op://rbiv7rvkkrsdlpcrz3bmv7nmcu/ifkeehu5gzi7wy5ub5qvwkaire/credential"
+          OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }} # This is required to connect to the vault in our 1Password account.
+          VARIABLES_TO_EXTRACT: 'GITHUB_GENERIC_ACTION_CREDENTIALS'
+          ONE_PASSWORD_SECRET_REFERENCES: ${{ vars.ONE_PASSWORD_SECRET_REFERENCES }}
 
       - name: Send a notification to mobility-feed-api
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ env.CREDENTIALS }}
+          token: ${{ env.GITHUB_GENERIC_ACTION_CREDENTIALS }}
           repository: MobilityData/mobility-feed-api
           event-type: gtfs-validator-release

--- a/build.gradle
+++ b/build.gradle
@@ -17,8 +17,8 @@
  * A note about publishing and signing.
  * Maven central requires that artifacts be signed. And upload is done to Sonatype.
  * To publish you will need these environment variables defined:
- *       SONATYPE_USERNAME
- *       SONATYPE_PASSWORD
+ *       SONATYPE_TOKEN_USERNAME
+ *       SONATYPE_TOKEN_PASSWORD
  *       MAVEN_GPG_PRIVATE_KEY
  *       MAVEN_GPG_PASSPHRASE
  * Suggestion is to put these in a shell script with restricted read permissions, then source it before calling
@@ -119,8 +119,8 @@ subprojects {
                     maven {
                         url = 'https://s01.oss.sonatype.org/service/local/staging/deploy/maven2'
                         credentials {
-                            username System.getenv("SONATYPE_USERNAME")
-                            password System.getenv("SONATYPE_PASSWORD")
+                            username System.getenv("SONATYPE_TOKEN_USERNAME")
+                            password System.getenv("SONATYPE_TOKEN_PASSWORD")
                         }
                     }
                 }


### PR DESCRIPTION
Closes #1906 
**Summary:**

Set the proper 1password secret references that were changed at one point making the publication to Sonatype fail.

Added the use of a github repo variable `ONE_PASSWORD_SECRET_REFERENCES` containing key-value pairs for the secret references:
```
SONATYPE_TOKEN_USERNAME = op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Sonatype user token/username
SONATYPE_TOKEN_PASSWORD = op://rbiv7rvkkrsdlpcrz3bmv7nmcu/Sonatype user token/password
MAVEN_GPG_PRIVATE_KEY = op://rbiv7rvkkrsdlpcrz3bmv7nmcu/dkkfywvsr3xq6eyeubq6cldaxi/Private Key
MAVEN_GPG_PASSPHRASE = op://rbiv7rvkkrsdlpcrz3bmv7nmcu/dkkfywvsr3xq6eyeubq6cldaxi/password
GITHUB_GENERIC_ACTION_CREDENTIALS = op://rbiv7rvkkrsdlpcrz3bmv7nmcu/GitHub generic action token for all repos/credential
```
The secret references in this variable are obtained from 1password.
So this introduced one level of indirection where the Github workflow should not contain any 1password references. Instead use the `.github/actions/extract-1password-secret/action.yml` composite action to obtain 1password secrets from an input list specifying the secret of interest.
See the documentation in `.github/actions/extract-1password-secret/action.yml`

Tested by creating a pre-release and making sure the proper jars are uploaded to Sonaytpe.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
