### PR TITLE
DRAFT: Fix for Issue/2089

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
@@ -117,7 +117,6 @@ public final class CsvFileLoader extends TableLoader {
         }
         if (rowNotices.hasValidationErrors()) {
           logger.atWarning().log("Invalid row in %s: %s", gtfsFilename, row);
-          // hasUnparsableRows = true;
         } else if (validRowLength) {
           GtfsEntity entity = builder.build();
           ValidatorUtil.invokeSingleEntityValidators(

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
@@ -116,7 +116,8 @@ public final class CsvFileLoader extends TableLoader {
           }
         }
         if (rowNotices.hasValidationErrors()) {
-          hasUnparsableRows = true;
+          logger.atWarning().log("Invalid row in %s: %s", gtfsFilename, row);
+          // hasUnparsableRows = true;
         } else if (validRowLength) {
           GtfsEntity entity = builder.build();
           ValidatorUtil.invokeSingleEntityValidators(


### PR DESCRIPTION
This is a draft PR for https://github.com/MobilityData/gtfs-validator/issues/2089.

## Problem

When any row in a file had a field-level validation error (e.g. an invalid URL in `agency.txt`), CsvFileLoader set `hasUnparsableRows = true` and returned an `UNPARSABLE_ROWS` container while discarding all entities from that file, including valid ones.
This caused a silent cascade: if `agency.txt` had even one bad field value, the agency table appeared empty to downstream validators, meaning invalid `agency_id` references in `routes.txt` went unreported.

## Root Cause

The `hasUnparsableRows` flag conflated two distinct problems:

- **Structural** parse failures (wrong row length, row number overflow), the row genuinely cannot be parsed, and the entity should be discarded
- **Field-level** validation errors (invalid URL, missing required field value), the row was parsed fine, the error is recorded, but the entity is excluded via the `else if` branch already

The flag was only correct for the first case. For the second, the error is already recorded in `noticeContainer` (line 126) and the entity is already excluded, setting `hasUnparsableRows = true` was redundant and harmful.