### PR TITLE
add new warning

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
@@ -64,12 +64,15 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
 
   @Override
   public boolean shouldCallValidate() {
-    // Only run when stop_times.txt actually contains a shape_dist_traveled column.
-    return stopTimeTable.hasColumn(GtfsStopTime.SHAPE_DIST_TRAVELED_FIELD_NAME);
+    return stopTimeTable != null
+        && stopTimeTable.hasColumn(GtfsStopTime.SHAPE_DIST_TRAVELED_FIELD_NAME);
   }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
+    if (tripTable == null || stopTimeTable == null || shapeTable == null) {
+      return;
+    }
     for (List<GtfsStopTime> stopTimesForTrip :
         Multimaps.asMap(stopTimeTable.byTripIdMap()).values()) {
 
@@ -94,8 +97,7 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
         // Missing shape is reported by a foreign-key rule; skip here.
         continue;
       }
-      boolean shapeHasDistTraveled =
-          shapePoints.stream().anyMatch(GtfsShape::hasShapeDistTraveled);
+      boolean shapeHasDistTraveled = shapePoints.stream().anyMatch(GtfsShape::hasShapeDistTraveled);
       if (!shapeHasDistTraveled) {
         // Find the first stop time that carries shape_dist_traveled for the notice context.
         GtfsStopTime firstStopTimeWithDist =
@@ -106,10 +108,7 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
 
         noticeContainer.addValidationNotice(
             new TripWithShapeDistTraveledButNoShapeDistancesNotice(
-                trip.csvRowNumber(),
-                tripId,
-                trip.shapeId(),
-                firstStopTimeWithDist.csvRowNumber()));
+                trip.csvRowNumber(), tripId, trip.shapeId(), firstStopTimeWithDist.csvRowNumber()));
       }
     }
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
@@ -62,28 +62,34 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
     this.shapeTable = shapeTable;
   }
 
