### PR TITLE
feat: add http headers parameter to cli and local app

### DIFF
--- a/app/gui/build.gradle
+++ b/app/gui/build.gradle
@@ -25,6 +25,7 @@ mainClassName = 'org.mobilitydata.gtfsvalidator.app.gui.Main'
 dependencies {
     implementation project(':core')
     implementation project(':main')
+    implementation libs.guava
     implementation libs.flogger
     implementation libs.flogger.system.backend
     testImplementation libs.junit

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
@@ -484,7 +484,9 @@ public class GtfsValidatorApp extends JFrame {
    * <p>Callers must ensure the text is valid via {@link #validateHttpHeadersText} first.
    */
   static ImmutableMap<String, String> parseHttpHeaders(String text) {
-    ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
+    // Use LinkedHashMap so duplicate header names keep the last value (last-wins semantics)
+    // rather than throwing, which is a more forgiving user experience.
+    java.util.LinkedHashMap<String, String> map = new java.util.LinkedHashMap<>();
     for (String line : text.split("\n")) {
       if (line.isBlank()) {
         continue;
@@ -492,7 +494,7 @@ public class GtfsValidatorApp extends JFrame {
       int colon = line.indexOf(':');
       map.put(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
     }
-    return map.build();
+    return ImmutableMap.copyOf(map);
   }
 
   private static Font createBoldFont() {

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.java
@@ -15,6 +15,7 @@
  */
 package org.mobilitydata.gtfsvalidator.app.gui;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import java.awt.Color;
 import java.awt.Component;
@@ -45,7 +46,9 @@ import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JScrollPane;
 import javax.swing.JSpinner;
+import javax.swing.JTextArea;
 import javax.swing.JTextField;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
@@ -78,6 +81,8 @@ public class GtfsValidatorApp extends JFrame {
 
   private final JSpinner numThreadsSpinner = new JSpinner();
   private final JTextField countryCodeField = new JTextField("", 3);
+  private final JTextArea httpHeadersField = new JTextArea(4, TEXT_FIELD_COLUMN_WIDTH);
+  private final JLabel httpHeadersErrorLabel = new JLabel();
 
   private final MonitoredValidationRunner validationRunner;
   private final ValidationDisplay validationDisplay;
@@ -127,6 +132,17 @@ public class GtfsValidatorApp extends JFrame {
 
   public String getCountryCode() {
     return countryCodeField.getText();
+  }
+
+  public void setHttpHeaders(String httpHeaders) {
+    httpHeadersField.setText(httpHeaders);
+  }
+
+  /**
+   * Returns the raw text from the HTTP headers field (newline-separated {@code Name: Value} lines).
+   */
+  public String getHttpHeaders() {
+    return httpHeadersField.getText();
   }
 
   void addPreValidationCallback(Runnable callback) {
@@ -291,6 +307,34 @@ public class GtfsValidatorApp extends JFrame {
     fieldConstraints.gridy = 1;
     panel.add(countryCodeField, fieldConstraints);
 
+    // HTTP Headers — spans both columns so the text area gets full width
+    GridBagConstraints fullRowConstraints = new GridBagConstraints();
+    fullRowConstraints.gridx = 0;
+    fullRowConstraints.gridwidth = 2;
+    fullRowConstraints.anchor = GridBagConstraints.NORTHWEST;
+    fullRowConstraints.fill = GridBagConstraints.HORIZONTAL;
+    fullRowConstraints.weightx = 1.0;
+
+    fullRowConstraints.gridy = 2;
+    panel.add(new JLabel(bundle.getString("http_headers")), fullRowConstraints);
+
+    httpHeadersField.setLineWrap(false);
+    JScrollPane headersScrollPane = new JScrollPane(httpHeadersField);
+    fullRowConstraints.gridy = 3;
+    panel.add(headersScrollPane, fullRowConstraints);
+
+    httpHeadersErrorLabel.setForeground(Color.RED);
+    httpHeadersErrorLabel.setVisible(false);
+    fullRowConstraints.gridy = 4;
+    panel.add(httpHeadersErrorLabel, fullRowConstraints);
+
+    fullRowConstraints.gridy = 5;
+    panel.add(new JLabel(bundle.getString("http_headers_description")), fullRowConstraints);
+
+    httpHeadersField
+        .getDocument()
+        .addDocumentListener(documentChangeListener(this::updateValidationButtonStatus));
+
     advancedOptionsPanel.setVisible(false);
   }
 
@@ -342,6 +386,13 @@ public class GtfsValidatorApp extends JFrame {
   }
 
   private void updateValidationButtonStatus() {
+    String headerError = validateHttpHeadersText(httpHeadersField.getText());
+    if (headerError != null) {
+      httpHeadersErrorLabel.setText(headerError);
+      httpHeadersErrorLabel.setVisible(true);
+    } else {
+      httpHeadersErrorLabel.setVisible(false);
+    }
     validateButton.setEnabled(isValidationReadyToRun());
   }
 
@@ -350,6 +401,9 @@ public class GtfsValidatorApp extends JFrame {
       return false;
     }
     if (outputDirectoryField.getText().isBlank()) {
+      return false;
+    }
+    if (validateHttpHeadersText(httpHeadersField.getText()) != null) {
       return false;
     }
     return true;
@@ -373,7 +427,7 @@ public class GtfsValidatorApp extends JFrame {
     config.setPrettyJson(true);
     config.setStdoutOutput(false);
 
-    String gtfsInput = gtfsInputField.getText();
+    String gtfsInput = gtfsInputField.getText().strip();
     if (gtfsInput.isBlank()) {
       throw new IllegalStateException("gtfsInputField is blank");
     }
@@ -383,7 +437,7 @@ public class GtfsValidatorApp extends JFrame {
       config.setGtfsSource(Path.of(gtfsInput).toUri());
     }
 
-    String outputDirectory = outputDirectoryField.getText();
+    String outputDirectory = outputDirectoryField.getText().strip();
     if (outputDirectory.isBlank()) {
       throw new IllegalStateException("outputDirectoryField is blank");
     }
@@ -399,7 +453,46 @@ public class GtfsValidatorApp extends JFrame {
       config.setCountryCode(CountryCode.forStringOrUnknown(countryCode));
     }
 
+    config.setHttpHeaders(parseHttpHeaders(httpHeadersField.getText()));
+
     return config.build();
+  }
+
+  /**
+   * Validates newline-separated {@code Name: Value} header lines.
+   *
+   * @return {@code null} if all lines are valid, or a human-readable error message for the first
+   *     invalid line.
+   */
+  static String validateHttpHeadersText(String text) {
+    for (String line : text.split("\n")) {
+      if (line.isBlank()) {
+        continue;
+      }
+      int colon = line.indexOf(':');
+      if (colon <= 0) {
+        return "Invalid header (expected \u201cName: Value\u201d): " + line.trim();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Parses newline-separated {@code Name: Value} header lines into an {@link ImmutableMap}. Blank
+   * lines are skipped. Colons inside the value are preserved.
+   *
+   * <p>Callers must ensure the text is valid via {@link #validateHttpHeadersText} first.
+   */
+  static ImmutableMap<String, String> parseHttpHeaders(String text) {
+    ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
+    for (String line : text.split("\n")) {
+      if (line.isBlank()) {
+        continue;
+      }
+      int colon = line.indexOf(':');
+      map.put(line.substring(0, colon).trim(), line.substring(colon + 1).trim());
+    }
+    return map.build();
   }
 
   private static Font createBoldFont() {

--- a/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferences.java
+++ b/app/gui/src/main/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferences.java
@@ -15,6 +15,7 @@ public class GtfsValidatorPreferences {
   private static final String KEY_OUTPUT_DIRECTORY = "output_directory";
   private static final String KEY_NUM_THREADS = "num_threads";
   private static final String KEY_COUNTRY_CODE = "country_code";
+  private static final String KEY_HTTP_HEADERS = "http_headers";
 
   private final Preferences prefs;
 
@@ -27,6 +28,9 @@ public class GtfsValidatorPreferences {
     loadPathSetting(KEY_OUTPUT_DIRECTORY, app::setOutputDirectory);
     loadIntSetting(KEY_NUM_THREADS, app::setNumThreads);
     loadStringSetting(KEY_COUNTRY_CODE, app::setCountryCode);
+    // HTTP headers are intentionally NOT loaded and any previously stored value is deleted to
+    // avoid leaking credentials (tokens, passwords) across sessions.
+    prefs.remove(KEY_HTTP_HEADERS);
   }
 
   public void savePreferences(GtfsValidatorApp app) {
@@ -34,6 +38,7 @@ public class GtfsValidatorPreferences {
     saveStringSetting(app::getOutputDirectory, KEY_OUTPUT_DIRECTORY);
     saveIntSetting(app::getNumThreads, KEY_NUM_THREADS);
     saveStringSetting(app::getCountryCode, KEY_COUNTRY_CODE);
+    // HTTP headers are intentionally NOT saved — they may contain credentials.
   }
 
   private void loadStringSetting(String key, Consumer<String> setter) {

--- a/app/gui/src/main/resources/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.properties
+++ b/app/gui/src/main/resources/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorApp.properties
@@ -15,5 +15,7 @@ advanced=Advanced
 advanced_options=Advanced Options
 number_of_threads=Number of threads used to run the validator:
 country_code=Country Code (for phone validation):
+http_headers=Custom HTTP Headers (one per line, Name: Value format):
+http_headers_description=Only applied when downloading from a URL. Example: Authorization: Bearer token
 
 validate=Validate

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static com.google.common.truth.Truth8.assertThat;
 import static org.mockito.Mockito.verify;
 
+import com.google.common.collect.ImmutableMap;
 import java.awt.GraphicsEnvironment;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -100,5 +101,94 @@ public class GtfsValidatorAppTest {
     app.getValidateButtonForTesting().doClick();
 
     verify(callback).run();
+  }
+
+  @Test
+  public void testHttpHeadersPassedToConfig() throws URISyntaxException {
+    app.setGtfsSource("http://transit/gtfs.zip");
+    app.setOutputDirectory(Path.of("/path/to/output"));
+    app.setHttpHeaders("Authorization: Bearer token123\nUser-Agent: my-app/2.0");
+
+    app.getValidateButtonForTesting().doClick();
+
+    verify(runner).run(configCaptor.capture(), Mockito.same(app));
+
+    ValidationRunnerConfig config = configCaptor.getValue();
+    assertThat(config.httpHeaders())
+        .isEqualTo(
+            ImmutableMap.of(
+                "Authorization", "Bearer token123",
+                "User-Agent", "my-app/2.0"));
+  }
+
+  @Test
+  public void testParseHttpHeaders_empty() {
+    assertThat(GtfsValidatorApp.parseHttpHeaders("")).isEmpty();
+    assertThat(GtfsValidatorApp.parseHttpHeaders("   \n  \n")).isEmpty();
+  }
+
+  @Test
+  public void testParseHttpHeaders_valueContainsColon() {
+    ImmutableMap<String, String> result =
+        GtfsValidatorApp.parseHttpHeaders("X-Endpoint: http://trace.example.com/id");
+    assertThat(result).isEqualTo(ImmutableMap.of("X-Endpoint", "http://trace.example.com/id"));
+  }
+
+  @Test
+  public void testNoHttpHeadersGivesEmptyMap() throws URISyntaxException {
+    app.setGtfsSource("http://transit/gtfs.zip");
+    app.setOutputDirectory(Path.of("/path/to/output"));
+
+    app.getValidateButtonForTesting().doClick();
+
+    verify(runner).run(configCaptor.capture(), Mockito.same(app));
+    assertThat(configCaptor.getValue().httpHeaders()).isEmpty();
+  }
+
+  // --- Validation tests ---
+
+  @Test
+  public void testValidateHttpHeadersText_validHeaders() {
+    assertThat(GtfsValidatorApp.validateHttpHeadersText("")).isNull();
+    assertThat(GtfsValidatorApp.validateHttpHeadersText("   \n  ")).isNull();
+    assertThat(GtfsValidatorApp.validateHttpHeadersText("Authorization: Bearer token")).isNull();
+    assertThat(
+            GtfsValidatorApp.validateHttpHeadersText(
+                "Authorization: Bearer token\nUser-Agent: app/1.0"))
+        .isNull();
+  }
+
+  @Test
+  public void testValidateHttpHeadersText_missingColon() {
+    // Value-only line (the bug that was reported)
+    String error =
+        GtfsValidatorApp.validateHttpHeadersText(
+            "Basic YXBpQG1vYmlsaXR5ZGF0YS5vcmc6cWN2M3RoaypOWk00cGFmX3V5YQ==");
+    assertThat(error).isNotNull();
+    assertThat(error).contains("Basic YXBpQG1vYmlsaXR5ZGF0YS5vcmc6cWN2M3RoaypOWk00cGFmX3V5YQ==");
+  }
+
+  @Test
+  public void testValidateHttpHeadersText_colonAtStart() {
+    // Colon at position 0 → name is empty → invalid
+    String error = GtfsValidatorApp.validateHttpHeadersText(": value");
+    assertThat(error).isNotNull();
+  }
+
+  @Test
+  public void testInvalidHeaderDisablesValidateButton() {
+    app.setGtfsSource("http://transit/gtfs.zip");
+    app.setOutputDirectory(Path.of("/path/to/output"));
+    // Valid so far — button should be enabled
+    assertThat(app.getValidateButtonForTesting().isEnabled()).isTrue();
+
+    // Set an invalid header — button should become disabled
+    app.setHttpHeaders("Basic YXBpQG1vYmlsaXR5ZGF0YS5vcmc6cWN2M3RoaypOWk00cGFmX3V5YQ==");
+    assertThat(app.getValidateButtonForTesting().isEnabled()).isFalse();
+
+    // Fix the header — button re-enabled
+    app.setHttpHeaders(
+        "Authorization: Basic YXBpQG1vYmlsaXR5ZGF0YS5vcmc6cWN2M3RoaypOWk00cGFmX3V5YQ==");
+    assertThat(app.getValidateButtonForTesting().isEnabled()).isTrue();
   }
 }

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorAppTest.java
@@ -128,6 +128,14 @@ public class GtfsValidatorAppTest {
   }
 
   @Test
+  public void testParseHttpHeaders_duplicateKeyKeepsLast() {
+    ImmutableMap<String, String> result =
+        GtfsValidatorApp.parseHttpHeaders(
+            "Authorization: Bearer first\nAuthorization: Bearer second");
+    assertThat(result).isEqualTo(ImmutableMap.of("Authorization", "Bearer second"));
+  }
+
+  @Test
   public void testParseHttpHeaders_valueContainsColon() {
     ImmutableMap<String, String> result =
         GtfsValidatorApp.parseHttpHeaders("X-Endpoint: http://trace.example.com/id");

--- a/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferencesTest.java
+++ b/app/gui/src/test/java/org/mobilitydata/gtfsvalidator/app/gui/GtfsValidatorPreferencesTest.java
@@ -56,4 +56,26 @@ public class GtfsValidatorPreferencesTest {
       assertThat(dest.getCountryCode()).isEqualTo("CA");
     }
   }
+
+  @Test
+  public void testHttpHeadersAreNotPersisted() {
+    // Headers must not survive a save/load cycle (security: they may contain credentials).
+    {
+      GtfsValidatorApp source = new GtfsValidatorApp(runner, display);
+      source.setGtfsSource("http://gtfs.org/gtfs.zip");
+      source.setOutputDirectory(Path.of("/tmp/gtfs"));
+      source.setHttpHeaders("Authorization: Bearer secret-token");
+
+      GtfsValidatorPreferences prefs = new GtfsValidatorPreferences();
+      prefs.savePreferences(source);
+    }
+
+    {
+      GtfsValidatorPreferences prefs = new GtfsValidatorPreferences();
+      GtfsValidatorApp dest = new GtfsValidatorApp(runner, display);
+      prefs.loadPreferences(dest);
+
+      assertThat(dest.getHttpHeaders()).isEmpty();
+    }
+  }
 }

--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -17,12 +17,15 @@
 package org.mobilitydata.gtfsvalidator.cli;
 
 import com.beust.jcommander.Parameter;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
 import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
 
@@ -114,6 +117,14 @@ public class Arguments {
       description = "Output JSON report to stdout instead of writing to files (conflicts with -o)")
   private boolean stdoutOutput = false;
 
+  @Parameter(
+      names = {"--http_header"},
+      description =
+          "Custom HTTP header to send when downloading a GTFS feed from a URL, in the format"
+              + " 'Name: Value'. May be repeated to set multiple headers. A 'User-Agent' header"
+              + " overrides the default validator User-Agent.")
+  private List<String> httpHeaders = new ArrayList<>();
+
   ValidationRunnerConfig toConfig() throws URISyntaxException {
     ValidationRunnerConfig.Builder builder = ValidationRunnerConfig.builder();
     if (input != null) {
@@ -149,7 +160,18 @@ public class Arguments {
     builder.setPrettyJson(pretty);
     builder.setSkipValidatorUpdate(skipValidatorUpdate);
     builder.setStdoutOutput(stdoutOutput);
+    builder.setHttpHeaders(parseHttpHeaders(httpHeaders));
     return builder.build();
+  }
+
+  private static ImmutableMap<String, String> parseHttpHeaders(List<String> rawHeaders) {
+    ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
+    for (String raw : rawHeaders) {
+      int colon = raw.indexOf(':');
+      // validate() already guarantees colon > 0 before toConfig() is called.
+      map.put(raw.substring(0, colon).trim(), raw.substring(colon + 1).trim());
+    }
+    return map.build();
   }
 
   public String getOutputBase() {
@@ -210,6 +232,14 @@ public class Arguments {
     if (outputBase == null && !stdoutOutput) {
       logger.atSevere().log("Must provide either --output_base or --stdout");
       return false;
+    }
+
+    for (String raw : httpHeaders) {
+      int colon = raw.indexOf(':');
+      if (colon <= 0) {
+        logger.atSevere().log("Invalid --http_header value (expected 'Name: Value'): %s", raw);
+        return false;
+      }
     }
 
     return true;

--- a/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
+++ b/cli/src/main/java/org/mobilitydata/gtfsvalidator/cli/Arguments.java
@@ -165,13 +165,15 @@ public class Arguments {
   }
 
   private static ImmutableMap<String, String> parseHttpHeaders(List<String> rawHeaders) {
-    ImmutableMap.Builder<String, String> map = ImmutableMap.builder();
+    // Use LinkedHashMap so duplicate header names keep the last value (last-wins semantics)
+    // rather than throwing, which is a more forgiving user experience.
+    java.util.LinkedHashMap<String, String> map = new java.util.LinkedHashMap<>();
     for (String raw : rawHeaders) {
       int colon = raw.indexOf(':');
       // validate() already guarantees colon > 0 before toConfig() is called.
       map.put(raw.substring(0, colon).trim(), raw.substring(colon + 1).trim());
     }
-    return map.build();
+    return ImmutableMap.copyOf(map);
   }
 
   public String getOutputBase() {

--- a/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.beust.jcommander.JCommander;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -296,13 +297,97 @@ public class ArgumentsTest {
   }
 
   @Test
-  public void exportNoticesSchema_schemaOnlyWithoutOutputBase_isNotValid() {
-    String[] cliArguments = {"--export_notices_schema"};
-    Arguments args = new Arguments();
-    new JCommander(args).parse(cliArguments);
-
-    assertThat(args.validate()).isFalse();
-    assertThat(args.getExportNoticeSchema()).isTrue();
-    assertThat(args.abortAfterNoticeSchemaExport()).isTrue();
+  public void httpHeader_singleHeader() throws URISyntaxException {
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header", "X-Custom-Header: my-value"
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    ValidationRunnerConfig config = underTest.toConfig();
+    assertThat(config.httpHeaders()).isEqualTo(ImmutableMap.of("X-Custom-Header", "my-value"));
   }
+
+  @Test
+  public void httpHeader_multipleHeaders() throws URISyntaxException {
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header", "Authorization: Bearer token123",
+      "--http_header", "User-Agent: my-custom-agent/1.0"
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    ValidationRunnerConfig config = underTest.toConfig();
+    assertThat(config.httpHeaders())
+        .isEqualTo(
+            ImmutableMap.of(
+                "Authorization", "Bearer token123",
+                "User-Agent", "my-custom-agent/1.0"));
+  }
+
+  @Test
+  public void httpHeader_headerValueContainsColon() throws URISyntaxException {
+    // Values like URLs that contain colons should be preserved fully.
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header", "X-Endpoint: http://trace.example.com/id"
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    ValidationRunnerConfig config = underTest.toConfig();
+    assertThat(config.httpHeaders())
+        .isEqualTo(ImmutableMap.of("X-Endpoint", "http://trace.example.com/id"));
+  }
+
+  @Test
+  public void httpHeader_noHeadersGivesEmptyMap() throws URISyntaxException {
+    String[] args = {"--input", "/tmp/gtfs.zip", "--output_base", "/tmp/out"};
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    ValidationRunnerConfig config = underTest.toConfig();
+    assertThat(config.httpHeaders()).isEmpty();
+  }
+
+  @Test
+  public void httpHeader_valueOnlyNoColen_isNotValid() {
+    // Reproduces the reported bug: user pastes just the credential value without "Name: "
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header", "Basic YXBpQG1vYmlsaXR5ZGF0YS5vcmc6cWN2M3RoaypOWk00cGFmX3V5YQ=="
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    assertFalse(underTest.validate());
+  }
+
+  @Test
+  public void httpHeader_colonAtStartNullName_isNotValid() {
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header", ": value"
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    assertFalse(underTest.validate());
+  }
+
+  @Test
+  public void httpHeader_validHeaderPassesValidation() {
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header",
+          "Authorization: Basic YXBpQG1vYmlsaXR5ZGF0YS5vcmc6cWN2M3RoaypOWk00cGFmX3V5YQ=="
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    assertTrue(underTest.validate());
+  }
+
+  // --- end of class ---
 }

--- a/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -352,6 +352,21 @@ public class ArgumentsTest {
   }
 
   @Test
+  public void httpHeader_duplicateKeyKeepsLast() throws URISyntaxException {
+    String[] args = {
+      "--url", "http://example.com/gtfs.zip",
+      "--output_base", "/tmp/out",
+      "--http_header", "Authorization: Bearer first",
+      "--http_header", "Authorization: Bearer second"
+    };
+    Arguments underTest = new Arguments();
+    new JCommander(underTest).parse(args);
+    assertTrue(underTest.validate());
+    ValidationRunnerConfig config = underTest.toConfig();
+    assertThat(config.httpHeaders()).isEqualTo(ImmutableMap.of("Authorization", "Bearer second"));
+  }
+
+  @Test
   public void httpHeader_valueOnlyNoColen_isNotValid() {
     // Reproduces the reported bug: user pastes just the credential value without "Name: "
     String[] args = {

--- a/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
+++ b/cli/src/test/java/org/mobilitydata/gtfsvalidator/cli/ArgumentsTest.java
@@ -249,6 +249,17 @@ public class ArgumentsTest {
   }
 
   @Test
+  public void exportNoticesSchema_schemaOnlyWithoutOutputBase_isNotValid() {
+    String[] cliArguments = {"--export_notices_schema"};
+    Arguments args = new Arguments();
+    new JCommander(args).parse(cliArguments);
+
+    assertThat(args.validate()).isFalse();
+    assertThat(args.getExportNoticeSchema()).isTrue();
+    assertThat(args.abortAfterNoticeSchemaExport()).isTrue();
+  }
+
+  @Test
   public void exportNoticesSchema_schemaAndValidation() {
     String[] cliArguments = {
       "--export_notices_schema", "--input", "input value", "--output_base", "output value"

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import org.apache.commons.compress.archivers.zip.ZipFile;
@@ -112,12 +113,17 @@ public abstract class GtfsInput implements Closeable {
    * @param targetPath the path to store the downloaded GTFS archive
    * @param noticeContainer
    * @param validatorVersion
+   * @param httpHeaders additional HTTP headers; a {@code "User-Agent"} entry overrides the default
    * @return the {@code GtfsInput} created after download of the GTFS archive
    * @throws IOException if GTFS archive cannot be stored at the specified location
    * @throws URISyntaxException if URL is malformed
    */
   public static GtfsInput createFromUrl(
-      URL sourceUrl, Path targetPath, NoticeContainer noticeContainer, String validatorVersion)
+      URL sourceUrl,
+      Path targetPath,
+      NoticeContainer noticeContainer,
+      String validatorVersion,
+      Map<String, String> httpHeaders)
       throws IOException, URISyntaxException {
     // getParent() may return null if there is no parent, so call toAbsolutePath() first.
     Path targetDirectory = targetPath.toAbsolutePath().getParent();
@@ -125,9 +131,23 @@ public abstract class GtfsInput implements Closeable {
       Files.createDirectories(targetDirectory);
     }
     try (OutputStream outputStream = Files.newOutputStream(targetPath)) {
-      HttpGetUtil.loadFromUrl(sourceUrl, outputStream, validatorVersion);
+      HttpGetUtil.loadFromUrl(sourceUrl, outputStream, validatorVersion, httpHeaders);
     }
     return createFromPath(targetPath, noticeContainer);
+  }
+
+  /**
+   * Creates a specific GtfsInput to read a GTFS ZIP archive from the given URL, using the default
+   * validator User-Agent.
+   *
+   * @deprecated Use {@link #createFromUrl(URL, Path, NoticeContainer, String, Map)} to support
+   *     custom HTTP headers.
+   */
+  @Deprecated
+  public static GtfsInput createFromUrl(
+      URL sourceUrl, Path targetPath, NoticeContainer noticeContainer, String validatorVersion)
+      throws IOException, URISyntaxException {
+    return createFromUrl(sourceUrl, targetPath, noticeContainer, validatorVersion, Map.of());
   }
 
   /**
@@ -136,15 +156,20 @@ public abstract class GtfsInput implements Closeable {
    *
    * @param sourceUrl the fully qualified URL to download of the resource to download
    * @param noticeContainer
+   * @param validatorVersion
+   * @param httpHeaders additional HTTP headers; a {@code "User-Agent"} entry overrides the default
    * @return the {@code GtfsInput} created after download of the GTFS archive
    * @throws IOException if no file could not be found at the specified location
    * @throws URISyntaxException if URL is malformed
    */
   public static GtfsInput createFromUrlInMemory(
-      URL sourceUrl, NoticeContainer noticeContainer, String validatorVersion)
+      URL sourceUrl,
+      NoticeContainer noticeContainer,
+      String validatorVersion,
+      Map<String, String> httpHeaders)
       throws IOException, URISyntaxException {
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
-      HttpGetUtil.loadFromUrl(sourceUrl, outputStream, validatorVersion);
+      HttpGetUtil.loadFromUrl(sourceUrl, outputStream, validatorVersion, httpHeaders);
       File zipFile = new File(sourceUrl.toString());
       String fileName = zipFile.getName().replace(".zip", "");
       if (containsGtfsFileInSubfolder(
@@ -154,6 +179,20 @@ public abstract class GtfsInput implements Closeable {
       return new GtfsZipFileInput(
           new ZipFile(new SeekableInMemoryByteChannel(outputStream.toByteArray())), fileName);
     }
+  }
+
+  /**
+   * Creates a specific GtfsInput to read data from the given URL, using the default validator
+   * User-Agent. The loaded ZIP file is kept in memory.
+   *
+   * @deprecated Use {@link #createFromUrlInMemory(URL, NoticeContainer, String, Map)} to support
+   *     custom HTTP headers.
+   */
+  @Deprecated
+  public static GtfsInput createFromUrlInMemory(
+      URL sourceUrl, NoticeContainer noticeContainer, String validatorVersion)
+      throws IOException, URISyntaxException {
+    return createFromUrlInMemory(sourceUrl, noticeContainer, validatorVersion, Map.of());
   }
 
   /**

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/util/HttpGetUtil.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/util/HttpGetUtil.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Map;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
@@ -49,15 +50,40 @@ public class HttpGetUtil {
    * @param sourceUrl the fully qualified URL
    * @param outputStream the output stream
    * @param validatorVersion the version of the validator
+   * @param extraHeaders additional HTTP headers to send; a {@code "User-Agent"} entry overrides the
+   *     default validator User-Agent
    */
-  public static void loadFromUrl(URL sourceUrl, OutputStream outputStream, String validatorVersion)
+  public static void loadFromUrl(
+      URL sourceUrl,
+      OutputStream outputStream,
+      String validatorVersion,
+      Map<String, String> extraHeaders)
       throws IOException, URISyntaxException {
     try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
       HttpGet request = new HttpGet(sourceUrl.toString());
+      // Apply default User-Agent first, then let extraHeaders override any header including it.
       request.addHeader("User-Agent", getUserAgent(validatorVersion));
+      for (Map.Entry<String, String> entry : extraHeaders.entrySet()) {
+        request.setHeader(entry.getKey(), entry.getValue());
+      }
       try (CloseableHttpResponse response = httpClient.execute(request)) {
         response.getEntity().writeTo(outputStream);
       }
     }
+  }
+
+  /**
+   * Downloads data from network using the default validator User-Agent.
+   *
+   * @param sourceUrl the fully qualified URL
+   * @param outputStream the output stream
+   * @param validatorVersion the version of the validator
+   * @deprecated Use {@link #loadFromUrl(URL, OutputStream, String, Map)} to support custom HTTP
+   *     headers.
+   */
+  @Deprecated
+  public static void loadFromUrl(URL sourceUrl, OutputStream outputStream, String validatorVersion)
+      throws IOException, URISyntaxException {
+    loadFromUrl(sourceUrl, outputStream, validatorVersion, Map.of());
   }
 }

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/util/HttpGetUtilTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/util/HttpGetUtilTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+
+public class HttpGetUtilTest {
+
+  @Test
+  public void getUserAgent_withVersion() {
+    String agent = HttpGetUtil.getUserAgent("1.2.3");
+    assertThat(agent).startsWith(HttpGetUtil.USER_AGENT_PREFIX + "/1.2.3");
+    assertThat(agent).contains("Java");
+  }
+
+  @Test
+  public void getUserAgent_withNullVersion() {
+    String agent = HttpGetUtil.getUserAgent(null);
+    assertThat(agent).startsWith(HttpGetUtil.USER_AGENT_PREFIX + "/");
+    assertThat(agent).contains("Java");
+  }
+
+  @Test
+  public void getUserAgent_prefixIsConstant() {
+    assertThat(HttpGetUtil.USER_AGENT_PREFIX).isEqualTo("MobilityData GTFS-Validator");
+  }
+}

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -28,7 +28,8 @@
 | `-p`       | `--pretty`                    | Optional               | Pretty JSON validation report. If specified, the JSON validation report will be printed using JSON Pretty print. This does not impact data parsing.                                                                                                           |
 | `--stdout` | `--stdout`                    | Optional               | Output JSON report to stdout instead of writing to files. Use with `-i` or `-u` but not with `-o`. Enables piping to tools like `jq`.                                                                                                                          |
 | `-d`       | `--date`                      | Optional               | The date used to validate the feed for time-based rules, e.g feed_expiration_30_days, in ISO_LOCAL_DATE format like '2001-01-30'. By default, the current date is used.                                                                                       |
-| `-svu`     | `--skip_validator_update`     | Optional               | Skip GTFS version validation update check. If specified, the GTFS version validation will be skipped. By default, the GTFS version validation will be performed.                                                                                              |                                              
+| `-svu`     | `--skip_validator_update`     | Optional               | Skip GTFS version validation update check. If specified, the GTFS version validation will be skipped. By default, the GTFS version validation will be performed.                                                                                              |
+| *(none)*   | `--http_header`               | Optional               | Custom HTTP header to send when downloading a GTFS feed from a URL, in the format `Name: Value`. May be repeated to set multiple headers. A `User-Agent` header overrides the default validator User-Agent (e.g. `--http_header "Authorization: Bearer token"`). Only used with `-u` / `--url`. |
 
 ⚠️ Note that exactly one of the following options must be provided: `--url` or `--input`.
 
@@ -61,6 +62,29 @@ java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip -o relative/outp
  1. Download the GTFS feed at the URL `https://url/to/dataset.zip` and name it `input.zip`  
  1. Validate the GTFS data and output the results to the directory located at `relative/output/path`. Validation results are exported to JSON by default.
 Please note that since downloading will take time, we recommend validating repeatedly on a local file.
+
+### with custom HTTP headers
+
+Use `--http_header` to send custom headers when downloading a feed from a URL. The flag can be repeated for multiple headers.
+
+Override the default `User-Agent`:
+```
+java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip -o relative/output/path --http_header "User-Agent: my-app/2.0 (contact@example.com)"
+```
+
+Add an authorization token:
+```
+java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip -o relative/output/path --http_header "Authorization: Bearer <token>"
+```
+
+Combine multiple headers:
+```
+java -jar gtfs-validator-v2.0.jar -u https://url/to/dataset.zip -o relative/output/path \
+  --http_header "User-Agent: my-app/2.0" \
+  --http_header "X-Trace-Id: abc123"
+```
+
+⚠️ Note that `--http_header` is only used when downloading from a URL (`-u`/`--url`). It has no effect with `-i`/`--input`.
 
 ## via stdout output (for scripting and piping)
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -401,13 +401,15 @@ public class ValidationRunner {
     }
 
     if (config.storageDirectory().isEmpty()) {
-      return GtfsInput.createFromUrlInMemory(source.toURL(), noticeContainer, validatorVersion);
+      return GtfsInput.createFromUrlInMemory(
+          source.toURL(), noticeContainer, validatorVersion, config.httpHeaders());
     } else {
       return GtfsInput.createFromUrl(
           source.toURL(),
           config.storageDirectory().get().resolve(GTFS_ZIP_FILENAME),
           noticeContainer,
-          validatorVersion);
+          validatorVersion,
+          config.httpHeaders());
     }
   }
 }

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
@@ -16,6 +16,7 @@
 package org.mobilitydata.gtfsvalidator.runner;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableMap;
 import java.net.URI;
 import java.nio.file.Path;
 import java.time.LocalDate;
@@ -69,6 +70,10 @@ public abstract class ValidationRunnerConfig {
   // If true, output JSON report to stdout instead of writing to files
   public abstract boolean stdoutOutput();
 
+  // Custom HTTP headers to include when downloading a GTFS feed from a URL.
+  // A "User-Agent" entry overrides the default validator User-Agent.
+  public abstract ImmutableMap<String, String> httpHeaders();
+
   public static Builder builder() {
     // Set reasonable defaults where appropriate.
     return new AutoValue_ValidationRunnerConfig.Builder()
@@ -80,7 +85,8 @@ public abstract class ValidationRunnerConfig {
         .setCountryCode(CountryCode.forStringOrUnknown(CountryCode.ZZ))
         .setDateForValidation(LocalDate.now())
         .setSkipValidatorUpdate(false)
-        .setStdoutOutput(false);
+        .setStdoutOutput(false)
+        .setHttpHeaders(ImmutableMap.of());
   }
 
   @AutoValue.Builder
@@ -108,6 +114,8 @@ public abstract class ValidationRunnerConfig {
     public abstract Builder setSkipValidatorUpdate(boolean skipValidatorUpdate);
 
     public abstract Builder setStdoutOutput(boolean stdoutOutput);
+
+    public abstract Builder setHttpHeaders(ImmutableMap<String, String> httpHeaders);
 
     public abstract ValidationRunnerConfig build();
   }

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/StorageHelper.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/StorageHelper.java
@@ -121,7 +121,7 @@ public class StorageHelper {
             blobInfo, 1, TimeUnit.HOURS, Storage.SignUrlOption.httpMethod(HttpMethod.POST));
     try (WriteChannel writer = storage.writer(signedURL)) {
       OutputStream outputStream = Channels.newOutputStream(writer);
-      HttpGetUtil.loadFromUrl(new URL(url), outputStream, validatorVersion);
+      HttpGetUtil.loadFromUrl(new URL(url), outputStream, validatorVersion, Map.of());
     }
   }
 


### PR DESCRIPTION
**Summary:**

Closes: #2138 
This PR adds support for custom HTTP headers. The custom HTTP headers are only present in the feed download request. The changes include CLI and local App support; **Out of scope: web/API support for custom headers.**
This can be tested locally:
```
java -jar ./cli/build/libs/gtfs-validator-0.1.0-SNAPSHOT-cli.jar --url https://apis.metroinfo.co.nz/rti/gtfs/v1/gtfs.zip --stdout --http_header "Ocp-Apim-Subscription-Key: YOUR KEY HERE"
```

App changes:
<img width="555" height="538" alt="Screenshot 2026-05-13 at 11 07 28 AM" src="https://github.com/user-attachments/assets/15a60b81-9138-4a34-8189-c8d162ffc345" />


## From our AI friend
This pull request adds support for specifying custom HTTP headers when downloading GTFS feeds, both in the GUI and CLI. It introduces a multi-line text field in the GUI for headers, validates the input format, ensures headers are not persisted for security, and updates the CLI to support repeated `--http_header` arguments. Comprehensive tests are included to verify correct parsing, validation, and security behavior.

**GUI enhancements:**

* Added a multi-line `JTextArea` for custom HTTP headers in the advanced options panel of the GUI (`GtfsValidatorApp.java`). This includes input validation, error display, and disables the Validate button if the headers are invalid. Headers are parsed and attached to the validation config when running. (`[[1]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR84-R85)`, `[[2]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR310-R337)`, `[[3]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR389-R395)`, `[[4]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR406-R408)`, `[[5]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR456-R497)`, [[6]](diffhunk://#diff-b928f6bbd6e71fecfe8df67d41bd50bb31c0f32a3a3b996dc2b609987d8e7011R18-R19)

* Added new methods to get/set HTTP headers in `GtfsValidatorApp`, and ensured the text is stripped for input fields. (`[[1]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR137-R147)`, `[[2]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aL376-R430)`, `[[3]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aL386-R440)`)

**Security improvements:**

* Updated `GtfsValidatorPreferences` so that HTTP headers are never persisted between sessions, preventing accidental credential leaks. (`[[1]](diffhunk://#diff-894cc05fe01e8f1e52dc74d7340a0358bdd7c8b322aeb13cc6dc8e905cdd955dR18)`, `[[2]](diffhunk://#diff-894cc05fe01e8f1e52dc74d7340a0358bdd7c8b322aeb13cc6dc8e905cdd955dR31-R41)`)

**CLI enhancements:**

* Added support for multiple `--http_header` arguments to the CLI, with validation and parsing logic to ensure correct format and inclusion in the validation config. (`[[1]](diffhunk://#diff-22608f7bb87b67e77e85dac973612a22a56a222bac933221964362f9bd14c397R20-R28)`, `[[2]](diffhunk://#diff-22608f7bb87b67e77e85dac973612a22a56a222bac933221964362f9bd14c397R120-R127)`, `[[3]](diffhunk://#diff-22608f7bb87b67e77e85dac973612a22a56a222bac933221964362f9bd14c397R163-R176)`, `[[4]](diffhunk://#diff-22608f7bb87b67e77e85dac973612a22a56a222bac933221964362f9bd14c397R237-R244)`)

**Dependency updates:**

* Added Guava as a dependency for immutable collections in the GUI project. (`[[1]](diffhunk://#diff-8bd2117f4359f8d33aa1e1e7f848b5c560e87e4893ab60f33e346754af397470R28)`, `[[2]](diffhunk://#diff-ae112f27bed85c17615136da6c93e309513cd176c91961233ae845ad15abb27aR18)`, `[[3]](diffhunk://#diff-3eb8597d612f3d3fa4b3d73e7ec0834c4e74c6a5f85e0f4f9f9c947c788245e2R7)`, `[[4]](diffhunk://#diff-75dac53269f1932f673cd90f34757b8df1138413a3f227f890833d37313627a4R25)`)

**Testing:**

* Added comprehensive tests for HTTP header parsing, validation, config integration, and security (non-persistence) in both GUI and CLI test suites. (`[[1]](diffhunk://#diff-3eb8597d612f3d3fa4b3d73e7ec0834c4e74c6a5f85e0f4f9f9c947c788245e2R105-R193)`, `[[2]](diffhunk://#diff-718ef9d6774ef19503af1607cd078479c581350d7a736a9fdf8ce82305614512R59-R80)`)

These changes collectively improve flexibility for authenticated/authorized downloads, ensure user credentials are not leaked, and maintain robust input validation.

**Expected behavior:** 

The CLI accepts the `--http_header` parameter to override the default values. The local app's advanced section contains the HTTP headers section 


Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
