### PR TITLE
docs: remove unused suppress/anchor lines from NEW_RULES

### DIFF
--- a/docs/NEW_RULES.md
+++ b/docs/NEW_RULES.md
@@ -143,10 +143,6 @@ Values for `csvRowNumber` and `tripId` will be different for each generated noti
 
 ### c. Implement the validation rule logic (`FileValidator`)
 
-<!--suppress ALL -->
-
-<a name="examples"/>
-
 Here's the fun part - writing the rule. Because this rule `...extends FileValidator`, we need to define what GTFS files we want - in this case the `trips.txt` and `stop_times.txt` tables.
 
 We do that by declaring the two variables at the top of the class `GtfsTripTableContainer tripTable` and `GtfsStopTimeTableContainer stopTimeTable` (similar `...TableContainer` classes exist for all GTFS files).


### PR DESCRIPTION
**Summary:**

This PR removes leftover lines from the documentation that caused formatting issues:

- `<!--suppress ALL -->`: IDE-specific directive, not useful in NEW_RULES.md.
- `<a name="examples"/>`: introduced an unclosed <a> tag, which made GitHub render the following section underlined.

**Problem:**
The unclosed `<a>` tag caused large portions of the NEW_RULES.md to appear underlined on GitHub, making it harder to read.
See the image below:

<img width="1004" height="735" alt="Screenshot 2025-09-04 at 15 49 51" src="https://github.com/user-attachments/assets/3793a89f-c243-4d53-a5f4-853d3c290957" />

**Notes:**
- No code changes, only documentation cleanup.
