### PR TITLE
feat: add safe_duration_factor and safe_duration_offset fields to trip schema

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTripSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTripSchema.java
@@ -60,4 +60,8 @@ public interface GtfsTripSchema extends GtfsEntity {
   GtfsBikesAllowed bikesAllowed();
 
   GtfsCarsAllowed carsAllowed();
+
+  double safeDurationFactor();
+
+  double safeDurationOffset();
 }


### PR DESCRIPTION
**Summary:**

Add safe duration fields to trips.txt to provide better, flexible trip time estimates

**Expected behavior:** 

The safe_duration_factor and safe_duration_offset are optional fields of the trip schema.


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
