### PR TITLE
fix: Put back the limit of 50 records per notice type in the html report.

### DIFF
--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -364,7 +364,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr th:each="notice: ${noticesByCode.value}">
+                                    <tr th:each="notice, iterStat : ${noticesByCode.value}" th:if="${iterStat.index < 50}">
                                         <th:block th:each="field: ${uniqueFieldsByCode[noticesByCode.key]}">
                                             <td th:text="${notice.getFields().contains(field) ? notice.getValueForField(field) : 'N/A'}" />
                                         </th:block>


### PR DESCRIPTION
**Summary:**
Closes #2025 

Reinstated the limit of 50 notices listed per notice type in the html report.

**Expected behavior:** 

The html report should never have more than 50 notices listed per notice type.

For the sake of expediency I did not add a test case for this.
It would be way more involved since it requires parsing the resulting HTML report file.
We can add a separate issue for that.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
