### PR TITLE
feat: modified MissingPickupDropOffBookingRuleIdNotice logic

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PickupBookingRuleIdValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/PickupBookingRuleIdValidator.java
@@ -25,6 +25,7 @@ public class PickupBookingRuleIdValidator extends FileValidator {
   public void validate(GtfsStopTime entity, NoticeContainer noticeContainer) {
     if (entity.hasPickupType()
         && entity.pickupType() == GtfsPickupDropOff.MUST_PHONE
+        && entity.hasStartPickupDropOffWindow()
         && !entity.hasPickupBookingRuleId()) {
       noticeContainer.addValidationNotice(
           new MissingPickupDropOffBookingRuleIdNotice(
@@ -34,6 +35,7 @@ public class PickupBookingRuleIdValidator extends FileValidator {
     }
     if (entity.hasDropOffType()
         && entity.dropOffType() == GtfsPickupDropOff.MUST_PHONE
+        && entity.hasEndPickupDropOffWindow()
         && !entity.hasDropOffBookingRuleId()) {
       noticeContainer.addValidationNotice(
           new MissingPickupDropOffBookingRuleIdNotice(
@@ -61,8 +63,12 @@ public class PickupBookingRuleIdValidator extends FileValidator {
   }
 
   /**
-   * `pickup_booking_rule_id` is recommended when `pickup_type=2` and `drop_off_booking_rule_id` is
-   * recommended when `drop_off_type=2`
+   * pickup_booking_rule_id is recommended when pickup_type=2 and drop_off_booking_rule_id is
+   * recommended when drop_off_type=2.
+   *
+   * <p>Currently, this notice is only triggered on feeds when either start_pickup_drop_off_window
+   * or end_pickup_drop_off_window is defined, since this recommendation was added to the
+   * specification for feeds with GTFS-Flex.
    */
   @GtfsValidationNotice(
       severity = SeverityLevel.WARNING,

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PickupBookingRuleIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PickupBookingRuleIdValidatorTest.java
@@ -37,7 +37,7 @@ public class PickupBookingRuleIdValidatorTest {
   }
 
   @Test
-  public void existingStartPickupDropOffWindowShouldNotGenerateNotice() {
+  public void existingBookingRuleIdShouldNotGenerateNotice() {
     GtfsStopTime stopTime =
         new GtfsStopTime.Builder()
             .setCsvRowNumber(2)

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PickupBookingRuleIdValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/PickupBookingRuleIdValidatorTest.java
@@ -10,6 +10,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.table.GtfsPickupDropOff;
 import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
 
 @RunWith(JUnit4.class)
 public class PickupBookingRuleIdValidatorTest {
@@ -27,6 +28,7 @@ public class PickupBookingRuleIdValidatorTest {
         new GtfsStopTime.Builder()
             .setCsvRowNumber(1)
             .setPickupType(GtfsPickupDropOff.MUST_PHONE)
+            .setStartPickupDropOffWindow(GtfsTime.fromSecondsSinceMidnight(18614))
             .build();
     assertThat(generateNotices(stopTime))
         .containsExactly(
@@ -35,12 +37,13 @@ public class PickupBookingRuleIdValidatorTest {
   }
 
   @Test
-  public void existingBookingRuleIdShouldNotGenerateNotice() {
+  public void existingStartPickupDropOffWindowShouldNotGenerateNotice() {
     GtfsStopTime stopTime =
         new GtfsStopTime.Builder()
             .setCsvRowNumber(2)
             .setPickupType(GtfsPickupDropOff.MUST_PHONE)
-            .setPickupBookingRuleId("bookingRuleId")
+            .setStartPickupDropOffWindow(GtfsTime.fromSecondsSinceMidnight(18614))
+            .setPickupBookingRuleId("booking_rule_id")
             .build();
     assertThat(generateNotices(stopTime)).isEmpty();
   }


### PR DESCRIPTION
**Summary:**

Closes #1821 

**Expected behavior:** 
I've checked some feeds listed in the New Warnings https://github.com/MobilityData/gtfs-validator/pull/1966 in this PR, for instance, ca-quebec-exo-laurentides-gtfs-744, the dataset doesn't have a booking rules file and  its report doesn't contain MissingPickupDropOffBookingRuleIdNotice. https://mobilitydatabase.org/feeds/gtfs/mdb-744
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/f5d46206-2337-4a75-8fb0-e442d923b8a5" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
