### PR TITLE
fix: Walked back changes in public API that made it backward incompatible

### DIFF
--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.ResourceBundle;
 import javax.swing.BorderFactory;
 import javax.swing.Box;
@@ -388,7 +387,7 @@ public class GtfsValidatorApp extends JFrame {
     if (outputDirectory.isBlank()) {
       throw new IllegalStateException("outputDirectoryField is blank");
     }
-    config.setOutputDirectory(Optional.of(Path.of(outputDirectory)));
+    config.setOutputDirectory(Path.of(outputDirectory));
 
     Object numThreads = numThreadsSpinner.getValue();
     if (numThreads instanceof Integer) {

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/ValidationDisplay.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/ValidationDisplay.java
@@ -18,9 +18,9 @@ class ValidationDisplay {
       handleError();
     }
 
-    Path reportPath = config.htmlReportPath().orElse(null);
+    Path reportPath = config.htmlReportPath();
     if (status == ValidationRunner.Status.SYSTEM_ERRORS) {
-      reportPath = config.systemErrorsReportPath().orElse(null);
+      reportPath = config.systemErrorsReportPath();
     }
 
     // Handle missing report path explicitly instead of letting null reach browse().

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
@@ -66,7 +66,7 @@ public class GtfsValidatorAppTest {
 
     ValidationRunnerConfig config = configCaptor.getValue();
     assertThat(config.gtfsSource()).isEqualTo(new URI("http://transit/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/path/to/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/path/to/output"));
     assertThat(config.numThreads()).isEqualTo(1);
     assertThat(config.countryCode().isUnknown()).isTrue();
   }
@@ -84,7 +84,7 @@ public class GtfsValidatorAppTest {
 
     ValidationRunnerConfig config = configCaptor.getValue();
     assertThat(config.gtfsSource()).isEqualTo(new URI("http://transit/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/path/to/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/path/to/output"));
     assertThat(config.numThreads()).isEqualTo(5);
     assertThat(config.countryCode().getCountryCode()).isEqualTo("US");
   }

--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -23,7 +23,6 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
-import java.util.Optional;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
 import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
 
@@ -126,10 +125,10 @@ public class Arguments {
       }
     }
     if (outputBase != null) {
-      builder.setOutputDirectory(Optional.of(Path.of(outputBase)));
+      builder.setOutputDirectory(Path.of(outputBase));
     } else if (stdoutOutput) {
-      // When using stdout, no output directory is needed
-      builder.setOutputDirectory(Optional.empty());
+      // When using stdout, output directory is not written to, but the API requires it.
+      builder.setOutputDirectory(Path.of("."));
     }
     if (countryCode != null) {
       builder.setCountryCode(CountryCode.forStringOrUnknown(countryCode));

--- a/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -45,7 +45,7 @@ public class ArgumentsTest {
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
     ValidationRunnerConfig config = underTest.toConfig();
     assertThat(config.gtfsSource()).isEqualTo(toFileUri("/tmp/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/tmp/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/tmp/output"));
     assertThat(config.countryCode()).isEqualTo(CountryCode.forStringOrUnknown("au"));
     assertThat(config.numThreads()).isEqualTo(4);
     assertThat(config.validationReportFileName()).matches("report.json");
@@ -72,7 +72,7 @@ public class ArgumentsTest {
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
     ValidationRunnerConfig config = underTest.toConfig();
     assertThat(config.gtfsSource()).isEqualTo(new URI("http://host/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/tmp/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/tmp/output"));
     assertThat(config.countryCode()).isEqualTo(CountryCode.forStringOrUnknown("au"));
     assertThat(config.numThreads()).isEqualTo(4);
     assertThat(config.storageDirectory()).hasValue(Path.of("/tmp/storage"));
@@ -95,7 +95,7 @@ public class ArgumentsTest {
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
     ValidationRunnerConfig config = underTest.toConfig();
     assertThat(config.gtfsSource()).isEqualTo(toFileUri("/tmp/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/tmp/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/tmp/output"));
     assertThat(config.countryCode()).isEqualTo(CountryCode.forStringOrUnknown("ca"));
     assertThat(config.numThreads()).isEqualTo(4);
     assertThat(config.validationReportFileName()).matches("report.json");
@@ -131,7 +131,7 @@ public class ArgumentsTest {
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
     ValidationRunnerConfig config = underTest.toConfig();
     assertThat(config.gtfsSource()).isEqualTo(new URI("http://host/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/tmp/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/tmp/output"));
     assertThat(config.countryCode()).isEqualTo(CountryCode.forStringOrUnknown("ca"));
     assertThat(config.numThreads()).isEqualTo(4);
     assertThat(config.storageDirectory()).hasValue(Path.of("/tmp/storage"));
@@ -152,7 +152,7 @@ public class ArgumentsTest {
     new JCommander(underTest).parse(commandLineArgumentAsStringArray);
     ValidationRunnerConfig config = underTest.toConfig();
     assertThat(config.gtfsSource()).isEqualTo(toFileUri("/tmp/gtfs.zip"));
-    assertThat(config.outputDirectory()).hasValue(Path.of("/tmp/output"));
+    assertThat(config.outputDirectory()).isEqualTo(Path.of("/tmp/output"));
     assertThat(config.countryCode()).isEqualTo(CountryCode.forStringOrUnknown("ca"));
     assertThat(config.numThreads()).isEqualTo(1);
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/JsonReportSummaryGenerator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/JsonReportSummaryGenerator.java
@@ -31,8 +31,8 @@ public class JsonReportSummaryGenerator {
             date,
             config != null ? config.gtfsSource().toString() : null,
             config != null ? config.numThreads() : 0,
-            config != null && config.outputDirectory().isPresent()
-                ? config.outputDirectory().get().toString()
+            config != null && !config.stdoutOutput() && config.outputDirectory() != null
+                ? config.outputDirectory().toString()
                 : null,
             config != null && !config.stdoutOutput() ? config.systemErrorsReportFileName() : null,
             config != null && !config.stdoutOutput() ? config.validationReportFileName() : null,

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -340,7 +340,7 @@ public class ValidationRunner {
 
     // Existing file-based output. At this point, stdoutOutput is false and
     // validate() guarantees that an output directory is configured.
-    Path outputDir = config.outputDirectory().get();
+    Path outputDir = config.outputDirectory();
     if (!Files.exists(outputDir)) {
       try {
         Files.createDirectories(outputDir);

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
@@ -29,8 +29,7 @@ public abstract class ValidationRunnerConfig {
   public abstract URI gtfsSource();
 
   // The directory where all validation reports will be written.
-  // Optional when using stdout mode.
-  public abstract Optional<Path> outputDirectory();
+  public abstract Path outputDirectory();
 
   // An optional storage directory to be used when downloading a GTFS feed
   // from an external URL.
@@ -40,14 +39,14 @@ public abstract class ValidationRunnerConfig {
 
   public abstract String htmlReportFileName();
 
-  public Optional<Path> htmlReportPath() {
-    return outputDirectory().map(dir -> dir.resolve(htmlReportFileName()));
+  public Path htmlReportPath() {
+    return outputDirectory().resolve(htmlReportFileName());
   }
 
   public abstract String systemErrorsReportFileName();
 
-  public Optional<Path> systemErrorsReportPath() {
-    return outputDirectory().map(dir -> dir.resolve(systemErrorsReportFileName()));
+  public Path systemErrorsReportPath() {
+    return outputDirectory().resolve(systemErrorsReportFileName());
   }
 
   // Determines the number of parallel threads of execution used during
@@ -88,7 +87,7 @@ public abstract class ValidationRunnerConfig {
   public abstract static class Builder {
     public abstract Builder setGtfsSource(URI gtfsSource);
 
-    public abstract Builder setOutputDirectory(Optional<Path> outputDirectory);
+    public abstract Builder setOutputDirectory(Path outputDirectory);
 
     public abstract Builder setStorageDirectory(Path storageDirectory);
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
@@ -40,7 +40,7 @@ public class JsonReportSummaryGeneratorTest {
     builder.setCountryCode(CountryCode.forStringOrUnknown("GB"));
     builder.setGtfsSource(new URI("some_dataset_filename"));
     builder.setHtmlReportFileName("some_html_filename");
-    builder.setOutputDirectory(Optional.of(Path.of("some_output_directory")));
+    builder.setOutputDirectory(Path.of("some_output_directory"));
     builder.setNumThreads(1);
     builder.setPrettyJson(true);
     builder.setSystemErrorsReportFileName("some_error_filename");
@@ -178,7 +178,7 @@ public class JsonReportSummaryGeneratorTest {
     builder.setCountryCode(CountryCode.forStringOrUnknown("GB"));
     builder.setGtfsSource(new URI("some_dataset_filename"));
     builder.setHtmlReportFileName("some_html_filename");
-    builder.setOutputDirectory(Optional.of(Path.of("some_output_directory")));
+    builder.setOutputDirectory(Path.of("some_output_directory"));
     builder.setNumThreads(1);
     builder.setPrettyJson(true);
     builder.setSystemErrorsReportFileName("some_error_filename");
@@ -196,7 +196,6 @@ public class JsonReportSummaryGeneratorTest {
             + "\"validatedAt\":\"now\","
             + "\"gtfsInput\":\"some_dataset_filename\","
             + "\"threads\":1,"
-            + "\"outputDirectory\":\"some_output_directory\","
             + "\"countryCode\":\"GB\","
             + "\"dateForValidation\":\"2020-01-02\"}";
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
@@ -7,7 +7,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
-import java.util.Optional;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -19,7 +18,7 @@ public class ValidationRunnerTest {
   private static ValidationRunnerConfig buildConfig(String gtfsDirectory) {
     ValidationRunnerConfig.Builder config = ValidationRunnerConfig.builder();
     config.setGtfsSource(Path.of(gtfsDirectory).toUri());
-    config.setOutputDirectory(Optional.of(Path.of("")));
+    config.setOutputDirectory(Path.of(""));
     config.setNumThreads(1);
     config.setCountryCode(CountryCode.forStringOrUnknown(""));
     config.setStdoutOutput(false);
@@ -52,7 +51,7 @@ public class ValidationRunnerTest {
     ValidationRunnerConfig config =
         ValidationRunnerConfig.builder()
             .setGtfsSource(Path.of("/tmp/nonexistent.zip").toUri())
-            .setOutputDirectory(Optional.of(Path.of("out")))
+            .setOutputDirectory(Path.of("out"))
             .build();
 
     assertFalse(config.stdoutOutput());

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandler.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandler.java
@@ -2,7 +2,6 @@ package org.mobilitydata.gtfsvalidator.web.service.util;
 
 import java.io.File;
 import java.nio.file.Path;
-import java.util.Optional;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
@@ -33,7 +32,7 @@ public class ValidationHandler {
     var configBuilder =
         ValidationRunnerConfig.builder()
             .setGtfsSource(feedFile.toURI())
-            .setOutputDirectory(Optional.of(outputPath))
+            .setOutputDirectory(outputPath)
             .setStdoutOutput(false)
             .setSkipValidatorUpdate(
                 true); // skipValidatorUpdate is true to prevent remote version checks and forces

--- a/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandlerTest.java
+++ b/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandlerTest.java
@@ -41,9 +41,7 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assertTrue(
-        config.outputDirectory().isPresent()
-            && mockOutputPath.equals(config.outputDirectory().get()));
+    assertTrue(mockOutputPath.equals(config.outputDirectory()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 
@@ -63,9 +61,7 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assertTrue(
-        config.outputDirectory().isPresent()
-            && mockOutputPath.equals(config.outputDirectory().get()));
+    assertTrue(mockOutputPath.equals(config.outputDirectory()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 
@@ -90,9 +86,7 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assertTrue(
-        config.outputDirectory().isPresent()
-            && mockOutputPath.equals(config.outputDirectory().get()));
+    assertTrue(mockOutputPath.equals(config.outputDirectory()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 
@@ -119,9 +113,7 @@ public class ValidationHandlerTest {
     verify(runner, times(1)).run(configCaptor.capture());
     var config = configCaptor.getValue();
     assert config.gtfsSource().equals(feedFileURI);
-    assertTrue(
-        config.outputDirectory().isPresent()
-            && mockOutputPath.equals(config.outputDirectory().get()));
+    assertTrue(mockOutputPath.equals(config.outputDirectory()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
 }


### PR DESCRIPTION
**Summary:**
Closes #2158 
cc @drewda

In #2132 the public API of the published jars was changed by mistake.
This PR walks that change back, but not the use of `stdout` which was the gist of #2132.
It only changes the use an optional in the return value  of [ValidationRunnerConfig.Builder#outputDirectory](https://github.com/MobilityData/gtfs-validator/blob/9b9cd8feb7a8ff5c3b7bffc8b35fa8574235b447/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java#L33)
and associated methods.

**Expected behavior:** 
There should be no change in behaviour

Tested by building https://github.com/MobilityData/gtfs-validator-example

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [ ] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s)
