### PR TITLE
chore: Bump action workflows to versions that use Node24

### DIFF
--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -138,12 +138,12 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download .jar file from master branch
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: gtfs-validator-master
           path: gtfs-validator-master
       - name: Download latest changes .jar file from previous job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: gtfs-validator-snapshot
           path: gtfs-validator-snapshot
@@ -179,15 +179,15 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download comparator .jar file from previous job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: comparator-snapshot
       - name: Retrieve reports from previous job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: reports_all
       - name: Retrieve gtfs latest versions from previous job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: datasets_metadata
       - name: Generate acceptance report test

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Project
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # We need to fetch with a depth of 2 for pull_request so we can do HEAD^2
           fetch-depth: 2
@@ -59,45 +59,45 @@ jobs:
   pack-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Package cli app jar with Gradle
         run: ./gradlew shadowJar
       - name: Persist gtfs-validator snapshot jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gtfs-validator-snapshot
           path: cli/build/libs/gtfs-validator-*-cli.jar
       - name: Persist comparator snapshot jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: comparator-snapshot
           path: output-comparator/build/libs/output-comparator-*-cli.jar
   pack-master:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: master
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
 
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Package cli app jar with Gradle
         run: ./gradlew shadowJar
       - name: Persist gtfs-validator jar from master branch
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gtfs-validator-master
           path: cli/build/libs/gtfs-validator-*-cli.jar
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python_version }}
@@ -122,7 +122,7 @@ jobs:
           echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist metadata
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: datasets_metadata
           path: scripts/mobility-database-harvester/datasets_metadata
@@ -136,14 +136,14 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download .jar file from master branch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: gtfs-validator-master
           path: gtfs-validator-master
       - name: Download latest changes .jar file from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: gtfs-validator-snapshot
           path: gtfs-validator-snapshot
@@ -159,7 +159,7 @@ jobs:
         env:
           OUTPUT_BASE: ${{ github.sha }}
       - name: Persist reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: reports_${{ env.CONCATENATED_IDS }}
           path: ${{ github.sha }}/output
@@ -168,7 +168,7 @@ jobs:
      needs: [ get-reports ]
      steps:
        - name: Merge Artifacts
-         uses: actions/upload-artifact/merge@v4
+         uses: actions/upload-artifact/merge@v6
          with:
            name: reports_all
            pattern: reports_*
@@ -177,17 +177,17 @@ jobs:
     needs: [ merge-reports-artifacts ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Download comparator .jar file from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: comparator-snapshot
       - name: Retrieve reports from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: reports_all
       - name: Retrieve gtfs latest versions from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: datasets_metadata
       - name: Generate acceptance report test
@@ -205,7 +205,7 @@ jobs:
            --run_id ${{github.run_id}}
       - name: Persist acceptance test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: acceptance_test_report
           path: acceptance-test-output

--- a/.github/workflows/acceptance_test.yml
+++ b/.github/workflows/acceptance_test.yml
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -87,7 +87,7 @@ jobs:
         with:
           ref: master
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/create_issue_if_referencemd_changes.yml
+++ b/.github/workflows/create_issue_if_referencemd_changes.yml
@@ -19,7 +19,7 @@ jobs:
           token: ${{ secrets.GENERIC_ACTION_REPO_SCOPE }} 
 
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '24.x'
 

--- a/.github/workflows/create_issue_if_referencemd_changes.yml
+++ b/.github/workflows/create_issue_if_referencemd_changes.yml
@@ -12,16 +12,16 @@ jobs:
     steps:
 
       - name: Checkout master of gtfs-validator repo
-        uses: actions/checkout@v4.0.0
+        uses: actions/checkout@v6
         with:
           ref: master
           fetch-depth: 0
           token: ${{ secrets.GENERIC_ACTION_REPO_SCOPE }} 
 
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v3.8.1
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '24.x'
 
       - name: Install Node.js dependencies
         run: npm install @actions/github

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -121,7 +121,7 @@ jobs:
         with:
           fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -46,7 +46,7 @@ jobs:
         with:
           fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -121,7 +121,7 @@ jobs:
         with:
           fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,22 +14,22 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
 
       - name: Run Java tests
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Generate aggregate test report
         run: ./gradlew testAggregateTestReport
 
       - name: Persist aggregated test reports on failure
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Test report - Java
           path: build/reports/tests/unit-test/aggregated-results/
@@ -42,11 +42,11 @@ jobs:
       matrix:
         platform: [linux/amd64, linux/arm64]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -117,11 +117,11 @@ jobs:
     needs: build_test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # need full clone so `./gradlew currentVersion` can search parents for older tags when needed
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -50,7 +50,7 @@ jobs:
           distribution: ${{ env.java_distribution }}
 
       - name: Package cli app jar with Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
         
       - name: Builds ShadowJar
         run: ./gradlew shadowJar

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -42,21 +42,21 @@ jobs:
   pack-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
 
       - name: Package cli app jar with Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v5
         
       - name: Builds ShadowJar
         run: ./gradlew shadowJar
 
       - name: Persist gtfs-validator snapshot jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: gtfs-validator-snapshot
           path: cli/build/libs/gtfs-validator-*-cli.jar
@@ -64,8 +64,8 @@ jobs:
     runs-on: ubuntu-latest-4-cores
     steps:
       - name: Checkout repository code
-        uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+        uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.python_version }}
       - name: Install dependencies
