### PR TITLE
Json stdout

### DIFF
--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.ResourceBundle;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -371,6 +372,7 @@ public class GtfsValidatorApp extends JFrame {
   private ValidationRunnerConfig buildConfig() throws URISyntaxException {
     ValidationRunnerConfig.Builder config = ValidationRunnerConfig.builder();
     config.setPrettyJson(true);
+    config.setStdoutOutput(false);
 
     String gtfsInput = gtfsInputField.getText();
     if (gtfsInput.isBlank()) {
@@ -386,7 +388,7 @@ public class GtfsValidatorApp extends JFrame {
     if (outputDirectory.isBlank()) {
       throw new IllegalStateException("outputDirectoryField is blank");
     }
-    config.setOutputDirectory(Path.of(outputDirectory));
+    config.setOutputDirectory(Optional.of(Path.of(outputDirectory)));
 
     Object numThreads = numThreadsSpinner.getValue();
     if (numThreads instanceof Integer) {

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/ValidationDisplay.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/ValidationDisplay.java
@@ -18,9 +18,9 @@ class ValidationDisplay {
       handleError();
     }
 
-    Path reportPath = config.htmlReportPath();
+    Path reportPath = config.htmlReportPath().orElse(null);
     if (status == ValidationRunner.Status.SYSTEM_ERRORS) {
-      reportPath = config.systemErrorsReportPath();
+      reportPath = config.systemErrorsReportPath().orElse(null);
     }
 
     try {

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
@@ -66,7 +66,7 @@ public class GtfsValidatorAppTest {
 
     ValidationRunnerConfig config = configCaptor.getValue();
     assertThat(config.gtfsSource()).isEqualTo(new URI("http://transit/gtfs.zip"));
-    assertThat(config.outputDirectory()).isEqualTo(Path.of("/path/to/output"));
+    assertThat(config.outputDirectory()).hasValue(Path.of("/path/to/output"));
     assertThat(config.numThreads()).isEqualTo(1);
     assertThat(config.countryCode().isUnknown()).isTrue();
   }
@@ -84,7 +84,7 @@ public class GtfsValidatorAppTest {
 
     ValidationRunnerConfig config = configCaptor.getValue();
     assertThat(config.gtfsSource()).isEqualTo(new URI("http://transit/gtfs.zip"));
-    assertThat(config.outputDirectory()).isEqualTo(Path.of("/path/to/output"));
+    assertThat(config.outputDirectory()).hasValue(Path.of("/path/to/output"));
     assertThat(config.numThreads()).isEqualTo(5);
     assertThat(config.countryCode().getCountryCode()).isEqualTo("US");
   }

--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -38,6 +38,9 @@ shadowJar {
         // from minimization.
         exclude(project(':main'))
         exclude(dependency(libs.httpclient5.get().toString()))
+        // Keep SLF4J implementation to avoid warnings
+        // Note that SLF4J comes from some transitive dependencies
+        exclude(dependency('org.slf4j:slf4j-jdk14'))
     }
     // Change the JAR name from 'main' to 'gtfs-validator'
     archiveBaseName = rootProject.name
@@ -55,6 +58,7 @@ dependencies {
     implementation libs.flogger
     implementation libs.flogger.system.backend
     implementation libs.guava
+    implementation libs.slf4j.jul
 
     testImplementation libs.junit
     testImplementation libs.truth

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -88,6 +88,8 @@ java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip --stdout
 
 ⚠️ Note that `--stdout` cannot be used with `-o` or `--output_base`. Use one or the other.
 
+⚠️ When using `--stdout`, all system errors and logging output are suppressed to ensure clean JSON output. Only severe-level log messages (hard crashes) will appear on stderr.
+
 ## via GitHub Actions - Run the validator on any gtfs archive available on a public url
 
 1. [Fork this repository](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo)

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -26,6 +26,7 @@
 | `-e`       | `--system_errors_report_name` | Optional               | Name of the system errors report (including `.json` extension).                                                                                                                                                                                               |
 | `-n`       | `--export_notices_schema`     | Optional               | Export notice schema as a json file.                                                                                                                                                                                                                          |
 | `-p`       | `--pretty`                    | Optional               | Pretty JSON validation report. If specified, the JSON validation report will be printed using JSON Pretty print. This does not impact data parsing.                                                                                                           |
+| `--stdout` | `--stdout`                    | Optional               | Output JSON report to stdout instead of writing to files. Use with `-i` or `-u` but not with `-o`. Enables piping to tools like `jq`.                                                                                                                          |
 | `-d`       | `--date`                      | Optional               | The date used to validate the feed for time-based rules, e.g feed_expiration_30_days, in ISO_LOCAL_DATE format like '2001-01-30'. By default, the current date is used.                                                                                       |
 | `-svu`     | `--skip_validator_update`     | Optional               | Skip GTFS version validation update check. If specified, the GTFS version validation will be skipped. By default, the GTFS version validation will be performed.                                                                                              |                                              
 
@@ -60,6 +61,32 @@ java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip -o relative/outp
  1. Download the GTFS feed at the URL `https://url/to/dataset.zip` and name it `input.zip`  
  1. Validate the GTFS data and output the results to the directory located at `relative/output/path`. Validation results are exported to JSON by default.
 Please note that since downloading will take time, we recommend validating repeatedly on a local file.
+
+## via stdout output (for scripting and piping)
+
+The `--stdout` option outputs JSON directly to stdout instead of writing files, making it ideal for scripting and piping to other tools.
+
+### Basic stdout usage
+``` 
+java -jar gtfs-validator-v2.0.jar -i relative/path/to/dataset.zip --stdout
+```
+
+### Pipe to jq for processing
+``` 
+java -jar gtfs-validator-v2.0.jar -i relative/path/to/dataset.zip --stdout | jq '.summary.validationTimeSeconds'
+```
+
+### Pretty JSON output to stdout
+``` 
+java -jar gtfs-validator-v2.0.jar -i relative/path/to/dataset.zip --stdout --pretty
+```
+
+### URL-based input with stdout
+``` 
+java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip --stdout
+```
+
+⚠️ Note that `--stdout` cannot be used with `-o` or `--output_base`. Use one or the other.
 
 ## via GitHub Actions - Run the validator on any gtfs archive available on a public url
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,3 +71,4 @@ aspectjrt = { module = "org.aspectj:aspectjrt", version.ref = "aspectjrt" }
 aspectjrt-weaver = { module = "org.aspectj:aspectjweaver", version.ref = "aspectjrtweaver" }
 findbugs = { module = "com.google.code.findbugs:jsr305", version.ref = "findbugs" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jacksonDatabind" }
+slf4j-jul = { module = "org.slf4j:slf4j-jdk14", version = "1.7.25" }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/JsonReportSummaryGenerator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/JsonReportSummaryGenerator.java
@@ -31,7 +31,9 @@ public class JsonReportSummaryGenerator {
             date,
             config != null ? config.gtfsSource().toString() : null,
             config != null ? config.numThreads() : 0,
-            config != null ? config.outputDirectory().toString() : null,
+            config != null && config.outputDirectory().isPresent()
+                ? config.outputDirectory().get().toString()
+                : null,
             config != null ? config.systemErrorsReportFileName() : null,
             config != null ? config.validationReportFileName() : null,
             config != null ? config.htmlReportFileName() : null,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -333,12 +333,6 @@ public class ValidationRunner {
         logger.atSevere().withCause(ex).log("Error creating JSON report");
       }
 
-      // System errors to stderr
-      try {
-        System.err.println(gson.toJson(noticeContainer.exportSystemErrors()));
-      } catch (Exception ex) {
-        logger.atSevere().withCause(ex).log("Error creating system errors report");
-      }
       return;
     }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -26,6 +26,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.time.ZonedDateTime;
@@ -75,6 +76,11 @@ public class ValidationRunner {
 
   @MemoryMonitor
   public Status run(ValidationRunnerConfig config) {
+    // Suppress logging when using stdout mode to avoid interfering with JSON output
+    if (config.stdoutOutput()) {
+      // Set logging level to SEVERE to minimize output
+      java.util.logging.Logger.getLogger("").setLevel(java.util.logging.Level.SEVERE);
+    }
     MemoryUsageRegister.getInstance().clearRegistry();
     // Registering the memory metrics manually to avoid multiple entries due to concurrent calls
     // and exclude from the metric the generation of the reports.
@@ -151,7 +157,7 @@ public class ValidationRunner {
 
     // Output
     exportReport(feedMetadata, noticeContainer, config, versionInfo);
-    printSummary(feedMetadata, feedContainer, feedLoader);
+    printSummary(feedMetadata, feedContainer, feedLoader, config);
     return Status.SUCCESS;
   }
 
@@ -162,7 +168,14 @@ public class ValidationRunner {
    * @param feedContainer the {@code GtfsFeedContainer}
    */
   public static void printSummary(
-      FeedMetadata feedMetadata, GtfsFeedContainer feedContainer, GtfsFeedLoader loader) {
+      FeedMetadata feedMetadata,
+      GtfsFeedContainer feedContainer,
+      GtfsFeedLoader loader,
+      ValidationRunnerConfig config) {
+    // Skip summary output when using stdout mode to avoid interfering with JSON output
+    if (config.stdoutOutput()) {
+      return;
+    }
     final long endNanos = System.nanoTime();
     var skippedValidators = loader.getSkippedValidators();
     var multiFileValidatorsWithParsingErrors =
@@ -296,45 +309,78 @@ public class ValidationRunner {
       NoticeContainer noticeContainer,
       ValidationRunnerConfig config,
       VersionInfo versionInfo) {
-    if (!Files.exists(config.outputDirectory())) {
-      try {
-        Files.createDirectories(config.outputDirectory());
-      } catch (IOException ex) {
-        logger.atSevere().withCause(ex).log(
-            "Error creating output directory: %s", config.outputDirectory());
-      }
-    }
+
     ZonedDateTime now = ZonedDateTime.now();
     String date = now.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX"));
-    boolean is_different_date = !now.toLocalDate().equals(config.dateForValidation());
-
     Gson gson = createGson(config.prettyJson());
-    HtmlReportGenerator htmlGenerator = new HtmlReportGenerator();
     JsonReportGenerator jsonGenerator = new JsonReportGenerator();
+
+    // Generate JSON report
+    JsonReport jsonReport = null;
     try {
-      JsonReport jsonReport =
+      jsonReport =
           jsonGenerator.generateReport(feedMetadata, noticeContainer, config, versionInfo, date);
-      Files.write(
-          config.outputDirectory().resolve(config.validationReportFileName()),
-          gson.toJson(jsonReport).getBytes(StandardCharsets.UTF_8));
     } catch (Exception ex) {
       logger.atSevere().withCause(ex).log("Error creating JSON report");
+      return;
     }
 
-    try {
-      htmlGenerator.generateReport(
-          feedMetadata,
-          noticeContainer,
-          config,
-          versionInfo,
-          config.outputDirectory().resolve(config.htmlReportFileName()),
-          date,
-          is_different_date);
-      Files.write(
-          config.outputDirectory().resolve(config.systemErrorsReportFileName()),
-          gson.toJson(noticeContainer.exportSystemErrors()).getBytes(StandardCharsets.UTF_8));
-    } catch (IOException e) {
-      logger.atSevere().withCause(e).log("Cannot store report files");
+    if (config.stdoutOutput()) {
+      // Output JSON to stdout
+      try {
+        System.out.println(gson.toJson(jsonReport));
+      } catch (Exception ex) {
+        logger.atSevere().withCause(ex).log("Error creating JSON report");
+      }
+
+      // System errors to stderr
+      try {
+        System.err.println(gson.toJson(noticeContainer.exportSystemErrors()));
+      } catch (Exception ex) {
+        logger.atSevere().withCause(ex).log("Error creating system errors report");
+      }
+      return;
+    }
+
+    // Existing file-based output
+    if (config.outputDirectory().isPresent()) {
+      Path outputDir = config.outputDirectory().get();
+      if (!Files.exists(outputDir)) {
+        try {
+          Files.createDirectories(outputDir);
+        } catch (IOException ex) {
+          logger.atSevere().withCause(ex).log("Error creating output directory: %s", outputDir);
+        }
+      }
+    }
+    boolean is_different_date = !now.toLocalDate().equals(config.dateForValidation());
+
+    HtmlReportGenerator htmlGenerator = new HtmlReportGenerator();
+    if (config.outputDirectory().isPresent()) {
+      Path outputDir = config.outputDirectory().get();
+      try {
+        Files.write(
+            outputDir.resolve(config.validationReportFileName()),
+            gson.toJson(jsonReport).getBytes(StandardCharsets.UTF_8));
+      } catch (Exception ex) {
+        logger.atSevere().withCause(ex).log("Error creating JSON report");
+      }
+
+      try {
+        htmlGenerator.generateReport(
+            feedMetadata,
+            noticeContainer,
+            config,
+            versionInfo,
+            outputDir.resolve(config.htmlReportFileName()),
+            date,
+            is_different_date);
+        Files.write(
+            outputDir.resolve(config.systemErrorsReportFileName()),
+            gson.toJson(noticeContainer.exportSystemErrors()).getBytes(StandardCharsets.UTF_8));
+      } catch (IOException e) {
+        logger.atSevere().withCause(e).log("Cannot store report files");
+      }
     }
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
@@ -29,7 +29,8 @@ public abstract class ValidationRunnerConfig {
   public abstract URI gtfsSource();
 
   // The directory where all validation reports will be written.
-  public abstract Path outputDirectory();
+  // Optional when using stdout mode.
+  public abstract Optional<Path> outputDirectory();
 
   // An optional storage directory to be used when downloading a GTFS feed
   // from an external URL.
@@ -39,14 +40,14 @@ public abstract class ValidationRunnerConfig {
 
   public abstract String htmlReportFileName();
 
-  public Path htmlReportPath() {
-    return outputDirectory().resolve(htmlReportFileName());
+  public Optional<Path> htmlReportPath() {
+    return outputDirectory().map(dir -> dir.resolve(htmlReportFileName()));
   }
 
   public abstract String systemErrorsReportFileName();
 
-  public Path systemErrorsReportPath() {
-    return outputDirectory().resolve(systemErrorsReportFileName());
+  public Optional<Path> systemErrorsReportPath() {
+    return outputDirectory().map(dir -> dir.resolve(systemErrorsReportFileName()));
   }
 
   // Determines the number of parallel threads of execution used during
@@ -66,6 +67,9 @@ public abstract class ValidationRunnerConfig {
   // If true, the validator will not check for a new validator version
   public abstract boolean skipValidatorUpdate();
 
+  // If true, output JSON report to stdout instead of writing to files
+  public abstract boolean stdoutOutput();
+
   public static Builder builder() {
     // Set reasonable defaults where appropriate.
     return new AutoValue_ValidationRunnerConfig.Builder()
@@ -83,7 +87,7 @@ public abstract class ValidationRunnerConfig {
   public abstract static class Builder {
     public abstract Builder setGtfsSource(URI gtfsSource);
 
-    public abstract Builder setOutputDirectory(Path outputDirectory);
+    public abstract Builder setOutputDirectory(Optional<Path> outputDirectory);
 
     public abstract Builder setStorageDirectory(Path storageDirectory);
 
@@ -102,6 +106,8 @@ public abstract class ValidationRunnerConfig {
     public abstract Builder setPrettyJson(boolean prettyJson);
 
     public abstract Builder setSkipValidatorUpdate(boolean skipValidatorUpdate);
+
+    public abstract Builder setStdoutOutput(boolean stdoutOutput);
 
     public abstract ValidationRunnerConfig build();
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
@@ -40,12 +40,13 @@ public class JsonReportSummaryGeneratorTest {
     builder.setCountryCode(CountryCode.forStringOrUnknown("GB"));
     builder.setGtfsSource(new URI("some_dataset_filename"));
     builder.setHtmlReportFileName("some_html_filename");
-    builder.setOutputDirectory(Path.of("some_output_directory"));
+    builder.setOutputDirectory(Optional.of(Path.of("some_output_directory")));
     builder.setNumThreads(1);
     builder.setPrettyJson(true);
     builder.setSystemErrorsReportFileName("some_error_filename");
     builder.setValidationReportFileName("some_report_filename");
     builder.setDateForValidation(LocalDate.parse("2020-01-02"));
+    builder.setStdoutOutput(false);
 
     return builder.build();
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -17,9 +18,10 @@ public class ValidationRunnerTest {
   private static ValidationRunnerConfig buildConfig(String gtfsDirectory) {
     ValidationRunnerConfig.Builder config = ValidationRunnerConfig.builder();
     config.setGtfsSource(Path.of(gtfsDirectory).toUri());
-    config.setOutputDirectory(Path.of(""));
+    config.setOutputDirectory(Optional.of(Path.of("")));
     config.setNumThreads(1);
     config.setCountryCode(CountryCode.forStringOrUnknown(""));
+    config.setStdoutOutput(false);
     return config.build();
   }
 

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandler.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandler.java
@@ -2,6 +2,7 @@ package org.mobilitydata.gtfsvalidator.web.service.util;
 
 import java.io.File;
 import java.nio.file.Path;
+import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
@@ -32,7 +33,8 @@ public class ValidationHandler {
     var configBuilder =
         ValidationRunnerConfig.builder()
             .setGtfsSource(feedFile.toURI())
-            .setOutputDirectory(outputPath);
+            .setOutputDirectory(Optional.of(outputPath))
+            .setStdoutOutput(false);
     if (!countryCode.isEmpty()) {
       var country = CountryCode.forStringOrUnknown(countryCode);
       logger.debug("setting country code: {}", country.getCountryCode());

--- a/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandlerTest.java
+++ b/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandlerTest.java
@@ -2,6 +2,7 @@ package org.mobilitydata.gtfsvalidator.web.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -40,7 +41,9 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assert config.outputDirectory().equals(mockOutputPath);
+    assertTrue(
+        config.outputDirectory().isPresent()
+            && mockOutputPath.equals(config.outputDirectory().get()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 
@@ -60,7 +63,9 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assert config.outputDirectory().equals(mockOutputPath);
+    assertTrue(
+        config.outputDirectory().isPresent()
+            && mockOutputPath.equals(config.outputDirectory().get()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 
@@ -85,7 +90,9 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assert config.outputDirectory().equals(mockOutputPath);
+    assertTrue(
+        config.outputDirectory().isPresent()
+            && mockOutputPath.equals(config.outputDirectory().get()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 
@@ -112,7 +119,9 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assert config.outputDirectory().equals(mockOutputPath);
+    assertTrue(
+        config.outputDirectory().isPresent()
+            && mockOutputPath.equals(config.outputDirectory().get()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 }


### PR DESCRIPTION
Hi, here's a PR to add some functionality that is useful for developers chaining this together with other tools on the command line. This is related to at least one issue that has requested some aspects of this in the past. This is my first PR ever for this repo, so please do feel free to revise as needed or to hold if it conflicts with other planned functionality. Thanks.

**Summary:**

Enables JSON reports to be optionally output directly to stdout for piping to other programs, rather than being written to file system. Log output is suppressed. Involves changing how output directory is handled, but not intended to change existing default functionality in the CLI or the GUI.

closes #1194

**Expected behavior:** 

- Adds an additional CLI argument
- Should *not* change GUI behavior
- CLI can now support usage such as:

```sh
java -jar cli/build/libs/gtfs-validator-0.1.0-SNAPSHOT-cli.jar -u https://data.trilliumtransit.com/gtfs/caltrain-ca-us/caltrain-ca-us.zip --stdout | jq '.notices[] .code'
"route_short_name_too_long"
"stop_without_stop_time"
"unknown_column"
"unknown_file"
```

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include ~~screenshot(s)~~ a shell example showing how this pull request works and fixes the issue(s)
