### PR TITLE
fix: changes logging for skipped validators to atInfo instead of atSevere in printSummary

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -230,7 +230,7 @@ public class ValidationRunner {
     }
 
     if (b.length() > 0) {
-      logger.atSevere().log(b.toString());
+      logger.atInfo().log(b.toString());
     }
 
     logger.atInfo().log("Validation took %.3f seconds%n", feedMetadata.validationTimeSeconds);


### PR DESCRIPTION
**Summary:**

We've started using the GTFS validator at Entur in Norway and this message is logged at too high a severity, with no way to disable to logging in the validator itself. If this change is not possible, then it would be great to have a way to opt out of it. Either by defining the validators required when running the validator or by setting a logging config in the validator.

**Expected behavior:** 


Below is a screenshot of what we're seeing currently. We want to change this log message to be at info instead of error severity.

<img width="1162" alt="image" src="https://github.com/user-attachments/assets/b0b128f4-7008-42e3-874c-4c74d8e599ee" />
