### PR TITLE
Changed Windows image to `windows-2022`

### DIFF
--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -45,7 +45,7 @@ jobs:
       # Adding fail-fast: false so at least some artifacts gets uploaded if others fail
       fail-fast: false
       matrix:
-        os: [ macos-latest, windows-latest, ubuntu-latest ]
+        os: [ macos-latest, windows-2022, ubuntu-latest ]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This is temporary while we test the new `windows-latest` that will default to `windows-2025` in September 2025.

GitHub email on this:

> The "windows-latest" label in GitHub Actions will be migrated to the Windows Server 2025 runner image.
> This change will be rolled out over a period of several weeks beginning September 2, 2025 and will complete by September 30, 2025.
> During this period your workflows will gradually switch over to the new image, once they are migrated they will not run on Windows Server 2022 in any future runs.

> [IMPORTANT] The Windows Server 2025 image may have different tools installed than Windows Server 2022. You can check the [tool list for Windows 2025](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md?elqTrackId=086c2bda1209481a8e3e7b1fb946df0e&elq=b09a738ed96044d09aecc7876db7c780&elqaid=4573&elqat=1&elqCampaignId=4763&elqak=8AF5E363CAA3D05433FD8CF75B89A0C1E2423AE6528DBB32FD1AD88A9F57ECC4EA00) to proactively identify any tooling differences and make updates to your workflows accordingly.

> What you need to do:
> You do not need to do anything at this time if you want your workflows to migrate to the latest windows version. If you want to remain on Windows 2022 you can follow the below instructions.
> Switch your workflows to use the `windows-2022` label by changing workflow YAML to use `runs-on: windows-2022`. We support the two latest stable windows versions plus latest beta, so windows 2022 will be maintained for the next 3 years.
For more information or if you have questions head to the [runner-images repository](https://github.com/actions/runner-images?elqTrackId=85ced36176f6470ca61993d12a1fd880&elq=b09a738ed96044d09aecc7876db7c780&elqaid=4573&elqat=1&elqCampaignId=4763&elqak=8AF53FF10191846495114AB87715ADD969803AE6528DBB32FD1AD88A9F57ECC4EA00).