### PR TITLE
notice(non_ascii_or_non_printable_char): use standard fieldName

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NonAsciiOrNonPrintableCharNotice.java
@@ -34,17 +34,17 @@ public class NonAsciiOrNonPrintableCharNotice extends ValidationNotice {
   /** Row number of the faulty record. */
   private final int csvRowNumber;
 
-  /** Name of the column where the error occurred. */
-  private final String columnName;
+  /** Faulty record's field name. */
+  private final String fieldName;
 
   /** Faulty value. */
   private final String fieldValue;
 
   public NonAsciiOrNonPrintableCharNotice(
-      String filename, int csvRowNumber, String columnName, String fieldValue) {
+      String filename, int csvRowNumber, String fieldName, String fieldValue) {
     this.filename = filename;
     this.csvRowNumber = csvRowNumber;
-    this.columnName = columnName;
+    this.fieldName = fieldName;
     this.fieldValue = fieldValue;
   }
 }


### PR DESCRIPTION
The serialized output of `NonAsciiOrNonPrintableCharNotice` carries the offending column under the key `columnName`, but every other notice (`InvalidCurrencyNotice`, `InvalidPhoneNumberNotice`, etc.) uses `fieldName`. That forces downstream pipelines to special-case this one rule.

Just renamed the field to match. Callers already pass `cellContext.fieldName()` into the constructor positionally, so no caller signatures change and no behavior changes — only the JSON key the field reflects to.

Closes #1205.