### PR TITLE
feat: Add quiet CLI flag to silence informational outputs

### DIFF
--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -114,6 +114,11 @@ public class Arguments {
       description = "Output JSON report to stdout instead of writing to files (conflicts with -o)")
   private boolean stdoutOutput = false;
 
+  @Parameter(
+      names = {"-q", "--quiet"},
+      description = "Silences non-critical log messages when running validator")
+  private boolean quiet = false;
+
   ValidationRunnerConfig toConfig() throws URISyntaxException {
     ValidationRunnerConfig.Builder builder = ValidationRunnerConfig.builder();
     if (input != null) {
@@ -149,6 +154,7 @@ public class Arguments {
     builder.setPrettyJson(pretty);
     builder.setSkipValidatorUpdate(skipValidatorUpdate);
     builder.setStdoutOutput(stdoutOutput);
+    builder.setQuietLogs(quiet);
     return builder.build();
   }
 
@@ -170,6 +176,10 @@ public class Arguments {
 
   public boolean getStdoutOutput() {
     return stdoutOutput;
+  }
+
+  public boolean getQuietLogs() {
+    return quiet;
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -106,8 +106,10 @@ public class ValidationRunner {
     }
     GtfsFeedLoader feedLoader = new GtfsFeedLoader(ClassGraphDiscovery.discoverTables());
 
+    if (!config.quietLogs()) {
     logger.atInfo().log("validation config:\n%s", config);
     logger.atInfo().log("validators:\n%s", validatorLoader.listValidators());
+    }
 
     final long startNanos = System.nanoTime();
     // Input.
@@ -248,8 +250,10 @@ public class ValidationRunner {
       logger.atWarning().log(b.toString());
     }
 
+    if (!config.quietLogs()) {
     logger.atInfo().log("Validation took %.3f seconds%n", feedMetadata.validationTimeSeconds);
     logger.atInfo().log(feedContainer.tableTotalsText());
+    }
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
@@ -69,6 +69,9 @@ public abstract class ValidationRunnerConfig {
   // If true, output JSON report to stdout instead of writing to files
   public abstract boolean stdoutOutput();
 
+  // If true, the validation runner will not print informational logging messages
+  public abstract boolean quietLogs();
+
   public static Builder builder() {
     // Set reasonable defaults where appropriate.
     return new AutoValue_ValidationRunnerConfig.Builder()
@@ -81,6 +84,7 @@ public abstract class ValidationRunnerConfig {
         .setDateForValidation(LocalDate.now())
         .setSkipValidatorUpdate(false)
         .setStdoutOutput(false);
+        .setQuietLogs(false);
   }
 
   @AutoValue.Builder
@@ -108,6 +112,8 @@ public abstract class ValidationRunnerConfig {
     public abstract Builder setSkipValidatorUpdate(boolean skipValidatorUpdate);
 
     public abstract Builder setStdoutOutput(boolean stdoutOutput);
+
+    public abstract Builder setQuietLogs(boolean quietLogs);
 
     public abstract ValidationRunnerConfig build();
   }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
@@ -83,7 +83,7 @@ public abstract class ValidationRunnerConfig {
         .setCountryCode(CountryCode.forStringOrUnknown(CountryCode.ZZ))
         .setDateForValidation(LocalDate.now())
         .setSkipValidatorUpdate(false)
-        .setStdoutOutput(false);
+        .setStdoutOutput(false)
         .setQuietLogs(false);
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
@@ -47,6 +47,7 @@ public class JsonReportSummaryGeneratorTest {
     builder.setValidationReportFileName("some_report_filename");
     builder.setDateForValidation(LocalDate.parse("2020-01-02"));
     builder.setStdoutOutput(false);
+    builder.setQuietLogs(false);
 
     return builder.build();
   }


### PR DESCRIPTION
**Summary:**

Adds a CLI flag (`-q, --quiet`) to silence informational printouts (those not related to a version upgrade) in the validation runner


Closes #256

**Expected behavior:** 

Explain and/or show screenshots for how you expect the pull request to work in your testing (in case other devices exhibit different behavior).


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