@@ -79,7 +79,7 @@ jobs:
           echo "matrix=$DATASETS" >> $GITHUB_OUTPUT
       - name: Persist metadata
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: datasets_metadata
           path: scripts/mobility-database-harvester/datasets_metadata
@@ -93,9 +93,9 @@ jobs:
     strategy:
       matrix: ${{ fromJson(needs.fetch-urls.outputs.matrix) }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Download latest changes .jar file from previous job
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
         with:
           name: gtfs-validator-snapshot
           path: gtfs-validator-snapshot
@@ -109,7 +109,7 @@ jobs:
         id: extract-id
         run: echo "feed_id=$(echo '${{ matrix.data }}' | jq -r '.id')" >> $GITHUB_ENV
       - name: Persist reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: reports_snapshot_${{ env.feed_id }}
           path: ${{ github.sha }}/output
@@ -118,7 +118,7 @@ jobs:
     needs: [ run-on-data ]
     steps:
       - name: Merge Artifacts
-        uses: actions/upload-artifact/merge@v4
+        uses: actions/upload-artifact/merge@v6
         with:
           name: reports_snapshot
           pattern: reports_snapshot_*

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Download latest changes .jar file from previous job
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
         with:
           name: gtfs-validator-snapshot
           path: gtfs-validator-snapshot

--- a/.github/workflows/end_to_end.yml
+++ b/.github/workflows/end_to_end.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -15,9 +15,9 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -31,7 +31,7 @@ jobs:
 
       - name: Upload Spotless Output
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: spotless-output
           path: spotless-output.txt

--- a/.github/workflows/formatting.yml
+++ b/.github/workflows/formatting.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/notice_migration_generation.yml
+++ b/.github/workflows/notice_migration_generation.yml
@@ -17,7 +17,7 @@ jobs:
   update_notice_migration:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Setup Python ${{ env.python_version }}
         uses: actions/setup-python@v4
@@ -29,7 +29,7 @@ jobs:
         run: pip install -r scripts/notice-migration-generator/requirements.txt
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}
@@ -39,7 +39,7 @@ jobs:
         run: python3 scripts/notice-migration-generator/get_previous_release.py
 
       - name: Checkout previous version
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           ref: ${{ env.PREVIOUS_VERSION }}
 
@@ -47,13 +47,13 @@ jobs:
         run: ./gradlew webClientRulesJSON
 
       - name: Upload previous rules.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rules-${{ env.PREVIOUS_VERSION }}
           path: web/client/static/rules.json
 
       - name: Checkout current version
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -61,13 +61,13 @@ jobs:
         run: ./gradlew webClientRulesJSON
 
       - name: Upload current rules.json
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: rules-${{ github.event.inputs.NEW_VERSION }}
           path: web/client/static/rules.json
 
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v6
 
       - name: Validate download
         run: ls -la rules*

