### PR TITLE
feat: standardize empty value on report.json

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInput.java
@@ -77,9 +77,7 @@ public class GtfsZipFileInput extends GtfsInput {
     if (!filenames.contains(filename)) {
       throw new FileNotFoundException(filename);
     }
-    synchronized (zipFile) {
-      return zipFile.getInputStream(zipFile.getEntry(filename));
-    }
+    return zipFile.getInputStream(zipFile.getEntry(filename));
   }
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsZipFileInput.java
@@ -77,7 +77,9 @@ public class GtfsZipFileInput extends GtfsInput {
     if (!filenames.contains(filename)) {
       throw new FileNotFoundException(filename);
     }
-    return zipFile.getInputStream(zipFile.getEntry(filename));
+    synchronized (zipFile) {
+      return zipFile.getInputStream(zipFile.getEntry(filename));
+    }
   }
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/AgencyMetadata.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/AgencyMetadata.java
@@ -10,8 +10,8 @@ public class AgencyMetadata {
   public AgencyMetadata(String name, String url, String phone, String email, String timezone) {
     this.name = name;
     this.url = url;
-    this.phone = phone.isEmpty() ? "N/A" : phone;
-    this.email = email.isEmpty() ? "N/A" : email;
-    this.timezone = timezone.isEmpty() ? "N/A" : timezone;
+    this.phone = phone.isEmpty() ? "" : phone;
+    this.email = email.isEmpty() ? "" : email;
+    this.timezone = timezone.isEmpty() ? "" : timezone;
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/FeedMetadata.java
@@ -431,16 +431,15 @@ public class FeedMetadata {
     var info = feedTable.getEntities().isEmpty() ? null : feedTable.getEntities().get(0);
 
     feedInfo.put(
-        JsonReportFeedInfo.FEED_INFO_PUBLISHER_NAME,
-        info == null ? "N/A" : info.feedPublisherName());
+        JsonReportFeedInfo.FEED_INFO_PUBLISHER_NAME, info == null ? "" : info.feedPublisherName());
     feedInfo.put(
-        JsonReportFeedInfo.FEED_INFO_PUBLISHER_URL, info == null ? "N/A" : info.feedPublisherUrl());
+        JsonReportFeedInfo.FEED_INFO_PUBLISHER_URL, info == null ? "" : info.feedPublisherUrl());
     feedInfo.put(
         JsonReportFeedInfo.FEED_INFO_FEED_CONTACT_EMAIL,
-        info == null ? "N/A" : info.feedContactEmail());
+        info == null ? "" : info.feedContactEmail());
     feedInfo.put(
         JsonReportFeedInfo.FEED_INFO_FEED_LANGUAGE,
-        info == null ? "N/A" : info.feedLang().getDisplayLanguage());
+        info == null ? "" : info.feedLang().getDisplayLanguage());
     if (feedTable.hasColumn(GtfsFeedInfo.FEED_START_DATE_FIELD_NAME)) {
       if (info != null) {
         LocalDate localDate = info.feedStartDate().getLocalDate();
@@ -458,7 +457,7 @@ public class FeedMetadata {
   private String checkLocalDate(LocalDate localDate) {
     String displayDate;
     if (localDate.toString().equals(LocalDate.EPOCH.toString())) {
-      displayDate = "N/A";
+      displayDate = "";
     } else {
       displayDate = localDate.toString();
     }
@@ -568,12 +567,12 @@ public class FeedMetadata {
     } finally {
       DateTimeFormatter formatter = DateTimeFormatter.ofPattern("MMMM d, yyyy");
       if ((earliestStartDate == null) && (latestEndDate == null)) {
-        feedInfo.put(JsonReportFeedInfo.FEED_INFO_SERVICE_WINDOW, "N/A");
+        feedInfo.put(JsonReportFeedInfo.FEED_INFO_SERVICE_WINDOW, "");
       } else if (earliestStartDate == null && latestEndDate != null) {
         feedInfo.put(JsonReportFeedInfo.FEED_INFO_SERVICE_WINDOW, latestEndDate.format(formatter));
       } else if (latestEndDate == null && earliestStartDate != null) {
         if (earliestStartDate.isAfter(latestEndDate)) {
-          feedInfo.put(JsonReportFeedInfo.FEED_INFO_SERVICE_WINDOW, "N/A");
+          feedInfo.put(JsonReportFeedInfo.FEED_INFO_SERVICE_WINDOW, "");
         } else {
           feedInfo.put(
               JsonReportFeedInfo.FEED_INFO_SERVICE_WINDOW, earliestStartDate.format(formatter));

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -269,10 +269,10 @@
                         <div th:with="isNotServiceWindow=${info.key != 'Service Window Start' and info.key != 'Service Window End'}">
                             <dd th:if="${isNotServiceWindow}" th:text="${info.key} + ':'" />
                             <dt th:if="${isNotServiceWindow}">
-                            <span th:if="${info.key.contains('URL') and info.value != 'N/A'}">
+                            <span th:if="${info.key.contains('URL') and not info.value.isEmpty()}">
                                 <a th:href="${info.value}" target="_blank" th:text="${info.value}" />
                             </span>
-                                <span th:if="${info.key.contains('URL') and info.value == 'N/A'}" th:text="${info.value}"></span>
+                                <span th:if="${info.value.isEmpty()}">N/A</span>
                                 <span th:unless="${info.key.contains('URL')}" th:text="${info.value}"/>
                                 <span th:if="${info.key == 'Service Window'}" >
                                      <a href="#" class="tooltip" onclick="event.preventDefault();"><span>(?)</span>


### PR DESCRIPTION
**Summary:**

This PR standardizes the empty strings by populating the values with `""` instead of `N/A` in the generated report.json. The `report.html` will still render `"N/A"` for empty values.

Closes #2003 

**Expected behavior:** 

Empty values are actually empty in the generated `report.json` instead of `"N/A"`.

<img width="631" alt="Screenshot 2025-03-05 at 2 21 47 PM" src="https://github.com/user-attachments/assets/2fd89818-81dd-4f0d-9802-142028d42aac" />

<img width="804" alt="Screenshot 2025-03-05 at 2 21 25 PM" src="https://github.com/user-attachments/assets/6ec9ea92-eace-4e97-a78e-b0f0e58fd93a" />

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
