### PR TITLE
fix: rename service_window_extends_past_feed_period to service_window_outside_feed_period

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceWindowValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceWindowValidator.java
@@ -40,10 +40,10 @@ import org.mobilitydata.gtfsvalidator.util.ServiceIntervalCache;
  * from trips.txt:
  *
  * <ol>
- *   <li>Service window extends past feed period: the feed validity period should cover every
- *       service window. A {@link ServiceWindowExtendsPastFeedPeriodNotice} is emitted once per
- *       service whose active date range extends outside the feed validity period, summarizing how
- *       many days fall before feed_start_date or after feed_end_date.
+ *   <li>Service window outside feed period: the feed validity period should cover every service
+ *       window. A {@link ServiceWindowOutsideFeedPeriodNotice} is emitted once per service whose
+ *       active date range extends outside the feed validity period, summarizing how many days fall
+ *       before feed_start_date or after feed_end_date.
  *   <li>Feed valid beyond total service window: the feed validity period should not extend far
  *       beyond the total service window. A {@link FeedValidBeyondTotalServiceWindowNotice} is
  *       emitted when the feed start/end date exceeds the total service window bounds by more than
@@ -53,7 +53,7 @@ import org.mobilitydata.gtfsvalidator.util.ServiceIntervalCache;
  *       strictly after today's date.
  * </ol>
  *
- * <p>Generated notices: {@link ServiceWindowExtendsPastFeedPeriodNotice}, {@link
+ * <p>Generated notices: {@link ServiceWindowOutsideFeedPeriodNotice}, {@link
  * FeedValidBeyondTotalServiceWindowNotice}, {@link FutureCalendarNotice}.
  */
 @GtfsValidator
@@ -149,7 +149,7 @@ public class FeedServiceWindowValidator extends FileValidator {
   }
 
   /**
-   * Emits a {@link ServiceWindowExtendsPastFeedPeriodNotice} if the service active window extends
+   * Emits a {@link ServiceWindowOutsideFeedPeriodNotice} if the service active window extends
    * outside the feed validity period.
    */
   private static void checkServiceWindow(
@@ -170,7 +170,7 @@ public class FeedServiceWindowValidator extends FileValidator {
 
     if (daysBeforeFeedStart > 0 || daysAfterFeedEnd > 0) {
       noticeContainer.addValidationNotice(
-          new ServiceWindowExtendsPastFeedPeriodNotice(
+          new ServiceWindowOutsideFeedPeriodNotice(
               serviceId,
               serviceStart.toString(),
               serviceEnd.toString(),
@@ -196,7 +196,7 @@ public class FeedServiceWindowValidator extends FileValidator {
             GtfsCalendarDateSchema.class,
             GtfsFeedInfoSchema.class
           }))
-  static class ServiceWindowExtendsPastFeedPeriodNotice extends ValidationNotice {
+  static class ServiceWindowOutsideFeedPeriodNotice extends ValidationNotice {
 
     /** The service_id whose active window extends outside the feed validity period. */
     private final String serviceId;
@@ -213,7 +213,7 @@ public class FeedServiceWindowValidator extends FileValidator {
     /** Number of days the service window extends after feed_end_date (0 if none). */
     private final long daysAfterFeedEnd;
 
-    ServiceWindowExtendsPastFeedPeriodNotice(
+    ServiceWindowOutsideFeedPeriodNotice(
         String serviceId,
         String serviceWindowStart,
         String serviceWindowEnd,

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceWindowValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/FeedServiceWindowValidatorTest.java
@@ -22,7 +22,7 @@ import org.mobilitydata.gtfsvalidator.type.GtfsDate;
 import org.mobilitydata.gtfsvalidator.util.ServiceIntervalCache;
 import org.mobilitydata.gtfsvalidator.validator.FeedServiceWindowValidator.FeedValidBeyondTotalServiceWindowNotice;
 import org.mobilitydata.gtfsvalidator.validator.FeedServiceWindowValidator.FutureCalendarNotice;
-import org.mobilitydata.gtfsvalidator.validator.FeedServiceWindowValidator.ServiceWindowExtendsPastFeedPeriodNotice;
+import org.mobilitydata.gtfsvalidator.validator.FeedServiceWindowValidator.ServiceWindowOutsideFeedPeriodNotice;
 
 public class FeedServiceWindowValidatorTest {
 
@@ -250,7 +250,7 @@ public class FeedServiceWindowValidatorTest {
   }
 
   // ---------------------------------------------------------------------------
-  // ServiceWindowExtendsPastFeedPeriodNotice
+  // ServiceWindowOutsideFeedPeriodNotice
   // ---------------------------------------------------------------------------
 
   @Test
@@ -265,7 +265,7 @@ public class FeedServiceWindowValidatorTest {
             ImmutableList.of("s1"));
 
     assertThat(notices).hasSize(1);
-    assertThat(notices.get(0)).isInstanceOf(ServiceWindowExtendsPastFeedPeriodNotice.class);
+    assertThat(notices.get(0)).isInstanceOf(ServiceWindowOutsideFeedPeriodNotice.class);
   }
 
   @Test
@@ -279,7 +279,7 @@ public class FeedServiceWindowValidatorTest {
             ImmutableList.of("s1"));
 
     assertThat(notices).hasSize(1);
-    assertThat(notices.get(0)).isInstanceOf(ServiceWindowExtendsPastFeedPeriodNotice.class);
+    assertThat(notices.get(0)).isInstanceOf(ServiceWindowOutsideFeedPeriodNotice.class);
   }
 
   @Test
@@ -293,7 +293,7 @@ public class FeedServiceWindowValidatorTest {
             ImmutableList.of("s1"));
 
     assertThat(notices).hasSize(1);
-    assertThat(notices.get(0)).isInstanceOf(ServiceWindowExtendsPastFeedPeriodNotice.class);
+    assertThat(notices.get(0)).isInstanceOf(ServiceWindowOutsideFeedPeriodNotice.class);
   }
 
   @Test
@@ -309,7 +309,7 @@ public class FeedServiceWindowValidatorTest {
             ImmutableList.of("s1", "s2"));
 
     assertThat(notices).hasSize(1);
-    assertThat(notices.get(0)).isInstanceOf(ServiceWindowExtendsPastFeedPeriodNotice.class);
+    assertThat(notices.get(0)).isInstanceOf(ServiceWindowOutsideFeedPeriodNotice.class);
   }
 
   @Test
@@ -339,9 +339,9 @@ public class FeedServiceWindowValidatorTest {
             "20240131",
             ImmutableList.of("s1"));
 
-    // ServiceWindowExtendsPastFeedPeriodNotice + FeedValidBeyondTotalServiceWindowNotice.
+    // ServiceWindowOutsideFeedPeriodNotice + FeedValidBeyondTotalServiceWindowNotice.
     assertThat(notices).hasSize(2);
-    assertThat(notices.get(0)).isInstanceOf(ServiceWindowExtendsPastFeedPeriodNotice.class);
+    assertThat(notices.get(0)).isInstanceOf(ServiceWindowOutsideFeedPeriodNotice.class);
     assertThat(notices.get(1)).isInstanceOf(FeedValidBeyondTotalServiceWindowNotice.class);
   }
 


### PR DESCRIPTION
**Summary:**

This PR renames service_window_extends_past_feed_period to service_window_outside_feed_period

**Expected behavior:** 

The service_window_extends_past_feed_period is renamed to service_window_outside_feed_period


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
