### PR TITLE
chore: run periodic GitHub Actions workflow only upstream, not in forks

### DIFF
--- a/.github/workflows/create_issue_if_referencemd_changes.yml
+++ b/.github/workflows/create_issue_if_referencemd_changes.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   fetch-and-create-pr:
+    if: github.repository_owner == 'MobilityData'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This PR changes the `create_issue_if_referencemd_changes.yml` workflow so that it only runs in the `MobilityData` org.

Currently, in [my fork](https://github.com/derhuerst/gtfs-validator/), there's a daily run that will always fail due to a missing token (and I don't *want* it to have those permissions either). This creates one email per day notifying me of the failure.

I also don't want to disable Actions completely for my fork.

According to [this answer](https://github.com/orgs/community/discussions/26704), it's not possible to explicitly check in a workflow if the repo is a fork, so I'm using `github.repository_owner == 'MobilityData'` as a workaround.