+  /**
+   * Skip validation entirely when any required table is absent or when stop_times.txt does not
+   * contain the shape_dist_traveled column at all (avoids iterating every trip needlessly).
+   */
   @Override
   public boolean shouldCallValidate() {
-    return stopTimeTable != null
-        && stopTimeTable.hasColumn(GtfsStopTime.SHAPE_DIST_TRAVELED_FIELD_NAME);
+    return tripTable != null
+        && stopTimeTable != null
+        && stopTimeTable.hasColumn(GtfsStopTime.SHAPE_DIST_TRAVELED_FIELD_NAME)
+        && shapeTable != null;
   }
 
   @Override
   public void validate(NoticeContainer noticeContainer) {
-    if (tripTable == null || stopTimeTable == null || shapeTable == null) {
-      return;
-    }
     for (List<GtfsStopTime> stopTimesForTrip :
         Multimaps.asMap(stopTimeTable.byTripIdMap()).values()) {
 
-      // Check whether any stop time in this trip carries a shape_dist_traveled value.
-      boolean stopTimesHaveShapeDistTraveled =
-          stopTimesForTrip.stream().anyMatch(GtfsStopTime::hasShapeDistTraveled);
-      if (!stopTimesHaveShapeDistTraveled) {
+      // Find the first stop time that carries a shape_dist_traveled value.
+      // If none exist there is nothing to check for this trip.
+      GtfsStopTime firstStopTimeWithDist =
+          stopTimesForTrip.stream()
+              .filter(GtfsStopTime::hasShapeDistTraveled)
+              .findFirst()
+              .orElse(null);
+      if (firstStopTimeWithDist == null) {
         continue;
       }
 
-      // Look up the trip to get its shape_id.
       String tripId = stopTimesForTrip.get(0).tripId();
       GtfsTrip trip = tripTable.byTripId(tripId).orElse(null);
       if (trip == null || !trip.hasShapeId() || trip.shapeId().isEmpty()) {
@@ -91,35 +97,42 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
         continue;
       }
 
-      // Check whether any shape point in the referenced shape has a shape_dist_traveled value.
       List<GtfsShape> shapePoints = shapeTable.byShapeId(trip.shapeId());
       if (shapePoints.isEmpty()) {
-        // Missing shape is reported by a foreign-key rule; skip here.
+        // A missing shape is reported by a foreign-key rule; skip here to avoid double-reporting.
         continue;
       }
-      boolean shapeHasDistTraveled = shapePoints.stream().anyMatch(GtfsShape::hasShapeDistTraveled);
-      if (!shapeHasDistTraveled) {
-        // Find the first stop time that carries shape_dist_traveled for the notice context.
-        GtfsStopTime firstStopTimeWithDist =
-            stopTimesForTrip.stream()
-                .filter(GtfsStopTime::hasShapeDistTraveled)
-                .findFirst()
-                .orElseThrow(); // safe: we already confirmed at least one exists
 
+      // All shape points must carry shape_dist_traveled for the distances to be usable.
+      // Partial population (some points have a value, others do not) is also treated as
+      // non-compliant because consumers cannot interpolate positions reliably from an
+      // incomplete distance sequence.
+      boolean allShapePointsHaveDist =
+          shapePoints.stream().allMatch(GtfsShape::hasShapeDistTraveled);
+      if (!allShapePointsHaveDist) {
         noticeContainer.addValidationNotice(
             new TripWithShapeDistTraveledButNoShapeDistancesNotice(
-                trip.csvRowNumber(), tripId, trip.shapeId(), firstStopTimeWithDist.csvRowNumber()));
+                trip.csvRowNumber(),
+                tripId,
+                trip.shapeId(),
+                // Row number of the first stop time with a distance value, provided as context
+                // so the consumer can locate the relevant record quickly. Only the first
+                // offending stop time is reported to keep notice volume manageable.
+                firstStopTimeWithDist.csvRowNumber()));
       }
     }
   }
 
   /**
    * A trip has shape_dist_traveled values in stop_times.txt but the shape referenced by the trip's
-   * shape_id has no shape_dist_traveled values in shapes.txt.
+   * shape_id does not have shape_dist_traveled values on all of its points in shapes.txt.
    *
-   * <p>When stop times define distance values but the shape does not, consumers cannot use those
-   * distances to align stops to the shape geometry. This inconsistency may cause incorrect routing
-   * or display behaviour.
+   * <p>When stop times define distance values but the shape does not carry matching distances on
+   * every point, consumers cannot use those distances to align stops to the shape geometry
+   * reliably. This inconsistency may cause incorrect routing or display behaviour.
+   *
+   * <p><b>Note:</b> Only the first stop time carrying a shape_dist_traveled value is referenced in
+   * the notice; this is a representative row rather than an exhaustive list.
    */
   @GtfsValidationNotice(
       severity = WARNING,
@@ -142,7 +155,8 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
 
     /**
      * The row number of the first stop_times.txt record for this trip that contains a
-     * shape_dist_traveled value.
+     * shape_dist_traveled value. Provided as a representative location; other stop times for the
+     * same trip may also carry distance values.
      */
     private final long stopTimeCsvRowNumber;
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
@@ -15,7 +15,7 @@
  */
 package org.mobilitydata.gtfsvalidator.validator;
 
-import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.INFO;
 
 import com.google.common.collect.Multimaps;
 import java.util.List;
@@ -135,7 +135,7 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileV
    * the notice; this is a representative row rather than an exhaustive list.
    */
   @GtfsValidationNotice(
-      severity = WARNING,
+      severity = INFO,
       files =
           @FileRefs({
             GtfsTripSchema.class,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidator.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2025 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.WARNING;
+
+import com.google.common.collect.Multimaps;
+import java.util.List;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeSchema;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeSchema;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripSchema;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+
+/**
+ * Validates that if a trip has shape_dist_traveled values in stop_times.txt and references a shape
+ * via shape_id, the corresponding shape points in shapes.txt also have shape_dist_traveled values.
+ *
+ * <p>When stop times carry shape_dist_traveled but the referenced shape does not, the distance
+ * values cannot be used to align stops to the shape, which may cause incorrect routing or display
+ * behaviour for consumers.
+ *
+ * <p>Generated notice: {@link TripWithShapeDistTraveledButNoShapeDistancesNotice}.
+ */
+@GtfsValidator
+public class TripWithShapeDistTraveledButNoShapeDistancesValidator extends FileValidator {
+
+  private final GtfsTripTableContainer tripTable;
+  private final GtfsStopTimeTableContainer stopTimeTable;
+  private final GtfsShapeTableContainer shapeTable;
+
+  @Inject
+  TripWithShapeDistTraveledButNoShapeDistancesValidator(
+      GtfsTripTableContainer tripTable,
+      GtfsStopTimeTableContainer stopTimeTable,
+      GtfsShapeTableContainer shapeTable) {
+    this.tripTable = tripTable;
+    this.stopTimeTable = stopTimeTable;
+    this.shapeTable = shapeTable;
+  }
+
+  @Override
+  public boolean shouldCallValidate() {
+    // Only run when stop_times.txt actually contains a shape_dist_traveled column.
+    return stopTimeTable.hasColumn(GtfsStopTime.SHAPE_DIST_TRAVELED_FIELD_NAME);
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    for (List<GtfsStopTime> stopTimesForTrip :
+        Multimaps.asMap(stopTimeTable.byTripIdMap()).values()) {
+
+      // Check whether any stop time in this trip carries a shape_dist_traveled value.
+      boolean stopTimesHaveShapeDistTraveled =
+          stopTimesForTrip.stream().anyMatch(GtfsStopTime::hasShapeDistTraveled);
+      if (!stopTimesHaveShapeDistTraveled) {
+        continue;
+      }
+
+      // Look up the trip to get its shape_id.
+      String tripId = stopTimesForTrip.get(0).tripId();
+      GtfsTrip trip = tripTable.byTripId(tripId).orElse(null);
+      if (trip == null || !trip.hasShapeId() || trip.shapeId().isEmpty()) {
+        // No associated shape – nothing to check.
+        continue;
+      }
+
+      // Check whether any shape point in the referenced shape has a shape_dist_traveled value.
+      List<GtfsShape> shapePoints = shapeTable.byShapeId(trip.shapeId());
+      if (shapePoints.isEmpty()) {
+        // Missing shape is reported by a foreign-key rule; skip here.
+        continue;
+      }
+      boolean shapeHasDistTraveled =
+          shapePoints.stream().anyMatch(GtfsShape::hasShapeDistTraveled);
+      if (!shapeHasDistTraveled) {
+        // Find the first stop time that carries shape_dist_traveled for the notice context.
+        GtfsStopTime firstStopTimeWithDist =
+            stopTimesForTrip.stream()
+                .filter(GtfsStopTime::hasShapeDistTraveled)
+                .findFirst()
+                .orElseThrow(); // safe: we already confirmed at least one exists
+
+        noticeContainer.addValidationNotice(
+            new TripWithShapeDistTraveledButNoShapeDistancesNotice(
+                trip.csvRowNumber(),
+                tripId,
+                trip.shapeId(),
+                firstStopTimeWithDist.csvRowNumber()));
+      }
+    }
+  }
+
+  /**
+   * A trip has shape_dist_traveled values in stop_times.txt but the shape referenced by the trip's
+   * shape_id has no shape_dist_traveled values in shapes.txt.
+   *
+   * <p>When stop times define distance values but the shape does not, consumers cannot use those
+   * distances to align stops to the shape geometry. This inconsistency may cause incorrect routing
+   * or display behaviour.
+   */
+  @GtfsValidationNotice(
+      severity = WARNING,
+      files =
+          @FileRefs({
+            GtfsTripSchema.class,
+            GtfsStopTimeSchema.class,
+            GtfsShapeSchema.class,
+          }))
+  public static class TripWithShapeDistTraveledButNoShapeDistancesNotice extends ValidationNotice {
+
+    /** The row number of the faulty record in trips.txt. */
+    private final long tripCsvRowNumber;
+
+    /** The trip_id of the faulty trip. */
+    private final String tripId;
+
+    /** The shape_id referenced by the trip. */
+    private final String shapeId;
+
+    /**
+     * The row number of the first stop_times.txt record for this trip that contains a
+     * shape_dist_traveled value.
+     */
+    private final long stopTimeCsvRowNumber;
+
+    TripWithShapeDistTraveledButNoShapeDistancesNotice(
+        long tripCsvRowNumber, String tripId, String shapeId, long stopTimeCsvRowNumber) {
+      this.tripCsvRowNumber = tripCsvRowNumber;
+      this.tripId = tripId;
+      this.shapeId = shapeId;
+      this.stopTimeCsvRowNumber = stopTimeCsvRowNumber;
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidatorTest.java
@@ -35,6 +35,10 @@ import org.mobilitydata.gtfsvalidator.validator.TripWithShapeDistTraveledButNoSh
 @RunWith(JUnit4.class)
 public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
 
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
   private static GtfsTrip createTrip(int csvRowNumber, String tripId, String shapeId) {
     GtfsTrip.Builder builder =
         new GtfsTrip.Builder()
@@ -88,12 +92,16 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
     return noticeContainer.getValidationNotices();
   }
 
+  // ---------------------------------------------------------------------------
+  // Tests — happy paths (no notice expected)
+  // ---------------------------------------------------------------------------
+
   /**
-   * Stop times have shape_dist_traveled and the shape also has shape_dist_traveled — no notice
-   * expected.
+   * All stop times and all shape points carry shape_dist_traveled — perfectly consistent data, no
+   * notice expected.
    */
   @Test
-  public void stopTimesAndShapeBothHaveDistTraveled_noNotice() {
+  public void stopTimesAndShapeAllHaveDistTraveled_noNotice() {
     List<ValidationNotice> notices =
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1")),
@@ -104,22 +112,10 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
     assertThat(notices).isEmpty();
   }
 
-  /** Stop times have shape_dist_traveled but the shape has none — a notice should be generated. */
-  @Test
-  public void stopTimesHaveDistTraveledButShapeDoesNot_generatesNotice() {
-    List<ValidationNotice> notices =
-        generateNotices(
-            ImmutableList.of(createTrip(1, "trip1", "shape1")),
-            ImmutableList.of(
-                createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
-            ImmutableList.of(createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, null)));
-
-    assertThat(notices).hasSize(1);
-    assertThat(notices.get(0))
-        .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
-  }
-
-  /** Stop times have no shape_dist_traveled and neither does the shape — no notice expected. */
+  /**
+   * No stop times carry shape_dist_traveled and neither do the shape points — nothing to validate,
+   * no notice expected.
+   */
   @Test
   public void neitherStopTimesNorShapeHaveDistTraveled_noNotice() {
     List<ValidationNotice> notices =
@@ -133,8 +129,8 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
   }
 
   /**
-   * Trip has no shape_id — even if stop times have shape_dist_traveled, no notice expected because
-   * there is no shape to compare against.
+   * The trip has no shape_id — even though stop times carry shape_dist_traveled there is no shape
+   * to compare against, so no notice is expected.
    */
   @Test
   public void tripWithNoShapeId_noNotice() {
@@ -148,44 +144,92 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
     assertThat(notices).isEmpty();
   }
 
+  // ---------------------------------------------------------------------------
+  // Tests — notice-generating cases
+  // ---------------------------------------------------------------------------
+
   /**
-   * Only some shape points have shape_dist_traveled — since at least one shape point has a value,
-   * no notice should be generated.
+   * Stop times have shape_dist_traveled but none of the shape points do — the shape distances are
+   * entirely absent, so a notice must be generated.
    */
   @Test
-  public void someShapePointsHaveDistTraveled_noNotice() {
+  public void stopTimesHaveDistTraveledButShapeHasNone_generatesNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", "shape1")),
+            ImmutableList.of(
+                createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of(createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, null)));
+
+    assertThat(notices).hasSize(1);
+    assertThat(notices.get(0))
+        .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
+  }
+
+  /**
+   * Stop times have shape_dist_traveled and the shape is only partially populated (some points have
+   * a value, others do not). Partial population is treated as non-compliant because consumers
+   * cannot reliably interpolate positions from an incomplete distance sequence.
+   */
+  @Test
+  public void stopTimesHaveDistTraveledAndShapeIsPartiallyPopulated_generatesNotice() {
     List<ValidationNotice> notices =
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1")),
             ImmutableList.of(
                 createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
             ImmutableList.of(
-                createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, 100.0)));
+                // One point has a value, one does not — partial population.
+                createShape(1, "shape1", 1, 0.0), createShape(2, "shape1", 2, null)));
 
-    assertThat(notices).isEmpty();
+    assertThat(notices).hasSize(1);
+    assertThat(notices.get(0))
+        .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
   }
 
-  /** Multiple trips: one has the mismatch, the other does not — only one notice expected. */
+  /**
+   * Multiple trips: trip1's shape has no distances (notice expected), trip2's shape has all
+   * distances (no notice). Exactly one notice should be generated.
+   */
   @Test
   public void multipleTrips_onlyMismatchedTripGeneratesNotice() {
     List<ValidationNotice> notices =
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1"), createTrip(2, "trip2", "shape2")),
             ImmutableList.of(
-                // trip1 stop times have dist, shape1 does not → notice
                 createStopTime(1, "trip1", 1, 0.0),
                 createStopTime(2, "trip1", 2, 50.0),
-                // trip2 stop times have dist, shape2 also does → no notice
                 createStopTime(3, "trip2", 1, 0.0),
                 createStopTime(4, "trip2", 2, 50.0)),
             ImmutableList.of(
+                // shape1: no distances → notice for trip1
                 createShape(1, "shape1", 1, null),
                 createShape(2, "shape1", 2, null),
+                // shape2: all distances present → no notice for trip2
                 createShape(3, "shape2", 1, 0.0),
                 createShape(4, "shape2", 2, 50.0)));
 
     assertThat(notices).hasSize(1);
-    assertThat(notices.get(0))
-        .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
+    TripWithShapeDistTraveledButNoShapeDistancesNotice notice =
+        (TripWithShapeDistTraveledButNoShapeDistancesNotice) notices.get(0);
+  }
+
+  /**
+   * The notice should reference the row number of the first stop time that carries a
+   * shape_dist_traveled value (row 2 here, since the first stop time has no distance).
+   */
+  @Test
+  public void noticeReferencesFirstStopTimeWithDist() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", "shape1")),
+            ImmutableList.of(
+                // Row 1: no distance; Row 2: has distance — notice should point to row 2.
+                createStopTime(1, "trip1", 1, null), createStopTime(2, "trip1", 2, 50.0)),
+            ImmutableList.of(createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, null)));
+
+    assertThat(notices).hasSize(1);
+    TripWithShapeDistTraveledButNoShapeDistancesNotice notice =
+        (TripWithShapeDistTraveledButNoShapeDistancesNotice) notices.get(0);
   }
 }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidatorTest.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2025 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsShape;
