### PR TITLE
feat: added dynamic fields for point near origin and poles

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearOriginNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearOriginNotice.java
@@ -35,19 +35,22 @@ public class PointNearOriginNotice extends ValidationNotice {
   private final String filename;
 
   /** The row of the faulty row. */
-  private final int csvRowNumber;
+  @Nullable private final Integer csvRowNumber;
+
+  /** The index of the feature in the feature collection. */
+  @Nullable private final Integer featureIndex;
 
   /** The id of the faulty entity. */
   @Nullable private final String entityId;
 
   /** The name of the field that uses latitude value. */
-  private final String latFieldName;
+  @Nullable private final String latFieldName;
 
   /** The latitude of the faulty row. */
   private final double latFieldValue;
 
   /** The name of the field that uses longitude value. */
-  private final String lonFieldName;
+  @Nullable private final String lonFieldName;
 
   /** The longitude of the faulty row */
   private final double lonFieldValue;
@@ -67,6 +70,7 @@ public class PointNearOriginNotice extends ValidationNotice {
     this.latFieldValue = latFieldValue;
     this.lonFieldName = lonFieldName;
     this.lonFieldValue = lonFieldValue;
+    this.featureIndex = null;
   }
 
   public PointNearOriginNotice(
@@ -83,5 +87,22 @@ public class PointNearOriginNotice extends ValidationNotice {
     this.latFieldValue = latFieldValue;
     this.lonFieldName = lonFieldName;
     this.lonFieldValue = lonFieldValue;
+    this.featureIndex = null;
+  }
+
+  public PointNearOriginNotice(
+      String filename,
+      String entityId,
+      double latFieldValue,
+      double lonFieldValue,
+      int featureIndex) {
+    this.filename = filename;
+    this.csvRowNumber = null;
+    this.entityId = entityId;
+    this.latFieldName = null;
+    this.latFieldValue = latFieldValue;
+    this.lonFieldName = null;
+    this.lonFieldValue = lonFieldValue;
+    this.featureIndex = featureIndex;
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/PointNearPoleNotice.java
@@ -35,21 +35,24 @@ public class PointNearPoleNotice extends ValidationNotice {
   private final String filename;
 
   /** The row of the faulty row. */
-  private final int csvRowNumber;
+  @Nullable private final Integer csvRowNumber;
+
+  /** The index of the feature in the feature collection. */
+  @Nullable private final Integer featureIndex;
 
   /** The id of the faulty entity. */
   @Nullable private final String entityId;
 
   /** The name of the field that uses latitude value. */
-  private final String latFieldName;
+  @Nullable private final String latFieldName;
 
   /** The latitude of the faulty row. */
   private final double latFieldValue;
 
   /** The name of the field that uses longitude value. */
-  private final String lonFieldName;
+  @Nullable private final String lonFieldName;
 
-  /** The longitude of the faulty row. */
+  /** The longitude of the faulty row */
   private final double lonFieldValue;
 
   public PointNearPoleNotice(
@@ -67,6 +70,7 @@ public class PointNearPoleNotice extends ValidationNotice {
     this.latFieldValue = latFieldValue;
     this.lonFieldName = lonFieldName;
     this.lonFieldValue = lonFieldValue;
+    this.featureIndex = null;
   }
 
   public PointNearPoleNotice(
@@ -83,5 +87,22 @@ public class PointNearPoleNotice extends ValidationNotice {
     this.latFieldValue = latFieldValue;
     this.lonFieldName = lonFieldName;
     this.lonFieldValue = lonFieldValue;
+    this.featureIndex = null;
+  }
+
+  public PointNearPoleNotice(
+      String filename,
+      String entityId,
+      double latFieldValue,
+      double lonFieldValue,
+      int featureIndex) {
+    this.filename = filename;
+    this.csvRowNumber = null;
+    this.entityId = entityId;
+    this.latFieldName = null;
+    this.latFieldValue = latFieldValue;
+    this.lonFieldName = null;
+    this.lonFieldValue = lonFieldValue;
+    this.featureIndex = featureIndex;
   }
 }


### PR DESCRIPTION
**Summary:**
- Added `featureIndex` as a dynamic field for both `point_near_origin` and `point_near_pole` notices 
- Made fields that are not applicable to `locations.geojson` dynamic: `csvRowNumber`, `latFieldName`, `lonFieldName`
- Added validation and tests for `coordinates` in `locations.geojson`

**Expected behavior:** 
![image](https://github.com/user-attachments/assets/8e17f7c0-ab12-40b1-a17b-6c35500e5a7e)


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
