### PR TITLE
fix: fix logic to check for nested GTFS files in ZIP

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
@@ -56,11 +56,12 @@ public abstract class GtfsInput implements Closeable {
       return new GtfsUnarchivedInput(path);
     }
     String fileName = path.getFileName().toString().replace(".zip", "");
-    ZipFile zipFile = path.getFileSystem().equals(FileSystems.getDefault())
-        // Read from a local ZIP file.
-        ? new ZipFile(path.toFile())
-        // Load a remote ZIP file to memory.
-        : new ZipFile(new SeekableInMemoryByteChannel(Files.readAllBytes(path)));
+    ZipFile zipFile =
+        path.getFileSystem().equals(FileSystems.getDefault())
+            // Read from a local ZIP file.
+            ? new ZipFile(path.toFile())
+            // Load a remote ZIP file to memory.
+            : new ZipFile(new SeekableInMemoryByteChannel(Files.readAllBytes(path)));
 
     if (hasSubfolderWithGtfsFile(path)) {
       noticeContainer.addValidationNotice(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
@@ -49,7 +49,6 @@ public abstract class GtfsInput implements Closeable {
    */
   public static GtfsInput createFromPath(Path path, NoticeContainer noticeContainer)
       throws IOException {
-    ZipFile zipFile;
     if (!Files.exists(path)) {
       throw new FileNotFoundException(path.toString());
     }
@@ -57,18 +56,12 @@ public abstract class GtfsInput implements Closeable {
       return new GtfsUnarchivedInput(path);
     }
     String fileName = path.getFileName().toString().replace(".zip", "");
-    if (path.getFileSystem().equals(FileSystems.getDefault())) {
-      // Read from a local ZIP file.
-      zipFile = new ZipFile(path.toFile());
-      if (hasSubfolderWithGtfsFile(path)) {
-        noticeContainer.addValidationNotice(
-            new InvalidInputFilesInSubfolderNotice(invalidInputMessage));
-      }
+    ZipFile zipFile = path.getFileSystem().equals(FileSystems.getDefault())
+        // Read from a local ZIP file.
+        ? new ZipFile(path.toFile())
+        // Load a remote ZIP file to memory.
+        : new ZipFile(new SeekableInMemoryByteChannel(Files.readAllBytes(path)));
 
-      return new GtfsZipFileInput(zipFile, fileName);
-    }
-    // Load a remote ZIP file to memory.
-    zipFile = new ZipFile(new SeekableInMemoryByteChannel(Files.readAllBytes(path)));
     if (hasSubfolderWithGtfsFile(path)) {
       noticeContainer.addValidationNotice(
           new InvalidInputFilesInSubfolderNotice(invalidInputMessage));
@@ -98,23 +91,13 @@ public abstract class GtfsInput implements Closeable {
    */
   private static boolean containsGtfsFileInSubfolder(ZipInputStream zipInputStream)
       throws IOException {
-    boolean containsSubfolder = false;
-    String subfolder = null;
     ZipEntry entry;
     while ((entry = zipInputStream.getNextEntry()) != null) {
-      String entryName = entry.getName();
-
-      if (entry.isDirectory()) {
-        subfolder = entryName;
-        containsSubfolder = true;
-      }
-      if (containsSubfolder && entryName.contains(subfolder) && entryName.endsWith(".txt")) {
-        String[] files = entryName.split("/");
-        String lastElement = files[files.length - 1];
-
-        if (GtfsFiles.containsGtfsFile(lastElement)) {
-          return true;
-        }
+      String[] nameParts = entry.getName().split("/");
+      boolean isInSubfolder = nameParts.length > 1;
+      boolean isGtfsFile = GtfsFiles.containsGtfsFile(nameParts[nameParts.length - 1]);
+      if (isInSubfolder && isGtfsFile) {
+        return true;
       }
     }
     return false;


### PR DESCRIPTION
**Summary:**

This PR fixes a bug with our logic to check whether a ZIP file we're loading has GTFS files in a subfolder. It looks like `ZipInputStream.getNextEntry` doesn't always return subfolders, depending on how the ZIP file was created. The subfolder and ZIP file having the same name in #1912 was a red herring.

<details>
```
$ unzip -l piercetransit-wa-us--flex-v2.zip
Archive:  piercetransit-wa-us--flex-v2.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      170  11-28-2023 15:22   piercetransit-wa-us--flex-v2/timetables.txt
       81  11-28-2023 15:22   piercetransit-wa-us--flex-v2/fare_attributes.txt
       18  11-28-2023 15:22   piercetransit-wa-us--flex-v2/stop_attributes.txt
       56  11-28-2023 15:22   piercetransit-wa-us--flex-v2/transfers.txt
      183  11-28-2023 15:22   piercetransit-wa-us--flex-v2/agency.txt
       12  11-28-2023 15:22   piercetransit-wa-us--flex-v2/areas.txt
       54  11-28-2023 15:22   piercetransit-wa-us--flex-v2/fare_rules.txt
      437  11-28-2023 15:22   piercetransit-wa-us--flex-v2/calendar_dates.txt
     4367  11-28-2023 15:22   piercetransit-wa-us--flex-v2/stop_times.txt
      374  11-28-2023 15:22   piercetransit-wa-us--flex-v2/location_groups.txt
      137  11-28-2023 15:22   piercetransit-wa-us--flex-v2/directions.txt
       53  11-28-2023 15:22   piercetransit-wa-us--flex-v2/frequencies.txt
       18  11-28-2023 15:22   piercetransit-wa-us--flex-v2/farezone_attributes.txt
      895  11-28-2023 15:22   piercetransit-wa-us--flex-v2/shapes.txt
      983  11-28-2023 15:22   piercetransit-wa-us--flex-v2/trips.txt
      355  11-28-2023 15:22   piercetransit-wa-us--flex-v2/feed_info.txt
     2051  11-28-2023 15:22   piercetransit-wa-us--flex-v2/locations.geojson
      104  11-28-2023 15:22   piercetransit-wa-us--flex-v2/runcut.txt
     2170  11-28-2023 15:22   piercetransit-wa-us--flex-v2/stops.txt
      117  11-28-2023 15:22   piercetransit-wa-us--flex-v2/linked_datasets.txt
      131  11-28-2023 15:22   piercetransit-wa-us--flex-v2/calendar_attributes.txt
       62  11-28-2023 15:22   piercetransit-wa-us--flex-v2/timetable_stop_order.txt
     1745  11-28-2023 15:22   piercetransit-wa-us--flex-v2/booking_rules.txt
      265  11-28-2023 15:22   piercetransit-wa-us--flex-v2/calendar.txt
      520  11-28-2023 15:22   piercetransit-wa-us--flex-v2/routes.txt
---------                     -------
    15358                     25 files
$ mv piercetransit-wa-us--flex-v2.zip foobar.zip
$ unzip -l foobar.zip
Archive:  foobar.zip
  Length      Date    Time    Name
---------  ---------- -----   ----
      170  11-28-2023 15:22   piercetransit-wa-us--flex-v2/timetables.txt
       81  11-28-2023 15:22   piercetransit-wa-us--flex-v2/fare_attributes.txt
       18  11-28-2023 15:22   piercetransit-wa-us--flex-v2/stop_attributes.txt
       56  11-28-2023 15:22   piercetransit-wa-us--flex-v2/transfers.txt
      183  11-28-2023 15:22   piercetransit-wa-us--flex-v2/agency.txt
       12  11-28-2023 15:22   piercetransit-wa-us--flex-v2/areas.txt
       54  11-28-2023 15:22   piercetransit-wa-us--flex-v2/fare_rules.txt
      437  11-28-2023 15:22   piercetransit-wa-us--flex-v2/calendar_dates.txt
     4367  11-28-2023 15:22   piercetransit-wa-us--flex-v2/stop_times.txt
      374  11-28-2023 15:22   piercetransit-wa-us--flex-v2/location_groups.txt
      137  11-28-2023 15:22   piercetransit-wa-us--flex-v2/directions.txt
       53  11-28-2023 15:22   piercetransit-wa-us--flex-v2/frequencies.txt
       18  11-28-2023 15:22   piercetransit-wa-us--flex-v2/farezone_attributes.txt
      895  11-28-2023 15:22   piercetransit-wa-us--flex-v2/shapes.txt
      983  11-28-2023 15:22   piercetransit-wa-us--flex-v2/trips.txt
      355  11-28-2023 15:22   piercetransit-wa-us--flex-v2/feed_info.txt
     2051  11-28-2023 15:22   piercetransit-wa-us--flex-v2/locations.geojson
      104  11-28-2023 15:22   piercetransit-wa-us--flex-v2/runcut.txt
     2170  11-28-2023 15:22   piercetransit-wa-us--flex-v2/stops.txt
      117  11-28-2023 15:22   piercetransit-wa-us--flex-v2/linked_datasets.txt
      131  11-28-2023 15:22   piercetransit-wa-us--flex-v2/calendar_attributes.txt
       62  11-28-2023 15:22   piercetransit-wa-us--flex-v2/timetable_stop_order.txt
     1745  11-28-2023 15:22   piercetransit-wa-us--flex-v2/booking_rules.txt
      265  11-28-2023 15:22   piercetransit-wa-us--flex-v2/calendar.txt
      520  11-28-2023 15:22   piercetransit-wa-us--flex-v2/routes.txt
---------                     -------
    15358                     25 files
```
</details>

Closes #1912

**Expected behavior:** 

We get a invalid_input_files_in_subfolder notice even if the subfolder is not treated as a standalone entry.

**Testing:**

Before:
<img width="753" alt="image" src="https://github.com/user-attachments/assets/79a24d67-9200-4d29-819d-c46a775c2ab1" />

After:
<img width="753" alt="image" src="https://github.com/user-attachments/assets/14f0723c-cb0d-44eb-b2a0-c7a023b99f11" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)