+import org.mobilitydata.gtfsvalidator.table.GtfsShapeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTrip;
+import org.mobilitydata.gtfsvalidator.table.GtfsTripTableContainer;
+import org.mobilitydata.gtfsvalidator.validator.TripWithShapeDistTraveledButNoShapeDistancesValidator.TripWithShapeDistTraveledButNoShapeDistancesNotice;
+
+@RunWith(JUnit4.class)
+public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
+
+  private static GtfsTrip createTrip(int csvRowNumber, String tripId, String shapeId) {
+    GtfsTrip.Builder builder =
+        new GtfsTrip.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setTripId(tripId)
+            .setRouteId("route1")
+            .setServiceId("service1");
+    if (shapeId != null) {
+      builder.setShapeId(shapeId);
+    }
+    return builder.build();
+  }
+
+  private static GtfsStopTime createStopTime(
+      int csvRowNumber, String tripId, int stopSequence, Double shapeDistTraveled) {
+    GtfsStopTime.Builder builder =
+        new GtfsStopTime.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setTripId(tripId)
+            .setStopId("stop1")
+            .setStopSequence(stopSequence);
+    if (shapeDistTraveled != null) {
+      builder.setShapeDistTraveled(shapeDistTraveled);
+    }
+    return builder.build();
+  }
+
+  private static GtfsShape createShape(
+      int csvRowNumber, String shapeId, int sequence, Double shapeDistTraveled) {
+    GtfsShape.Builder builder =
+        new GtfsShape.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setShapeId(shapeId)
+            .setShapePtLat(0.0)
+            .setShapePtLon(0.0)
+            .setShapePtSequence(sequence);
+    if (shapeDistTraveled != null) {
+      builder.setShapeDistTraveled(shapeDistTraveled);
+    }
+    return builder.build();
+  }
+
+  private static List<ValidationNotice> generateNotices(
+      List<GtfsTrip> trips, List<GtfsStopTime> stopTimes, List<GtfsShape> shapes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    new TripWithShapeDistTraveledButNoShapeDistancesValidator(
+            GtfsTripTableContainer.forEntities(trips, noticeContainer),
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer),
+            GtfsShapeTableContainer.forEntities(shapes, noticeContainer))
+        .validate(noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+
+  /**
+   * Stop times have shape_dist_traveled and the shape also has shape_dist_traveled — no notice
+   * expected.
+   */
+  @Test
+  public void stopTimesAndShapeBothHaveDistTraveled_noNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", "shape1")),
+            ImmutableList.of(
+                createStopTime(1, "trip1", 1, 0.0),
+                createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of(
+                createShape(1, "shape1", 1, 0.0),
+                createShape(2, "shape1", 2, 100.0)));
+
+    assertThat(notices).isEmpty();
+  }
+
+  /**
+   * Stop times have shape_dist_traveled but the shape has none — a notice should be generated.
+   */
+  @Test
+  public void stopTimesHaveDistTraveledButShapeDoesNot_generatesNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", "shape1")),
+            ImmutableList.of(
+                createStopTime(1, "trip1", 1, 0.0),
+                createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of(
+                createShape(1, "shape1", 1, null),
+                createShape(2, "shape1", 2, null)));
+
+    assertThat(notices).hasSize(1);
+    assertThat(notices.get(0))
+        .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
+  }
+
+  /**
+   * Stop times have no shape_dist_traveled and neither does the shape — no notice expected.
+   */
+  @Test
+  public void neitherStopTimesNorShapeHaveDistTraveled_noNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", "shape1")),
+            ImmutableList.of(
+                createStopTime(1, "trip1", 1, null),
+                createStopTime(2, "trip1", 2, null)),
+            ImmutableList.of(
+                createShape(1, "shape1", 1, null),
+                createShape(2, "shape1", 2, null)));
+
+    assertThat(notices).isEmpty();
+  }
+
+  /**
+   * Trip has no shape_id — even if stop times have shape_dist_traveled, no notice expected because
+   * there is no shape to compare against.
+   */
+  @Test
+  public void tripWithNoShapeId_noNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", null)),
+            ImmutableList.of(
+                createStopTime(1, "trip1", 1, 0.0),
+                createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of());
+
+    assertThat(notices).isEmpty();
+  }
+
+  /**
+   * Only some shape points have shape_dist_traveled — since at least one shape point has a value,
+   * no notice should be generated.
+   */
+  @Test
+  public void someShapePointsHaveDistTraveled_noNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(createTrip(1, "trip1", "shape1")),
+            ImmutableList.of(
+                createStopTime(1, "trip1", 1, 0.0),
+                createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of(
+                createShape(1, "shape1", 1, null),
+                createShape(2, "shape1", 2, 100.0)));
+
+    assertThat(notices).isEmpty();
+  }
+
+  /**
+   * Multiple trips: one has the mismatch, the other does not — only one notice expected.
+   */
+  @Test
+  public void multipleTrips_onlyMismatchedTripGeneratesNotice() {
+    List<ValidationNotice> notices =
+        generateNotices(
+            ImmutableList.of(
+                createTrip(1, "trip1", "shape1"),
+                createTrip(2, "trip2", "shape2")),
+            ImmutableList.of(
+                // trip1 stop times have dist, shape1 does not → notice
+                createStopTime(1, "trip1", 1, 0.0),
+                createStopTime(2, "trip1", 2, 50.0),
+                // trip2 stop times have dist, shape2 also does → no notice
+                createStopTime(3, "trip2", 1, 0.0),
+                createStopTime(4, "trip2", 2, 50.0)),
+            ImmutableList.of(
+                createShape(1, "shape1", 1, null),
+                createShape(2, "shape1", 2, null),
+                createShape(3, "shape2", 1, 0.0),
+                createShape(4, "shape2", 2, 50.0)));
+
+    assertThat(notices).hasSize(1);
+    assertThat(notices.get(0))
+        .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TripWithShapeDistTraveledButNoShapeDistancesValidatorTest.java
@@ -98,49 +98,36 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1")),
             ImmutableList.of(
-                createStopTime(1, "trip1", 1, 0.0),
-                createStopTime(2, "trip1", 2, 100.0)),
-            ImmutableList.of(
-                createShape(1, "shape1", 1, 0.0),
-                createShape(2, "shape1", 2, 100.0)));
+                createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of(createShape(1, "shape1", 1, 0.0), createShape(2, "shape1", 2, 100.0)));
 
     assertThat(notices).isEmpty();
   }
 
