### PR TITLE
fix: discard circular trips when trip_headsign matches intermediate stop name

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripHeadsignValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripHeadsignValidator.java
@@ -58,6 +58,10 @@ public class TripHeadsignValidator extends FileValidator {
 
       // stopTimes are already sorted
       String lastStopId = stopTimes.get(stopTimes.size() - 1).stopId();
+      //      Check if this is a circular trip
+      if (lastStopId == stopTimes.get(0).stopId()) {
+        return;
+      }
 
       // Check all stops except the last
       for (int i = 0; i < stopTimes.size() - 1; i++) {

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripHeadsignValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripHeadsignValidatorTest.java
@@ -129,6 +129,20 @@ public class TripHeadsignValidatorTest {
                 1, "t0", "Airport", "stop_a", 1, "stop_c"));
   }
 
+  @Test
+  public void circularTripsShouldNotGenerateNotice() {
+    assertThat(
+            generateNotices(
+                ImmutableList.of(createTrip(1, "r1", "s1", "t0", "City Hall")),
+                ImmutableList.of(
+                    createStopTime(0, "t0", "stop_a", 1),
+                    createStopTime(0, "t0", "stop_b", 2),
+                    createStopTime(0, "t0", "stop_a", 3)),
+                ImmutableList.of(
+                    createStop("stop_a", "City Hall"), createStop("stop_b", "Airport"))))
+        .isEmpty();
+  }
+
   private static List<ValidationNotice> generateNotices(
       List<GtfsTrip> trips, List<GtfsStopTime> stopTimes, List<GtfsStop> stops) {
     NoticeContainer noticeContainer = new NoticeContainer();


### PR DESCRIPTION
**Summary:**
Related to #2139

This PR discards circular trips when the trip_headsign matches the intermediate stop name.

**Expected behavior:** 

The `trip_headsign_matches_intermediate_stop` notice should not be triggered 

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [ ] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
