### PR TITLE
chore: update gradle action to v4

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4
   test:
     needs: [ validate_gradle_wrapper ]
     runs-on: ubuntu-latest
@@ -33,9 +33,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Run Java tests
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: testAggregateTestReport
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Generate aggregate test report
+        run: ./gradlew testAggregateTestReport
+
       - name: Persist aggregated test reports on failure
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4
   pack-snapshot:
     needs: validate_gradle_wrapper
     runs-on: ubuntu-latest
@@ -61,9 +61,11 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Package cli app jar with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: shadowJar
+        uses: gradle/gradle-build-action@v4
+        
+      - name: Builds ShadowJar
+        run: ./gradlew shadowJar
+
       - name: Persist gtfs-validator snapshot jar
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: gradle/wrapper-validation-action@v2
+      - uses: gradle/actions/wrapper-validation@v4
 
   build_push:
     needs: [ validate_gradle_wrapper ]
@@ -81,11 +81,9 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${MACOS_CI_KEYCHAIN_PWD}" build.keychain
 
       - name: "Package GUI app installer with Gradle"
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: |
-            jpackage
-            -Psign-app=${{github.event_name == 'push' || github.event_name == 'release'}}
+        uses: gradle/actions/setup-gradle@v4
+      - name: Run Gradle GUI packaging command on push or release
+        run: ./gradlew jpackage -Psign-app=${{github.event_name == 'push' || github.event_name == 'release'}}
 
       # On MacOS, we now submit the app for "notarization", where Apple will scan the app for
       # malware and other issues.  This step can take a few minutes or more; the action will wait
@@ -142,9 +140,10 @@ jobs:
 
       - name: Package cli and gui app jars with Gradle
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          arguments: shadowJar
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Produce shadowJar
+        run: ./gradlew shadowJar
 
       - name: Persist cli app jar
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4
   test:
     needs: [ validate_gradle_wrapper ]
     runs-on: ${{ matrix.os }}
@@ -35,9 +35,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Run tests on Java ${{ matrix.java_version }} and ${{ matrix.os }}
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: testAggregateTestReport --continue
+        uses: gradle/actions/setup-gradle@v4
+      - name: Continue on test report
+        run: ./gradlew testAggregateTestReport --continue
+
       - name: Persist aggregated test reports on failure - Java ${{ matrix.java_version }} on ${{ matrix.os }}
         if: ${{ failure() }}
         uses: actions/upload-artifact@v4
@@ -66,9 +67,10 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Package cli app jar with Gradle
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: shadowJar
+        uses: gradle/actions/setup-gradle@v4
+      - name: Produce shadowJar
+        run: ./gradlew shadowJar
+
       - name: Persist cli app jar
         uses: actions/upload-artifact@v4
         with:
@@ -95,10 +97,10 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
+      - name: Setup Javadoc build
+        uses: gradle/actions/setup-gradle@v4
       - name: Build Javadoc
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: aggregateJavadoc
+        run: ./gradlew aggregateJavadoc
       - name: Persist javadoc
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
**Summary:**

Summarize the changes in the pull request including how it relates to any issues (include the #number, or link them).

Closes #2033 by removing links to deprecated versions of Gradle actions, and updates Gradle actions to v4 (v5 is released, but uses Node 24, which GHA will not run by default until March 4/26).

**Expected behavior:** 

Actions to build as expected.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues

