### PR TITLE
feat: rename unused_parent_station rule to unused_station

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentStationValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ParentStationValidator.java
@@ -40,7 +40,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeSchema;
  *
  * <ul>
  *   <li>{@link WrongParentLocationTypeNotice}.
- *   <li>{@link UnusedParentStationNotice}.
+ *   <li>{@link UnusedStationNotice}.
  * </ul>
  */
 @GtfsValidator
@@ -114,7 +114,7 @@ public class ParentStationValidator extends FileValidator {
       }
       GtfsStop stationStop = optionalStationStop.get();
       noticeContainer.addValidationNotice(
-          new UnusedParentStationNotice(
+          new UnusedStationNotice(
               stationStop.csvRowNumber(), stationStop.stopId(), stationStop.stopName()));
     }
   }
@@ -190,12 +190,12 @@ public class ParentStationValidator extends FileValidator {
   }
 
   /**
-   * Unused parent station.
+   * Unused station.
    *
    * <p>A stop has `location_type` STATION (1) but does not appear in any stop's `parent_station`.
    */
   @GtfsValidationNotice(severity = INFO, files = @FileRefs({GtfsStopSchema.class}))
-  static class UnusedParentStationNotice extends ValidationNotice {
+  static class UnusedStationNotice extends ValidationNotice {
     /** The row number of the faulty record. */
     private final int csvRowNumber;
 
@@ -205,7 +205,7 @@ public class ParentStationValidator extends FileValidator {
     /** The name of the faulty stop. */
     private final String stopName;
 
-    UnusedParentStationNotice(int csvRowNumber, String stopId, String stopName) {
+    UnusedStationNotice(int csvRowNumber, String stopId, String stopName) {
       this.csvRowNumber = csvRowNumber;
       this.stopId = stopId;
       this.stopName = stopName;

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentStationValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ParentStationValidatorTest.java
@@ -28,7 +28,7 @@ import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsLocationType;
 import org.mobilitydata.gtfsvalidator.table.GtfsStop;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTableContainer;
-import org.mobilitydata.gtfsvalidator.validator.ParentStationValidator.UnusedParentStationNotice;
+import org.mobilitydata.gtfsvalidator.validator.ParentStationValidator.UnusedStationNotice;
 import org.mobilitydata.gtfsvalidator.validator.ParentStationValidator.WrongParentLocationTypeNotice;
 
 @RunWith(JUnit4.class)
@@ -94,7 +94,7 @@ public class ParentStationValidatorTest {
   public void entranceParent() {
     assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE, GtfsLocationType.STATION))
         // No issue with the types, but the station has no stop (just an entrance).
-        .containsExactly(new UnusedParentStationNotice(2, "parent", "Parent location"));
+        .containsExactly(new UnusedStationNotice(2, "parent", "Parent location"));
     assertThat(validateChildAndParent(GtfsLocationType.ENTRANCE, GtfsLocationType.STOP))
         .containsExactly(
             new WrongParentLocationTypeNotice(
@@ -113,7 +113,7 @@ public class ParentStationValidatorTest {
   public void genericNodeParent() {
     assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE, GtfsLocationType.STATION))
         // No issue with the types, but the station has no stop.
-        .containsExactly(new UnusedParentStationNotice(2, "parent", "Parent location"));
+        .containsExactly(new UnusedStationNotice(2, "parent", "Parent location"));
     assertThat(validateChildAndParent(GtfsLocationType.GENERIC_NODE, GtfsLocationType.STOP))
         .containsExactly(
             new WrongParentLocationTypeNotice(
@@ -145,7 +145,7 @@ public class ParentStationValidatorTest {
                     "Parent location",
                     GtfsLocationType.STATION.getNumber(),
                     GtfsLocationType.STOP.getNumber()),
-                new UnusedParentStationNotice(2, "parent", "Parent location")));
+                new UnusedStationNotice(2, "parent", "Parent location")));
   }
 
   @Test
@@ -185,7 +185,7 @@ public class ParentStationValidatorTest {
                 noticeContainer))
         .validate(noticeContainer);
     assertThat(noticeContainer.getValidationNotices())
-        .containsExactly(new UnusedParentStationNotice(2, "unused_station", "Unused station"));
+        .containsExactly(new UnusedStationNotice(2, "unused_station", "Unused station"));
   }
 
   @Test


### PR DESCRIPTION
**Summary:**

See title. As per #1604, "unused_parent_station" is a bit of a misnomer because a station without any stops is not, by definition, a parent station.

Closes #1604

**Expected behavior:** 

The "unused_parent_station" rule is now called "unused_station", including in [rules.html](https://gtfs-validator.mobilitydata.org/rules.html).

**Testing:**

Three tests are failing when I run `gradle test` but they fail on the master branch as well:
- JsonReportSummaryTest.withFeedMetadataNoConfigTest
- JsonReportSummaryTest.withFeedMetadataWithConfigTest
- VersionResolverTest.classMethod

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
