### PR TITLE
feat: Add conditional min_transfer_time validation

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTransferSchema.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTransferSchema.java
@@ -38,6 +38,7 @@ public interface GtfsTransferSchema extends GtfsEntity {
   @Index
   GtfsTransferType transferType();
 
+  @ConditionallyRequired
   @NonNegative
   int minTransferTime();
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransferMinTransferTimeConditionalValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransferMinTransferTimeConditionalValidator.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.table.GtfsTransferType.MINIMUM_TIME;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsTransfer;
+
+/**
+ * Validates the conditional requirement of {@code transfers.min_transfer_time}.
+ *
+ * <p>Generated notice: {@link MissingRequiredFieldNotice}.
+ */
+@GtfsValidator
+public class TransferMinTransferTimeConditionalValidator
+    extends SingleEntityValidator<GtfsTransfer> {
+
+  @Override
+  public void validate(GtfsTransfer transfer, NoticeContainer noticeContainer) {
+    if (MINIMUM_TIME.equals(transfer.transferType()) && !transfer.hasMinTransferTime()) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice(
+              GtfsTransfer.FILENAME,
+              transfer.csvRowNumber(),
+              GtfsTransfer.MIN_TRANSFER_TIME_FIELD_NAME));
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransferMinTransferTimeConditionalValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransferMinTransferTimeConditionalValidatorTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mobilitydata.gtfsvalidator.table.GtfsTransferType.IMPOSSIBLE;
+import static org.mobilitydata.gtfsvalidator.table.GtfsTransferType.MINIMUM_TIME;
+import static org.mobilitydata.gtfsvalidator.table.GtfsTransferType.RECOMMENDED;
+import static org.mobilitydata.gtfsvalidator.table.GtfsTransferType.TIMED;
+
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsTransfer;
+
+public class TransferMinTransferTimeConditionalValidatorTest {
+
+  @Test
+  public void MinimumTimeWithoutMinTransferTimeShouldGenerateNotice() {
+    assertThat(
+            validationNoticesFor(
+                new GtfsTransfer.Builder()
+                    .setCsvRowNumber(2)
+                    .setTransferType(MINIMUM_TIME)
+                    .build()))
+        .containsExactly(new MissingRequiredFieldNotice("transfers.txt", 2, "min_transfer_time"));
+  }
+
+  @Test
+  public void MinimumTimeWithZeroMinTransferTimeShouldGenerateNothing() {
+    assertThat(
+            validationNoticesFor(
+                new GtfsTransfer.Builder()
+                    .setCsvRowNumber(2)
+                    .setTransferType(MINIMUM_TIME)
+                    .setMinTransferTime(0)
+                    .build()))
+        .isEmpty();
+  }
+
+  @Test
+  public void MinimumTimeWithPositiveMinTransferTimeShouldGenerateNothing() {
+    assertThat(
+            validationNoticesFor(
+                new GtfsTransfer.Builder()
+                    .setCsvRowNumber(2)
+                    .setTransferType(MINIMUM_TIME)
+                    .setMinTransferTime(60)
+                    .build()))
+        .isEmpty();
+  }
+
+  @Test
+  public void OtherTransferTypesWithoutMinTransferTimeShouldGenerateNothing() {
+    assertThat(
+            validationNoticesFor(
+                new GtfsTransfer.Builder().setCsvRowNumber(2).setTransferType(RECOMMENDED).build()))
+        .isEmpty();
+
+    assertThat(
+            validationNoticesFor(
+                new GtfsTransfer.Builder().setCsvRowNumber(2).setTransferType(TIMED).build()))
+        .isEmpty();
+
+    assertThat(
+            validationNoticesFor(
+                new GtfsTransfer.Builder().setCsvRowNumber(2).setTransferType(IMPOSSIBLE).build()))
+        .isEmpty();
+  }
+
+  private List<ValidationNotice> validationNoticesFor(GtfsTransfer entity) {
+    TransferMinTransferTimeConditionalValidator validator =
+        new TransferMinTransferTimeConditionalValidator();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    validator.validate(entity, noticeContainer);
+    return noticeContainer.getValidationNotices();
+  }
+}


### PR DESCRIPTION
**Summary:**

Implements #2174 by adding validation for the conditionally required `transfers.min_transfer_time` field when `transfer_type = 2` (`MINIMUM_TIME`).

**Expected behavior:**

When `transfer_type = 2` and `min_transfer_time` is missing or empty, the validator emits the existing `missing_required_field` ERROR notice for `min_transfer_time` in `transfers.txt`.

A supplied value of `0` remains valid. Other transfer types do not require `min_transfer_time`.

**Implementation:**

- Mark `min_transfer_time` as `@ConditionallyRequired` in `GtfsTransferSchema`.
- Add `TransferMinTransferTimeConditionalValidator`.
- Reuse the existing `MissingRequiredFieldNotice`.
- Add focused unit tests covering missing, zero, positive, and non-`MINIMUM_TIME` cases.

**Validation:**

- [x] Focused validator tests: 4/4 passed.
- [x] Existing transfer validation tests: 3/3 passed.
- [x] End-to-end CLI validation reproduced the expected `missing_required_field` notice.
- [x] Spotless formatting check passed.
- [x] Full `:main:test` was run. Three unrelated Mockito-based tests also fail on the clean parent commit, confirming they are pre-existing and not introduced by this change.
- [x] No documentation changes are required for this focused validator.
- [x] Linked issue: #2174.
- [ ] Screenshots: not applicable for this validator change.

Closes #2174