### PR TITLE
fix: ServiceSpreadValidator with no active date interval

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ServiceSpreadValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/ServiceSpreadValidator.java
@@ -78,7 +78,7 @@ public class ServiceSpreadValidator extends FileValidator {
               ServiceInterval intervals =
                   serviceIntervalCache.getIntervals(
                       serviceId, calendarTableContainer, calendarDateTableContainer);
-              if (intervals == null) {
+              if (intervals == null || intervals.isEmpty()) {
                 return;
               }
               for (DateInterval gap : intervals.getGaps()) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ServiceSpreadValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/ServiceSpreadValidatorTest.java
@@ -15,6 +15,7 @@ import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateExceptionType;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarDateTableContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsCalendarTableContainer;
 import org.mobilitydata.gtfsvalidator.type.GtfsDate;
+import org.mobilitydata.gtfsvalidator.util.ServiceInterval;
 import org.mobilitydata.gtfsvalidator.util.ServiceIntervalCache;
 import org.mobilitydata.gtfsvalidator.validator.ServiceSpreadValidator.BigGapInServiceNotice;
 import org.mobilitydata.gtfsvalidator.validator.ServiceSpreadValidator.ServiceExtendsFarInTheFutureNotice;
@@ -343,5 +344,64 @@ public class ServiceSpreadValidatorTest {
             .toList();
 
     assertThat(futureNotices).containsExactly(expectedFutureNotice);
+  }
+
+  @Test
+  public void serviceIntervalCacheReturnsNull_noNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    ImmutableList<GtfsCalendar> calendars =
+        ImmutableList.of(
+            buildCalendar(new CalendarMetadata("service_null", "20240101", "20240131", true), 1));
+    GtfsCalendarTableContainer calendarTable =
+        GtfsCalendarTableContainer.forEntities(calendars, noticeContainer);
+    GtfsCalendarDateTableContainer calendarDateTable =
+        GtfsCalendarDateTableContainer.forEntities(ImmutableList.of(), noticeContainer);
+    DateForValidation dateForValidation = new DateForValidation(LocalDate.of(2024, 1, 1));
+
+    ServiceIntervalCache cache =
+        new ServiceIntervalCache() {
+          @Override
+          public ServiceInterval getIntervals(
+              String serviceId,
+              GtfsCalendarTableContainer calendarTableContainer,
+              GtfsCalendarDateTableContainer calendarDateTableContainer) {
+            return null;
+          }
+        };
+
+    new ServiceSpreadValidator(cache, dateForValidation, calendarTable, calendarDateTable)
+        .validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void serviceIntervalCacheReturnsEmptyIntervals_noNotice() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    ImmutableList<GtfsCalendar> calendars =
+        ImmutableList.of(
+            buildCalendar(new CalendarMetadata("service_empty", "20240101", "20240131", true), 1));
+    GtfsCalendarTableContainer calendarTable =
+        GtfsCalendarTableContainer.forEntities(calendars, noticeContainer);
+    GtfsCalendarDateTableContainer calendarDateTable =
+        GtfsCalendarDateTableContainer.forEntities(ImmutableList.of(), noticeContainer);
+    DateForValidation dateForValidation = new DateForValidation(LocalDate.of(2024, 1, 1));
+
+    ServiceInterval emptyInterval = new ServiceInterval();
+    ServiceIntervalCache cache =
+        new ServiceIntervalCache() {
+          @Override
+          public ServiceInterval getIntervals(
+              String serviceId,
+              GtfsCalendarTableContainer calendarTableContainer,
+              GtfsCalendarDateTableContainer calendarDateTableContainer) {
+            return emptyInterval;
+          }
+        };
+
+    new ServiceSpreadValidator(cache, dateForValidation, calendarTable, calendarDateTable)
+        .validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
   }
 }


### PR DESCRIPTION
**Summary:**

Fixes #2136 

**Expected behavior:** 

The ServiceSpreadValidator can handle intervals with no active date.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
