### PR TITLE
fix: require transfers stop ids when transfer_type is empty

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransferStopIdsConditionalValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TransferStopIdsConditionalValidator.java
@@ -35,6 +35,9 @@ import org.mobilitydata.gtfsvalidator.table.GtfsTransferTableContainer;
  *   <li>{@link MissingRequiredFieldNotice} - {@code from_stop_id} is missing or {@code to_stop_id}
  *       is missing for all transfer types except for in-seat transfer types
  * </ul>
+ *
+ * <p>An empty {@code transfer_type} means a recommended transfer point, which is the same as {@code
+ * transfer_type=0}, so both stop ids are required for it as well.
  */
 @GtfsValidator
 public class TransferStopIdsConditionalValidator extends FileValidator {
@@ -49,9 +52,7 @@ public class TransferStopIdsConditionalValidator extends FileValidator {
   @Override
   public void validate(NoticeContainer noticeContainer) {
     for (GtfsTransfer transfer : transfersContainer.getEntities()) {
-      if (transfer.hasTransferType()) {
-        validateTransferEntity(transfer, noticeContainer);
-      }
+      validateTransferEntity(transfer, noticeContainer);
     }
   }
 

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransferStopIdsConditionalValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TransferStopIdsConditionalValidatorTest.java
@@ -94,4 +94,42 @@ public class TransferStopIdsConditionalValidatorTest {
       noticeContainer.getValidationNotices().clear();
     }
   }
+
+  /**
+   * This test is used to verify that the validator generates a notice when the stop ids are missing
+   * and the {@code transfer_type} is empty, which is a recommended transfer point.
+   */
+  @Test
+  public void testTransferMissingStopIdsEmptyTransferType() {
+    GtfsTransferTableContainer gtfsTransferTableContainer =
+        GtfsTransferTableContainer.forEntities(
+            ImmutableList.of(new GtfsTransfer.Builder().build()), noticeContainer);
+
+    new TransferStopIdsConditionalValidator(gtfsTransferTableContainer).validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactlyElementsIn(
+            Arrays.asList(
+                new MissingRequiredFieldNotice(
+                    GtfsTransfer.FILENAME, 0, GtfsTransfer.FROM_STOP_ID_FIELD_NAME),
+                new MissingRequiredFieldNotice(
+                    GtfsTransfer.FILENAME, 0, GtfsTransfer.TO_STOP_ID_FIELD_NAME)));
+  }
+
+  /**
+   * This test is used to verify that the validator does not generate a notice when the stop ids are
+   * present and the {@code transfer_type} is empty.
+   */
+  @Test
+  public void testTransferStopIdsPresentEmptyTransferTypeNoNotice() {
+    GtfsTransferTableContainer gtfsTransferTableContainer =
+        GtfsTransferTableContainer.forEntities(
+            ImmutableList.of(
+                new GtfsTransfer.Builder().setFromStopId("stop1").setToStopId("stop2").build()),
+            noticeContainer);
+
+    new TransferStopIdsConditionalValidator(gtfsTransferTableContainer).validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
 }


### PR DESCRIPTION
**Summary:**

Closes #2105.

The spec change in google/transit@a806576 (google/transit#591) made `transfers.from_stop_id` and `transfers.to_stop_id` **Required if `transfer_type` is empty, `0`, `1`, `2` or `3`** — previously the reference only required them for `1`, `2` and `3`.

`TransferStopIdsConditionalValidator` wraps its per-row check in `if (transfer.hasTransferType())`, so rows whose `transfer_type` is empty are skipped entirely and the newly required case is never validated. An empty `transfer_type` is a recommended transfer point, which is the same as `transfer_type=0` — a value the validator already treats as requiring both stop ids.

This drops that guard so every row is checked. In-seat transfer types (`4` and `5`) keep their exemption through the existing `isTransferTypeInSeat` check, so the only behavior that changes is the empty case.

**Expected behavior:**

| `transfers.txt` row | before | after |
|---|---|---|
| `transfer_type` empty, no `from_stop_id` / `to_stop_id` | no notice | two `missing_required_field` notices, one per field |
| `transfer_type` empty, both stop ids present | no notice | no notice |
| `transfer_type` `0`–`3`, stop ids missing | two notices | unchanged |
| `transfer_type` `4` or `5`, stop ids missing | no notice | unchanged |

No new notice type is introduced — this reuses `missing_required_field` — so `RULES.md` needs no change.

Two unit tests are added for the empty `transfer_type` case, which the existing tests never covered (every existing case calls `setTransferType()`).

One note on CI: I ran the checks on my fork first. `Format code`, `Test Package Document` (`test` on Java 17 for both ubuntu-latest and windows-latest) and `Package Installers` are green. `Rule acceptance tests` cannot run on a fork — its `get-reports` matrix requires the `ubuntu-latest-4-cores` runner label, which forks do not have — so that comparison needs to run here. Since this rule newly fires on real feeds that leave `transfer_type` empty, the acceptance report is worth a look before merging.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo — no documentation change needed, see above
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) — not applicable to a validation rule; the added unit tests show the behavior instead
