### PR TITLE
fix: preserve original GTFS source in reports

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/JsonReportSummaryGenerator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/JsonReportSummaryGenerator.java
@@ -24,12 +24,13 @@ public class JsonReportSummaryGenerator {
       ValidationRunnerConfig config,
       VersionInfo versionInfo,
       String date) {
-    this.gtfsInput = config != null ? config.gtfsSource().toString() : null;
+    String displayGtfsSource = config != null ? config.getDisplayGtfsSource() : null;
+    this.gtfsInput = displayGtfsSource;
     this.summary =
         new JsonReportSummary(
             versionInfo.currentVersion().orElse(null),
             date,
-            config != null ? config.gtfsSource().toString() : null,
+            displayGtfsSource,
             config != null ? config.numThreads() : 0,
             config != null && !config.stdoutOutput() && config.outputDirectory() != null
                 ? config.outputDirectory().toString()

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerConfig.java
@@ -29,6 +29,13 @@ public abstract class ValidationRunnerConfig {
   // The GTFS input, as a URI to a local file or an external URL.
   public abstract URI gtfsSource();
 
+  // The original human-readable GTFS source, when different from gtfsSource.
+  public abstract Optional<String> originalGtfsSource();
+
+  public String getDisplayGtfsSource() {
+    return originalGtfsSource().orElse(gtfsSource().toString());
+  }
+
   // The directory where all validation reports will be written.
   public abstract Path outputDirectory();
 
@@ -92,6 +99,8 @@ public abstract class ValidationRunnerConfig {
   @AutoValue.Builder
   public abstract static class Builder {
     public abstract Builder setGtfsSource(URI gtfsSource);
+
+    public abstract Builder setOriginalGtfsSource(Optional<String> originalGtfsSource);
 
     public abstract Builder setOutputDirectory(Path outputDirectory);
 

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -233,7 +233,7 @@
                 th:text="${date}"></span>,
         <br/>
         for the dataset
-        <span th:text="${config.gtfsSource}"></span><span
+        <span th:text="${config.displayGtfsSource}"></span><span
                 th:text="${config.countryCode.isUnknown()} ? '. No country code was provided.' : ', with the country code: ' + ${config.countryCode} + '.'"></span>
         </br>
         <span th:if="${is_different_date}" th:text="'The date used during validation was ' + ${config.dateForValidation} + '.'"></span></p>

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportTemplateTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportTemplateTest.java
@@ -1,0 +1,24 @@
+package org.mobilitydata.gtfsvalidator.reportsummary;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.junit.Test;
+
+public class HtmlReportTemplateTest {
+
+  @Test
+  public void reportUsesOriginalGtfsSourceWhenAvailable() throws Exception {
+    String template;
+    try (var stream = getClass().getClassLoader().getResourceAsStream("report.html")) {
+      if (stream == null) {
+        throw new IllegalStateException("report.html not found");
+      }
+      template = new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+    }
+
+    assertTrue(template.contains("${config.displayGtfsSource}"));
+    assertFalse(template.contains("${config.gtfsSource}"));
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/JsonReportSummaryGeneratorTest.java
@@ -149,6 +149,30 @@ public class JsonReportSummaryGeneratorTest {
   }
 
   @Test
+  public void reportUsesOriginalGtfsSourceWhenAvailable() throws Exception {
+    ValidationRunnerConfig.Builder builder = ValidationRunnerConfig.builder();
+    builder.setCountryCode(CountryCode.forStringOrUnknown("GB"));
+    builder.setGtfsSource(new URI("some_dataset_filename"));
+    builder.setOriginalGtfsSource(Optional.of("sample-feed.zip"));
+    builder.setHtmlReportFileName("some_html_filename");
+    builder.setOutputDirectory(Path.of("some_output_directory"));
+    builder.setNumThreads(1);
+    builder.setPrettyJson(true);
+    builder.setSystemErrorsReportFileName("some_error_filename");
+    builder.setValidationReportFileName("some_report_filename");
+    builder.setDateForValidation(LocalDate.parse("2020-01-02"));
+    builder.setStdoutOutput(false);
+
+    JsonReportSummaryGenerator summaryGenerator =
+        new JsonReportSummaryGenerator(null, builder.build(), versionInfo, "now");
+
+    assertEquals("sample-feed.zip", summaryGenerator.gtfsInput);
+    assertEquals(
+        "sample-feed.zip",
+        gson.toJsonTree(summaryGenerator.summary).getAsJsonObject().get("gtfsInput").getAsString());
+  }
+
+  @Test
   public void withFeedMetadataNoConfigTest() throws Exception {
 
     FeedMetadata feedMetadata = generateFeedMetaData();

--- a/web/client/cypress/e2e/error_messages.cy.js
+++ b/web/client/cypress/e2e/error_messages.cy.js
@@ -44,6 +44,7 @@ context('GTFS Validator - Confirm error messaging', () => {
       'POST',
       `${Cypress.env('PUBLIC_CLIENT_API_ROOT')}/create-job`,
       (req) => {
+        expect(req.body.filename).to.equal('sample-feed.zip');
         req.reply({
           statusCode: 200,
           statusMessage: 'OK',

--- a/web/client/src/routes/+page.svelte
+++ b/web/client/src/routes/+page.svelte
@@ -21,6 +21,7 @@
    * @typedef CreateJobParameters
    * @type {object}
    * @property {string=} url - job source url.
+   * @property {string=} filename - original uploaded filename.
    * @property {string} countryCode - country code.
    */
 
@@ -206,9 +207,8 @@
       addError('Please include a file to validate.');
     }
   }
-
-  /** @param {string=} url **/
-  function createJob(url) {
+  /** @param {string=} url @param {string=} filename **/
+  function createJob(url, filename) {
     updateStatus('authorizing');
     jobInProgress = false; // stop any ongoing polling loops
     jobId = '_waiting_';
@@ -221,6 +221,10 @@
 
       if (url) {
         data.url = url;
+      }
+
+      if (filename) {
+        data.filename = filename;
       }
 
       const xhr = new XMLHttpRequest();
@@ -344,11 +348,12 @@
   async function generateReport(source) {
     // if source is a URL, pass it to createJob
     const url = typeof source === 'string' ? source : undefined;
+    const filename = source instanceof File ? source.name : undefined;
 
     // get a job id from the server
     let job
     try {
-      job = await createJob(url);
+      job = await createJob(url, filename);
     } catch (error) {
       addError( typeof error === 'string'? error : generalValidationErrorMessage);
       statusModal.close();

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/controller/CreateJobRequest.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/controller/CreateJobRequest.java
@@ -23,12 +23,18 @@ public class CreateJobRequest {
 
   private String countryCode;
   private String url;
+  private String filename;
 
   public CreateJobRequest() {}
 
   public CreateJobRequest(String countryCode, String url) {
+    this(countryCode, url, null);
+  }
+
+  public CreateJobRequest(String countryCode, String url, String filename) {
     this.countryCode = countryCode;
     this.url = url;
+    this.filename = filename;
   }
 
   public String getCountryCode() {
@@ -37,5 +43,9 @@ public class CreateJobRequest {
 
   public String getUrl() {
     return url;
+  }
+
+  public String getFilename() {
+    return filename;
   }
 }

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/controller/ValidationController.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/controller/ValidationController.java
@@ -60,9 +60,16 @@ public class ValidationController {
     URL uploadUrl = null;
     try {
       if (body != null) {
-        if (!Strings.isNullOrEmpty(body.getCountryCode())) {
-          storageHelper.saveJobMetadata(new JobMetadata(jobId, body.getCountryCode()));
+        String originalGtfsSource =
+            !Strings.isNullOrEmpty(body.getUrl()) ? body.getUrl() : body.getFilename();
+
+        if (!Strings.isNullOrEmpty(body.getCountryCode())
+            || !Strings.isNullOrEmpty(originalGtfsSource)) {
+          storageHelper.saveJobMetadata(
+              new JobMetadata(
+                  jobId, Strings.nullToEmpty(body.getCountryCode()), originalGtfsSource));
         }
+
         if (!Strings.isNullOrEmpty(body.getUrl())) {
           var validatorVersion = versionResolver.resolveCurrentVersion();
           storageHelper.saveJobFileFromUrl(jobId, body.getUrl(), validatorVersion.orElse(null));
@@ -118,7 +125,9 @@ public class ValidationController {
 
       var fileName = jobData.getFileName();
 
-      var countryCode = storageHelper.getJobMetadata(jobId).getCountryCode();
+      var jobMetadata = storageHelper.getJobMetadata(jobId);
+      var countryCode = jobMetadata.getCountryCode();
+      var originalGtfsSource = jobMetadata.getOriginalGtfsSource();
 
       // copy the file from GCS to a temp directory
       tempFile = storageHelper.downloadFeedFileFromStorage(jobId, fileName);
@@ -126,7 +135,7 @@ public class ValidationController {
       outputPath = storageHelper.createOutputFolderForJob(jobId);
       try {
         // extracts feed files from zip to temp output directory, validates
-        validationHandler.validateFeed(tempFile, outputPath, countryCode);
+        validationHandler.validateFeed(tempFile, outputPath, countryCode, originalGtfsSource);
         storageHelper.writeExecutionResultFile(new ExecutionResult("success"), outputPath);
       } catch (Exception exc) {
         logger.error("Error", exc);

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/JobMetadata.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/JobMetadata.java
@@ -11,4 +11,9 @@ import lombok.NoArgsConstructor;
 public class JobMetadata {
   private String jobId;
   private String countryCode;
+  private String originalGtfsSource;
+
+  public JobMetadata(String jobId, String countryCode) {
+    this(jobId, countryCode, null);
+  }
 }

--- a/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandler.java
+++ b/web/service/src/main/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandler.java
@@ -29,9 +29,19 @@ public class ValidationHandler {
    */
   public void validateFeed(@NonNull File feedFile, @NonNull Path outputPath, String countryCode)
       throws Exception {
+    validateFeed(feedFile, outputPath, countryCode, null);
+  }
+
+  public void validateFeed(
+      @NonNull File feedFile,
+      @NonNull Path outputPath,
+      String countryCode,
+      String originalGtfsSource)
+      throws Exception {
     var configBuilder =
         ValidationRunnerConfig.builder()
             .setGtfsSource(feedFile.toURI())
+            .setOriginalGtfsSource(java.util.Optional.ofNullable(originalGtfsSource))
             .setOutputDirectory(outputPath)
             .setStdoutOutput(false)
             .setSkipValidatorUpdate(

--- a/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/controller/CreateJobEndpointTest.java
+++ b/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/controller/CreateJobEndpointTest.java
@@ -104,10 +104,36 @@ public class CreateJobEndpointTest {
 
     makeCreateJobRequestAndCheckResult(request, testJobId, null);
 
-    // should not call saveJobMetadata
-    verify(storageHelper, times(0)).saveJobMetadata(any(JobMetadata.class));
+    // URL provenance must be persisted even when no country code is provided.
+    verify(storageHelper, times(1)).saveJobMetadata(jobMetadataCaptor.capture());
+    var jobMetadataJson = mapper.writeValueAsString(jobMetadataCaptor.getValue());
+    org.junit.jupiter.api.Assertions.assertTrue(
+        jobMetadataJson.contains("\"originalGtfsSource\":\"" + url + "\""));
     // should saveJobFileFromUrl
     verify(storageHelper, times(1)).saveJobFileFromUrl(testJobId, url, VALIDATOR_TEST_VERSION);
+  }
+
+  @Test
+  public void createJobWithFilenameButNoCountryCodePersistsMetadata() throws Exception {
+    doReturn(new URL(testUploadUrl)).when(storageHelper).generateUniqueUploadUrl(testJobId);
+
+    String json = "{\"filename\":\"sample-feed.zip\"}";
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/create-job")
+                .content(json)
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.jobId").value(testJobId))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.url").value(testUploadUrl));
+
+    // Uploaded-file provenance must be persisted even when no country code is provided.
+    verify(storageHelper, times(1)).saveJobMetadata(jobMetadataCaptor.capture());
+    var jobMetadataJson = mapper.writeValueAsString(jobMetadataCaptor.getValue());
+    org.junit.jupiter.api.Assertions.assertTrue(
+        jobMetadataJson.contains("\"originalGtfsSource\":\"sample-feed.zip\""));
+    verify(storageHelper, times(0)).saveJobFileFromUrl(anyString(), anyString(), anyString());
   }
 
   @Test

--- a/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/controller/RunValidatorEndpointTest.java
+++ b/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/controller/RunValidatorEndpointTest.java
@@ -41,7 +41,7 @@ public class RunValidatorEndpointTest {
   @BeforeEach
   public void setUp() throws Exception {
     testJobId = "123";
-    jobMetaData = new JobMetadata(testJobId, "US");
+    jobMetaData = new JobMetadata(testJobId, "US", "sample-feed.zip");
     mockFeedFile = mock(File.class);
     mockOutputPath = mock(Path.class);
     mockOutputPathToFile = mock(File.class);
@@ -97,7 +97,11 @@ public class RunValidatorEndpointTest {
     // verify that the validationHandler is called with the downloaded feed file, output path, and
     // country code
     verify(validationHandler, times(1))
-        .validateFeed(mockFeedFile, mockOutputPath, jobMetaData.getCountryCode());
+        .validateFeed(
+            mockFeedFile,
+            mockOutputPath,
+            jobMetaData.getCountryCode(),
+            jobMetaData.getOriginalGtfsSource());
 
     // verify that the validation output files are uploaded to storage
     verify(storageHelper, times(1)).uploadFilesToStorage(testJobId, mockOutputPath);
@@ -123,7 +127,8 @@ public class RunValidatorEndpointTest {
         .andExpect(MockMvcResultMatchers.status().is5xxServerError());
 
     // should not have attempted validation
-    verify(validationHandler, times(0)).validateFeed(any(File.class), any(Path.class), anyString());
+    verify(validationHandler, times(0))
+        .validateFeed(any(File.class), any(Path.class), anyString(), anyString());
 
     // should not have uploaded to storage
     verify(storageHelper, times(0)).uploadFilesToStorage(anyString(), any(Path.class));
@@ -137,7 +142,7 @@ public class RunValidatorEndpointTest {
   public void runValidatorValidateFeedFailure() throws Exception {
     doThrow(new Exception())
         .when(validationHandler)
-        .validateFeed(any(File.class), any(Path.class), anyString());
+        .validateFeed(any(File.class), any(Path.class), anyString(), anyString());
 
     doReturn(mockFeedFile)
         .when(storageHelper)
@@ -151,5 +156,29 @@ public class RunValidatorEndpointTest {
         .andExpect(MockMvcResultMatchers.status().isOk());
 
     assertTrue(executionResultIsError());
+  }
+
+  @Test
+  public void runValidatorForwardsOriginalGtfsSource() throws Exception {
+    doReturn(mockFeedFile)
+        .when(storageHelper)
+        .downloadFeedFileFromStorage(anyString(), anyString());
+
+    doReturn(true).when(mockFeedFile).exists();
+    doReturn(true).when(mockOutputPathToFile).exists();
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.post("/run-validator")
+                .content(mapper.writeValueAsString(pubSubMessage))
+                .contentType(MediaType.APPLICATION_JSON))
+        .andExpect(MockMvcResultMatchers.status().isOk());
+
+    verify(validationHandler, times(1))
+        .validateFeed(
+            mockFeedFile,
+            mockOutputPath,
+            jobMetaData.getCountryCode(),
+            jobMetaData.getOriginalGtfsSource());
   }
 }

--- a/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/StorageHelperTest.java
+++ b/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/StorageHelperTest.java
@@ -2,6 +2,7 @@ package org.mobilitydata.gtfsvalidator.web.service.util;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -74,6 +75,25 @@ public class StorageHelperTest {
     assertEquals(expectedBlobId, blobIdCaptor.getValue());
 
     assertEquals(expectedJson, mapper.writeValueAsString(actualJobMetadata));
+  }
+
+  @Test
+  public void testGetOldJobMetadataWithoutOriginalGtfsSource() throws Exception {
+
+    StorageHelper storageHelper = new StorageHelper(storage, null);
+
+    String testJobId = UUID.randomUUID().toString();
+    String oldMetadataJson = "{\"jobId\":\"" + testJobId + "\",\"countryCode\":\"US\"}";
+
+    Blob mockBlob = mock(Blob.class);
+    when(storage.get(any(BlobId.class))).thenReturn(mockBlob);
+    when(mockBlob.getContent()).thenReturn(oldMetadataJson.getBytes());
+
+    JobMetadata actualJobMetadata = storageHelper.getJobMetadata(testJobId);
+
+    assertEquals(testJobId, actualJobMetadata.getJobId());
+    assertEquals("US", actualJobMetadata.getCountryCode());
+    assertNull(actualJobMetadata.getOriginalGtfsSource());
   }
 
   @Test

--- a/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandlerTest.java
+++ b/web/service/src/test/java/org/mobilitydata/gtfsvalidator/web/service/util/ValidationHandlerTest.java
@@ -116,4 +116,24 @@ public class ValidationHandlerTest {
     assertTrue(mockOutputPath.equals(config.outputDirectory()));
     assert config.countryCode().equals(CountryCode.forStringOrUnknown(countryCode));
   }
+
+  @Test
+  public void validateFeedPreservesOperationalSourceAndOriginalGtfsSource() throws Exception {
+    var handler = new ValidationHandler(runner);
+    Path mockOutputPath = mock(Path.class);
+    File mockFeedFile = mock(File.class);
+    URI feedFileURI = URI.create("file://fake/path/to.zip");
+
+    doReturn(feedFileURI).when(mockFeedFile).toURI();
+    doReturn(ValidationRunner.Status.SUCCESS).when(runner).run(any(ValidationRunnerConfig.class));
+
+    handler.validateFeed(mockFeedFile, mockOutputPath, "US", "sample-feed.zip");
+
+    verify(runner, times(1)).run(configCaptor.capture());
+
+    ValidationRunnerConfig config = configCaptor.getValue();
+
+    assertEquals(feedFileURI, config.gtfsSource());
+    assertEquals(java.util.Optional.of("sample-feed.zip"), config.originalGtfsSource());
+  }
 }


### PR DESCRIPTION
## Summary

Fixes #1539 by preserving the human-readable GTFS source separately from the operational source used by the validator.

For web uploads, reports now show the original uploaded filename instead of the temporary server-side filename. For URL submissions, reports show the original URL, as requested in the issue discussion.

## Implementation

- Add optional `originalGtfsSource` provenance to `ValidationRunnerConfig` while retaining `gtfsSource` for operational file/URL access.
- Add a single display-source fallback (`originalGtfsSource` when present, otherwise `gtfsSource`) used by JSON and HTML reports.
- Forward uploaded filenames from the web client through `CreateJobRequest` and persisted `JobMetadata`.
- Persist URL provenance even when no country code is supplied.
- Forward persisted provenance through `ValidationController` and `ValidationHandler` without changing the operational temporary file URI.
- Preserve compatibility with existing callers and previously persisted `JobMetadata` that does not contain `originalGtfsSource`.

## Validation

- [x] Full `:main:test` passed.
- [x] Full `:web:service:test` passed.
- [x] `:main:spotlessCheck` passed.
- [x] `:web:service:spotlessCheck` passed.
- [x] `npm run check` passed with 0 errors and 0 warnings (3 pre-existing hints).
- [x] Full Cypress suite passed: 7/7 tests.
- [x] Regression coverage verifies uploaded filename propagation to `/create-job`.
- [x] Regression coverage verifies URL and filename provenance persistence.
- [x] Regression coverage verifies operational `gtfsSource` remains separate from `originalGtfsSource`.
- [x] Regression coverage verifies JSON and HTML report source selection.
- [x] Backward-compatibility test verifies old two-field `JobMetadata` JSON still deserializes with `originalGtfsSource == null`.
- [x] `git diff --check` passed.

Closes #1539