### PR TITLE
fix: handle GeoJSON locations when computing distance between stops

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/util/StopUtil.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/util/StopUtil.java
@@ -32,6 +32,8 @@ public class StopUtil {
    *
    * <p>Returns (0, 0) if no coordinates are found in parent chain.
    */
+  // TODO: Replace with `getOptionalStopOrParentLatLng` everywhere. Falling back to
+  //   `S2LatLng.CENTER` can (and does) cause bugs.
   public static S2LatLng getStopOrParentLatLng(GtfsStopTableContainer stopTable, String stopId) {
     // Do not do an infinite loop since there may be a data bug and an infinite cycle of parents.
     for (int i = 0; i < 3; ++i) {
@@ -50,6 +52,12 @@ public class StopUtil {
       }
     }
     return S2LatLng.CENTER;
+  }
+
+  public static Optional<S2LatLng> getOptionalStopOrParentLatLng(
+      GtfsStopTableContainer stopTable, String stopId) {
+    return Optional.of(getStopOrParentLatLng(stopTable, stopId))
+        .filter(s2LatLng -> s2LatLng != S2LatLng.CENTER);
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidator.java
@@ -26,8 +26,7 @@ import com.google.common.geometry.S2LatLng;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import javax.inject.Inject;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
@@ -103,7 +102,7 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
       final double maxSpeedKph = getMaxVehicleSpeedKph(route.get().routeType());
       final double[] distancesKm =
           findDistancesKmBetweenStops(tripAndStopTimes.getStopTimes(), stopTable);
-      validateConsecutiveStops(trips, distancesKm, maxSpeedKph, noticeContainer);
+      validateConsecutiveStops(trips, maxSpeedKph, noticeContainer);
       validateFarStops(trips, distancesKm, maxSpeedKph, noticeContainer);
     }
   }
@@ -175,6 +174,24 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
     return distancesKm;
   }
 
