### PR TITLE
fix: hide the note if the expiration date is equal to the expected date.

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidator.java
@@ -69,7 +69,7 @@ public class FeedExpirationDateValidator extends SingleEntityValidator<GtfsFeedI
                 currentDatePlusSevenDays));
         return;
       }
-      if (entity.feedEndDate().compareTo(currentDatePlusThirtyDays) <= 0) {
+      if (entity.feedEndDate().compareTo(currentDatePlusThirtyDays) < 0) {
         noticeContainer.addValidationNotice(
             new FeedExpirationDate30DaysNotice(
                 entity.csvRowNumber(),

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedExpirationDateValidatorTest.java
@@ -83,14 +83,26 @@ public class FeedExpirationDateValidatorTest {
   }
 
   @Test
-  public void feedExpiring30DaysFromNowShouldGenerateNotice() {
-    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)))))
+  public void feedExpiring29DaysFromNowShouldGenerateNotice() {
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(29)))))
         .containsExactly(
             new FeedExpirationDate30DaysNotice(
                 1,
                 GtfsDate.fromLocalDate(TEST_NOW),
-                GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)),
+                GtfsDate.fromLocalDate(TEST_NOW.plusDays(29)),
                 GtfsDate.fromLocalDate(TEST_NOW.plusDays(30))));
+  }
+
+  @Test
+  public void feedExpiring30DaysFromNowShouldGenerateNotice() {
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(30)))))
+        .isEmpty();
+  }
+
+  @Test
+  public void feedExpiring31DaysFromNowShouldGenerateNotice() {
+    assertThat(validateFeedInfo(createFeedInfo(GtfsDate.fromLocalDate(TEST_NOW.plusDays(31)))))
+        .isEmpty();
   }
 
   @Test


### PR DESCRIPTION
**Summary:**

While validating a GTFS feed, I received the following message:
feedEndDate: 20250712, suggestedExpirationDate: 20250712

This message is confusing because the suggestedExpirationDate is the same as the feedEndDate, which might imply that the feed is expiring exactly when it ends — but no further action or recommendation is provided. It's unclear whether this is intended or if the feed should include more future service dates.

**Expected behavior:** 

If the dates are the same and no issue is present, the validator should not flag this message as a warning or should clarify that the feed is valid until its last service date.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
