### PR TITLE
fix: prevent html validation reports from being indexed by search engines

### DIFF
--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -2,6 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>GTFS Schedule Validation Report</title>
+    <meta name="robots" content="noindex, nofollow">
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8; width=device-width, initial-scale=1"/>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>


### PR DESCRIPTION
This change adds a meta tag to the HTML report template to prevent search engines from indexing or following links in the report.

**Summary:**

This change adds a meta tag to the HTML report template to prevent search engines from indexing or following links in the report.

**Expected behavior:** 

Google or other search engines should not index validation reports


Please make sure these boxes are checked before submitting your pull request - thanks!

- [ ] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [X] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
