### PR TITLE
fix: update TripAndShapeDistanceValidator to ignore shape with no shape_dist_traveled (#2018)

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidator.java
@@ -84,6 +84,11 @@ public class TripAndShapeDistanceValidator extends FileValidator {
               }
 
               double maxShapeDist = maxShape.shapeDistTraveled();
+
+              if (maxShapeDist == 0) {
+                return;
+              }
+
               double distanceInMeters =
                   getDistanceMeters(maxShape.shapePtLatLon(), stop.stopLatLon());
               if (maxStopTimeDist > maxShapeDist) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripAndShapeDistanceValidatorTest.java
@@ -109,6 +109,24 @@ public class TripAndShapeDistanceValidatorTest {
   }
 
   @Test
+  public void testTripDistanceExceedsShapeDistanceNoShapeDistance() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            createTripTable(2),
+            createStopTimesTable(1, 10.0),
+            createShapeTable(1, 0.0, 10.0),
+            createStopTable(1));
+    boolean found =
+        notices.stream()
+            .anyMatch(
+                notice ->
+                    notice
+                        instanceof
+                        TripAndShapeDistanceValidator.TripDistanceExceedsShapeDistanceNotice);
+    assertThat(found).isFalse();
+  }
+
+  @Test
   public void testTripDistanceExceedsShapeDistanceWarning() {
     List<ValidationNotice> notices =
         generateNotices(


### PR DESCRIPTION
**Summary:**
update TripAndShapeDistanceValidator to ignore shape with no shape_dist_traveled

**Expected behavior:** 

Some GTFS feeds do not provide shape_dist_traveled in shapes.txt In this case, the value is set to 0 in the code, so sorting shapes based on ShapeDistTraveled does not work and usually returns the first shape row.

It leads to an error, the first shape of the shape is usually very far away from the last stop of the trips following the shape.

We can assume the biggest shape_dist_traveled of a given shape should never be 0, otherwise it means the value is not set. In this case, we return early to ensure no validation error will be issued.

Fixes #2018

⚠️ I've not been able to run unit tests on this PR

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [ ] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