-  /**
-   * Stop times have shape_dist_traveled but the shape has none — a notice should be generated.
-   */
+  /** Stop times have shape_dist_traveled but the shape has none — a notice should be generated. */
   @Test
   public void stopTimesHaveDistTraveledButShapeDoesNot_generatesNotice() {
     List<ValidationNotice> notices =
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1")),
             ImmutableList.of(
-                createStopTime(1, "trip1", 1, 0.0),
-                createStopTime(2, "trip1", 2, 100.0)),
-            ImmutableList.of(
-                createShape(1, "shape1", 1, null),
-                createShape(2, "shape1", 2, null)));
+                createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
+            ImmutableList.of(createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, null)));
 
     assertThat(notices).hasSize(1);
     assertThat(notices.get(0))
         .isInstanceOf(TripWithShapeDistTraveledButNoShapeDistancesNotice.class);
   }
 
-  /**
-   * Stop times have no shape_dist_traveled and neither does the shape — no notice expected.
-   */
+  /** Stop times have no shape_dist_traveled and neither does the shape — no notice expected. */
   @Test
   public void neitherStopTimesNorShapeHaveDistTraveled_noNotice() {
     List<ValidationNotice> notices =
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1")),
             ImmutableList.of(
-                createStopTime(1, "trip1", 1, null),
-                createStopTime(2, "trip1", 2, null)),
-            ImmutableList.of(
-                createShape(1, "shape1", 1, null),
-                createShape(2, "shape1", 2, null)));
+                createStopTime(1, "trip1", 1, null), createStopTime(2, "trip1", 2, null)),
+            ImmutableList.of(createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, null)));
 
     assertThat(notices).isEmpty();
   }
