### PR TITLE
fix: sort expired_calendar notices by row number

### DIFF
--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ExpiredCalendarValidatorTest.java
@@ -317,6 +317,12 @@ public class ExpiredCalendarValidatorTest {
                     .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_ADDED)
                     .build(),
                 new GtfsCalendarDate.Builder()
+                    .setCsvRowNumber(4)
+                    .setServiceId("SERVICE_ID_4")
+                    .setDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(7)))
+                    .setExceptionType(GtfsCalendarDateExceptionType.SERVICE_ADDED)
+                    .build(),
+                new GtfsCalendarDate.Builder()
                     .setCsvRowNumber(1)
                     .setServiceId("SERVICE_ID_1")
                     .setDate(GtfsDate.fromLocalDate(TEST_NOW.minusDays(1)))
@@ -326,9 +332,12 @@ public class ExpiredCalendarValidatorTest {
     new ExpiredCalendarValidator(new DateForValidation(TEST_NOW), calendarTable, calendarDateTable)
         .validate(container);
     assertThat(container.getValidationNotices())
+        // We verify that entries are sorted by row number.
         .containsExactly(
-            new ExpiredCalendarValidator.ExpiredCalendarNotice(3, "SERVICE_ID_3"),
+            new ExpiredCalendarValidator.ExpiredCalendarNotice(1, "SERVICE_ID_1"),
             new ExpiredCalendarValidator.ExpiredCalendarNotice(2, "SERVICE_ID_2"),
-            new ExpiredCalendarValidator.ExpiredCalendarNotice(1, "SERVICE_ID_1"));
+            new ExpiredCalendarValidator.ExpiredCalendarNotice(3, "SERVICE_ID_3"),
+            new ExpiredCalendarValidator.ExpiredCalendarNotice(4, "SERVICE_ID_4"))
+        .inOrder();
   }
 }


### PR DESCRIPTION
**Summary:**

This PR updates the validator for the expired_calendar rule to sort notices by row number.

Closes #1931 

**Expected behavior:** 

expired_calendar notices are sorted by row number in ascending order.

**Testing:**

I used the first sample file in #1931 and validated with and without my changes.

Before:

csvRowNumber | serviceId
-- | --
113 | "66"
137 | "67"
199 | "68"
41 | "27"
42 | "28"
43 | "29"
... | ...

After:

csvRowNumber | serviceId
-- | --
2 | "36"
3 | "37"
4 | "38"
5 | "39"
6 | "40"
7 | "34"
... | ...

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