--- a/.github/workflows/notice_migration_generation.yml
+++ b/.github/workflows/notice_migration_generation.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Setup Python ${{ env.python_version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.python_version }}
           cache: 'pip'
@@ -67,7 +67,7 @@ jobs:
           path: web/client/static/rules.json
 
       - name: Download all workflow artifacts
-        uses: actions/download-artifact@v6
+        uses: actions/download-artifact@v8
 
       - name: Validate download
         run: ls -la rules*

--- a/.github/workflows/notice_migration_generation.yml
+++ b/.github/workflows/notice_migration_generation.yml
@@ -29,7 +29,7 @@ jobs:
         run: pip install -r scripts/notice-migration-generator/requirements.txt
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -51,7 +51,7 @@ jobs:
         run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -205,7 +205,7 @@ jobs:
             
               console.log('Uploading', file);
 
-              await github.repos.uploadReleaseAsset({
+              await github.rest.repos.uploadReleaseAsset({
                 owner, repo,
                 release_id: context.payload.release.id,
                 name: `Installer ${os}.${extension}`,

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         os: [ macos-latest, windows-latest, ubuntu-latest ]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
@@ -51,7 +51,7 @@ jobs:
         run: echo "SHORT_SHA=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_ENV
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}
@@ -75,7 +75,7 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${MACOS_CI_KEYCHAIN_PWD}" build.keychain
 
       - name: "Package GUI app installer with Gradle"
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Run Gradle GUI packaging command on push or release
         run: ./gradlew jpackage -Psign-app=${{github.event_name == 'push' || github.event_name == 'release'}}
 
@@ -134,27 +134,27 @@ jobs:
 
       - name: Package cli and gui app jars with Gradle
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Produce shadowJar
         run: ./gradlew shadowJar
 
       - name: Persist cli app jar
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "gtfs-validator-cli-${{ env.SHORT_SHA }}.zip"
           path: cli/build/libs/gtfs-validator-*-cli.jar
 
       - name: Persist gui app jar
         if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: "gtfs-validator-gui-${{ env.SHORT_SHA }}.zip"
           path: app/gui/build/libs/gui-*-all.jar
 
       - name: "Upload Installer"
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Installer - ${{matrix.os}}
           path: |

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -183,7 +183,7 @@ jobs:
         if: github.event_name == 'prerelease' || github.event_name == 'release'
         env:
           OS_NAME: '${{ matrix.os }}'
-        uses: actions/github-script@v2
+        uses: actions/github-script@v6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/package_installers.yml
+++ b/.github/workflows/package_installers.yml
@@ -183,7 +183,7 @@ jobs:
         if: github.event_name == 'prerelease' || github.event_name == 'release'
         env:
           OS_NAME: '${{ matrix.os }}'
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/publish_assets.yml
+++ b/.github/workflows/publish_assets.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin can resolve the most recent version tag.
           # This is useful only for the manual trigger.
@@ -32,7 +32,7 @@ jobs:
         run: echo "The version extracted from github.ref is ${{ steps.get_version.outputs.version }}"
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/publish_assets.yml
+++ b/.github/workflows/publish_assets.yml
@@ -32,7 +32,7 @@ jobs:
         run: echo "The version extracted from github.ref is ${{ steps.get_version.outputs.version }}"
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/publish_snapshots.yml
+++ b/.github/workflows/publish_snapshots.yml
@@ -27,7 +27,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/publish_snapshots.yml
+++ b/.github/workflows/publish_snapshots.yml
@@ -20,14 +20,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ env.java_version }}
           distribution: ${{ env.java_distribution }}

--- a/.github/workflows/stg_web_client_merge.yml
+++ b/.github/workflows/stg_web_client_merge.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/stg_web_client_merge.yml
+++ b/.github/workflows/stg_web_client_merge.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/stg_web_svc_merge.yml
+++ b/.github/workflows/stg_web_svc_merge.yml
@@ -23,14 +23,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/stg_web_svc_merge.yml
+++ b/.github/workflows/stg_web_svc_merge.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -16,21 +16,21 @@ jobs:
         java_version: [ '17' ]
         os: [ ubuntu-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'zulu'
 
       - name: Run tests on Java ${{ matrix.java_version }} and ${{ matrix.os }}
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Continue on test report
         run: ./gradlew testAggregateTestReport --continue
 
       - name: Persist aggregated test reports on failure - Java ${{ matrix.java_version }} on ${{ matrix.os }}
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Test report - Java ${{ matrix.java_version }} on ${{ matrix.os }}
           path: build/reports/tests/unit-test/aggregated-results/
@@ -43,20 +43,20 @@ jobs:
         java_version: [ '17' ]
         os: [ ubuntu-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'zulu'
 
       - name: Package cli app jar with Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Produce shadowJar
         run: ./gradlew shadowJar
 
       - name: Persist cli app jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Application - CLI executable - Java ${{ matrix.java_version }} JAR file -- ${{ matrix.os }}
           path: cli/build/libs/gtfs-validator-*-cli.jar
@@ -69,19 +69,19 @@ jobs:
         java_version: [ '17' ]
         os: [ ubuntu-latest, windows-latest ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v6
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'zulu'
 
       - name: Setup Javadoc build
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
       - name: Build Javadoc
         run: ./gradlew aggregateJavadoc
       - name: Persist javadoc
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: Documentation - javadoc - Java ${{ matrix.java_version }} - ${{ matrix.os }}
           path: build/docs/javadoc/

--- a/.github/workflows/test_pack_doc.yml
+++ b/.github/workflows/test_pack_doc.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'zulu'
@@ -45,7 +45,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'zulu'
@@ -71,7 +71,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Set up JDK ${{ matrix.java_version }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           java-version: ${{ matrix.java_version }}
           distribution: 'zulu'

--- a/.github/workflows/web_client_pr.yml
+++ b/.github/workflows/web_client_pr.yml
@@ -25,14 +25,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/web_client_pr.yml
+++ b/.github/workflows/web_client_pr.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/web_client_test.yml
+++ b/.github/workflows/web_client_test.yml
@@ -7,7 +7,7 @@ on:
         - 'web/client/**'
 
 env:
-  NODE_VERSION: "20"
+  NODE_VERSION: "24"
 
 jobs:
   cypress-run:
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/web_client_test.yml
+++ b/.github/workflows/web_client_test.yml
@@ -15,7 +15,7 @@ jobs:
     name: Cypress e2e tests
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -32,13 +32,13 @@ jobs:
           wait-on: "npx wait-on --timeout 2000 http://127.0.0.1:5173"
           working-directory: web/client
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: failure()
         with:
           name: cypress-screenshots
           path: web/client/cypress/screenshots
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         if: always()
         with:
           name: cypress-videos

--- a/.github/workflows/web_release.yml
+++ b/.github/workflows/web_release.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/web_release.yml
+++ b/.github/workflows/web_release.yml
@@ -21,14 +21,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/web_svc_pr.yml
+++ b/.github/workflows/web_svc_pr.yml
@@ -31,7 +31,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v6
+        uses: actions/setup-java@v5
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}

--- a/.github/workflows/web_svc_pr.yml
+++ b/.github/workflows/web_svc_pr.yml
@@ -24,14 +24,14 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # We need to download all tags so that the axion-release-plugin
           # can resolve the most recent version tag.
           fetch-depth: 0
 
       - name: Set up JDK ${{ env.java_version }}-${{ env.java_distribution }}
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           # We need a recent version of Java with jpackage included.
           java-version: ${{ env.java_version }}


### PR DESCRIPTION
**Summary:**

Bumps the actions under `.github` to versions that use Node 24, since [this will become the default soon](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)


Please make sure these boxes are checked before submitting your pull request - thanks!


- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