@@ -155,8 +142,7 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", null)),
             ImmutableList.of(
-                createStopTime(1, "trip1", 1, 0.0),
-                createStopTime(2, "trip1", 2, 100.0)),
+                createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
             ImmutableList.of());
 
     assertThat(notices).isEmpty();
@@ -172,25 +158,19 @@ public class TripWithShapeDistTraveledButNoShapeDistancesValidatorTest {
         generateNotices(
             ImmutableList.of(createTrip(1, "trip1", "shape1")),
             ImmutableList.of(
-                createStopTime(1, "trip1", 1, 0.0),
-                createStopTime(2, "trip1", 2, 100.0)),
+                createStopTime(1, "trip1", 1, 0.0), createStopTime(2, "trip1", 2, 100.0)),
             ImmutableList.of(
-                createShape(1, "shape1", 1, null),
-                createShape(2, "shape1", 2, 100.0)));
+                createShape(1, "shape1", 1, null), createShape(2, "shape1", 2, 100.0)));
 
     assertThat(notices).isEmpty();
   }
 
-  /**
-   * Multiple trips: one has the mismatch, the other does not — only one notice expected.
-   */
+  /** Multiple trips: one has the mismatch, the other does not — only one notice expected. */
   @Test
   public void multipleTrips_onlyMismatchedTripGeneratesNotice() {
     List<ValidationNotice> notices =
         generateNotices(
-            ImmutableList.of(
-                createTrip(1, "trip1", "shape1"),
-                createTrip(2, "trip2", "shape2")),
+            ImmutableList.of(createTrip(1, "trip1", "shape1"), createTrip(2, "trip2", "shape2")),
             ImmutableList.of(
                 // trip1 stop times have dist, shape1 does not → notice
                 createStopTime(1, "trip1", 1, 0.0),


### PR DESCRIPTION
**Summary:**

This adds the warning rule `trip_with_shape_dist_traveled_but_no_shape_distances` of https://github.com/MobilityData/gtfs-validator/issues/2019.

> "For cases where a shape_dist_traveled value is defined in stop_times.txt for a trip but not in shapes.txt."


The provided test dataset (as referenced in the issue):
<img width="913" height="583" alt="Bildschirmfoto vom 2026-05-03 15-06-08" src="https://github.com/user-attachments/assets/48e34999-f80d-4ac5-aa5e-20803d5432d6" />

