### PR TITLE
feat: publish the Java GUI as a independent jar asset

### DIFF
--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -140,7 +140,7 @@ jobs:
            --app-image "${{ env.MACOS_TARGET_PATH }}" \
            --dest ${{ env.MACOS_TARGET_DEST_PATH }}
 
-      - name: Package cli and gui app jar with Gradle
+      - name: Package cli and gui app jars with Gradle
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/actions/setup-gradle@v3
         with:

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -140,7 +140,7 @@ jobs:
            --app-image "${{ env.MACOS_TARGET_PATH }}" \
            --dest ${{ env.MACOS_TARGET_DEST_PATH }}
 
-      - name: Package cli app jar with Gradle
+      - name: Package cli and gui app jar with Gradle
         if: ${{ matrix.os == 'ubuntu-latest' }}
         uses: gradle/actions/setup-gradle@v3
         with:
@@ -152,6 +152,13 @@ jobs:
         with:
           name: "gtfs-validator-cli-${{ env.SHORT_SHA }}.zip"
           path: cli/build/libs/gtfs-validator-*-cli.jar
+
+      - name: Persist gui app jar
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: "gtfs-validator-gui-${{ env.SHORT_SHA }}.zip"
+          path: app/gui/build/libs/gui-*-all.jar
 
       - name: "Upload Installer"
         uses: actions/upload-artifact@v4

--- a/.github/workflows/publish_assets.yml
+++ b/.github/workflows/publish_assets.yml
@@ -35,7 +35,7 @@ jobs:
         if: github.event_name == 'release'
         run: ./gradlew shadowJar
 
-      - name: Upload JAR Asset
+      - name: Upload CLI JAR Asset
         if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
@@ -44,6 +44,17 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./cli/build/libs/gtfs-validator-${{ steps.get_version.outputs.version-without-v }}-cli.jar
           asset_name: gtfs-validator-${{ steps.get_version.outputs.version-without-v }}-cli.jar
+          asset_content_type: application/java-archive
+
+      - name: Upload GUI JAR Asset
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./app/gui/build/libs/gui-${{ steps.get_version.outputs.version-without-v }}-all.jar
+          asset_name: gtfs-validator-${{ steps.get_version.outputs.version-without-v }}-gui.jar
           asset_content_type: application/java-archive
 
       - name: Generate rules.json

--- a/README.md
+++ b/README.md
@@ -84,6 +84,24 @@ Before running validation, tap the `Advanced` button to configure other aspects 
 * Number of threads used to run the validator.
 * The country code used for phone number validation.
 
+### Using GUI by command line
+#### Setup
+1. Install Java 17 or higher. To check which version of Java is installed on your computer, type the following command in the terminal: `java --version`. You can download Java from one of the following sources:
+    - **[Eclipse Adoptium (Temurin)](https://adoptium.net/temurin/releases/)** – Open-source & widely used
+    - **[Amazon Corretto](https://aws.amazon.com/corretto/)** - AWS-supported, optimized for cloud
+    - **[Azul Zulu](https://www.azul.com/downloads/)** - Enterprise ready
+    - **[Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/download/)** - Microsoft's JDK
+    - **[Oracle JDK](https://www.oracle.com/java/technologies/javase-downloads.html)** - Official Java from Oracle
+2. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` GUI jar (not OS-specific). It is located in the **Assets** section of the release, and it looks like `gtfs-validator-vX.X.X-gui.jar`
+3. Open the terminal on your computer
+4. Navigate to the directory containing the jar file. You can do this by typing the following command in the terminal:`cd {directory path}`, where {directory path} is the absolute or relative path to the directory. You can then make sure you're in the right directory by typing `pwd` in the terminal (this stands for *present working directory*). You can also make sure the jar file is there by typing `ls` in the terminal (this stands for *list* and will display the list of files in this directory). More about commands to navigate file and directories [here](https://help.ubuntu.com/community/UsingTheTerminal#File_.26_Directory_Commands).
+
+#### Run it
+You can run this validator using a GTFS dataset on your computer, or from a URL.
+- To validate a GTFS dataset on your computer, run the following command in the terminal, replacing the text in brackets:
+    - `java -jar {name of the jar file}`
+    - here is an example of what the command could look like:  `java -jar gtfs-validator-gui.jar`
+
 # Using the command line
 ### Setup 
 1. Install Java 17 or higher. To check which version of Java is installed on your computer, type the following command in the terminal: `java --version`. You can download Java from one of the following sources:
@@ -92,7 +110,7 @@ Before running validation, tap the `Advanced` button to configure other aspects 
     - **[Azul Zulu](https://www.azul.com/downloads/)** - Enterprise ready
     - **[Microsoft Build of OpenJDK](https://learn.microsoft.com/en-us/java/openjdk/download/)** - Microsoft's JDK
     - **[Oracle JDK](https://www.oracle.com/java/technologies/javase-downloads.html)** - Official Java from Oracle 
-2. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` CLI jar (not OS-specific). It is located in the **Assets** section of the release, and it looks like `gtfs-validator-vX.X.X_cli.jar`
+2. Navigate to the [Releases page](https://github.com/MobilityData/gtfs-validator/releases) and download the latest `Gtfs Validator` CLI jar (not OS-specific). It is located in the **Assets** section of the release, and it looks like `gtfs-validator-vX.X.X-cli.jar`
 3. Open the terminal on your computer
 4. Navigate to the directory containing the jar file. You can do this by typing the following command in the terminal:`cd {directory path}`, where {directory path} is the absolute or relative path to the directory. You can then make sure you're in the right directory by typing `pwd` in the terminal (this stands for *present working directory*). You can also make sure the jar file is there by typing `ls` in the terminal (this stands for *list* and will display the list of files in this directory). More about commands to navigate file and directories [here](https://help.ubuntu.com/community/UsingTheTerminal#File_.26_Directory_Commands).
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeFieldsTest.java
@@ -57,7 +57,6 @@ public class NoticeFieldsTest {
             "agencyId",
             "agencyLang",
             "agencyName",
-            "amount",
             "arrivalTime",
             "arrivalTime2",
             "attributionId",


### PR DESCRIPTION
**Summary:**


This pull request includes changes to the GitHub workflows to support the packaging and publishing of both CLI and GUI JAR assets.

Closes #1999 

**Expected behavior:** 

The GTFS-Validator GUI can be downloaded and executed from the project assets as a single JAR.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