+  private Optional<Double> getDistanceKm(GtfsStopTime start, GtfsStopTime end) {
+    if (!start.hasDepartureTime() || !end.hasArrivalTime()) {
+      return Optional.empty();
+    }
+
+    Optional<S2LatLng> maybeFirstLatLng =
+        StopUtil.getOptionalStopOrParentLatLng(stopTable, start.stopId());
+    Optional<S2LatLng> maybeSecondLatLng =
+        StopUtil.getOptionalStopOrParentLatLng(stopTable, end.stopId());
+
+    if (maybeFirstLatLng.isEmpty() || maybeSecondLatLng.isEmpty()) {
+      return Optional.empty();
+    }
+
+    double distanceKm = S2Earth.getDistanceKm(maybeFirstLatLng.get(), maybeSecondLatLng.get());
+    return Optional.of(distanceKm);
+  }
+
   /**
    * Validates travel speed between far stops for all trips that belong to the same route and visit
    * the same stops at the same times.
@@ -244,40 +261,39 @@ public class StopTimeTravelSpeedValidator extends FileValidator {
    * <p>If there is a fast travel detected, then a separate notice is issued for each trip.
    */
   private void validateConsecutiveStops(
-      List<TripAndStopTimes> trips,
-      double[] distancesKm,
-      double maxSpeedKph,
-      NoticeContainer noticeContainer) {
+      List<TripAndStopTimes> trips, double maxSpeedKph, NoticeContainer noticeContainer) {
     final List<GtfsStopTime> stopTimes = trips.get(0).getStopTimes();
-    for (int i = 0; i < distancesKm.length; ++i) {
-      final GtfsStopTime stopTime1 = stopTimes.get(i);
-      final GtfsStopTime stopTime2 = stopTimes.get(i + 1);
-      if (!(stopTime1.hasDepartureTime() && stopTime2.hasArrivalTime())) {
+    GtfsStopTime start = stopTimes.get(0);
+    for (int i = 0; i < stopTimes.size(); ++i) {
+      GtfsStopTime end = stopTimes.get(i + 1);
+
+      Optional<Double> maybeDistanceKm = getDistanceKm(start, end);
+      // We couldn't calculate the distance, for instance because one of the stops is
+      // actually a GeoJSON location and doesn't have a specific latitude and longitude.
+      // We try comparing with the next stop instead.
+      if (maybeDistanceKm.isEmpty()) {
         continue;
       }
-      final double distanceKm = distancesKm[i];
-      final double speedKph = getSpeedKphBetweenStops(distanceKm, stopTime1, stopTime2);
-      if (speedKph <= maxSpeedKph) {
-        continue;
+
+      double distanceKm = maybeDistanceKm.get();
+      double speedKph = getSpeedKphBetweenStops(distanceKm, start, end);
+
+      if (speedKph > maxSpeedKph) {
+        final Optional<GtfsStop> stop1 = stopTable.byStopId(start.stopId());
+        final Optional<GtfsStop> stop2 = stopTable.byStopId(end.stopId());
+        // This should always evaluate to true since we check whether both stops exist
+        // in `getDistanceAndSpeed`; this is just here as a precaution.
+        if (stop1.isPresent() && stop2.isPresent()) {
+          // Issue one notice for each trip.
+          for (TripAndStopTimes trip : trips) {
+            noticeContainer.addValidationNotice(
+                new FastTravelBetweenConsecutiveStopsNotice(
+                    trip.getTrip(), start, stop1.get(), end, stop2.get(), speedKph, distanceKm));
+          }
+        }
       }
-      final Optional<GtfsStop> stop1 = stopTable.byStopId(stopTime1.stopId());
-      final Optional<GtfsStop> stop2 = stopTable.byStopId(stopTime2.stopId());
-      if (stop1.isEmpty() || stop2.isEmpty()) {
-        // Broken reference is reported in another rule.
-        return;
-      }
-      // Issue one notice per each trip.
-      for (TripAndStopTimes trip : trips) {
-        noticeContainer.addValidationNotice(
-            new FastTravelBetweenConsecutiveStopsNotice(
-                trip.getTrip(),
-                trip.getStopTimes().get(i),
-                stop1.get(),
-                trip.getStopTimes().get(i + 1),
-                stop2.get(),
-                speedKph,
-                distanceKm));
-      }
+
+      start = end;
     }
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/StopTimeTravelSpeedValidatorTest.java
@@ -17,13 +17,16 @@
 package org.mobilitydata.gtfsvalidator.validator;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.findDistancesKmBetweenStops;
 import static org.mobilitydata.gtfsvalidator.validator.StopTimeTravelSpeedValidator.getSpeedKphBetweenStops;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.geometry.S2LatLng;
+import com.ibm.icu.impl.Pair;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -325,5 +328,44 @@ public final class StopTimeTravelSpeedValidatorTest {
     List<GtfsStopTime> stopTimes =
         createStopTimesSameDepartureArrival(ImmutableList.of(GtfsTime.fromString("08:00:00")));
     assertThat(getSpeedKphBetweenStops(2, stopTimes.get(0), stopTimes.get(0))).isEqualTo(120);
+  }
+
+  @Test
+  public void findDistancesKmBetweenStops_geoJsonLocation() {
+    List<S2LatLng> points =
+        ImmutableList.of(
+            S2LatLng.fromDegrees(42.879, -73.19313), // s0
+            S2LatLng.fromDegrees(42.89522, -73.20155)); // 21
+    List<GtfsStop> stops = createStops(points);
+
+    List<Optional<Pair<String, GtfsTime>>> stopIdsAndTimes =
+        ImmutableList.of(
+            Optional.of(Pair.of("s0", GtfsTime.fromString("14:48:00"))),
+            // There's a GeoJSON location between the two stops.
+            Optional.empty(),
+            Optional.of(Pair.of("s1", GtfsTime.fromString("14:56:00"))));
+
+    List<GtfsStopTime> stopTimes = new ArrayList<>(stopIdsAndTimes.size());
+    for (int i = 0; i < stopIdsAndTimes.size(); ++i) {
+      GtfsStopTime.Builder stopTimeBuilder =
+          new GtfsStopTime.Builder().setTripId(TEST_TRIP_ID).setStopSequence(i);
+
+      stopIdsAndTimes
+          .get(i)
+          .ifPresent(
+              t ->
+                  stopTimeBuilder
+                      .setArrivalTime(t.second)
+                      .setDepartureTime(t.second)
+                      .setStopId(t.first));
+      stopTimes.add(stopTimeBuilder.build());
+    }
+
+    double[] distancesKm =
+        findDistancesKmBetweenStops(stopTimes, GtfsStopTableContainer.forEntities(stops, null));
+
+    assertThat(distancesKm).hasLength(2);
+    assertThat(distancesKm[0]).isEqualTo(0.0);
+    assertThat(distancesKm[1]).isEqualTo(S2Earth.getDistanceKm(points.get(0), points.get(1)));
   }
 }


### PR DESCRIPTION
**Summary:**

This PR fixes a bug where we calculate the distance between two stops incorrectly if there's a GeoJSON location between them. We currently fall back to Null Island (0, 0) when we can't get the coordinates of a stop time's stop (in this case, because there's no stop id for a GeoJSON location) which messes up our calculations and can lead to false positives for the fast_travel_between_far_stops notice. See [this comment](https://github.com/MobilityData/gtfs-validator/issues/2031#issuecomment-2902791587).

We also address false negatives for the fast_travel_between_consecutive_stops notice due to only comparing consecutive entries in stop_times.txt.

I'll write some tests once we're happy with the approach.

Closes #2031 

**Expected behavior:** 

- We don't get a fast_travel_between_far_stops notice when two stops are within a reasonable distance but there's a GeoJSON location between them.
- We get a fast_travel_between_consecutive_stops notice when two consecutive stops are too far apart and there's a GeoJSON location between them.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
