### PR TITLE
feat: detect invalid GTFS line endings

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidLineEndingNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/InvalidLineEndingNotice.java
@@ -1,0 +1,19 @@
+package org.mobilitydata.gtfsvalidator.notice;
+
+import static org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRef.FILE_REQUIREMENTS;
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.ERROR;
+
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.SectionRefs;
+
+/** A GTFS text file contains a line ending other than LF or CRLF. */
+@GtfsValidationNotice(severity = ERROR, sections = @SectionRefs(FILE_REQUIREMENTS))
+public class InvalidLineEndingNotice extends ValidationNotice {
+
+  /** The name of the file containing an invalid line ending. */
+  private final String filename;
+
+  public InvalidLineEndingNotice(String filename) {
+    this.filename = filename;
+  }
+}

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
@@ -5,6 +5,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.flogger.FluentLogger;
 import com.univocity.parsers.common.TextParsingException;
 import com.univocity.parsers.csv.CsvParserSettings;
+import java.io.FilterInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
@@ -14,6 +16,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.mobilitydata.gtfsvalidator.notice.CsvParsingFailedNotice;
 import org.mobilitydata.gtfsvalidator.notice.EmptyFileNotice;
+import org.mobilitydata.gtfsvalidator.notice.InvalidLineEndingNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.parsing.CsvFile;
 import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
@@ -55,7 +58,9 @@ public final class CsvFileLoader extends TableLoader {
         Optional<Integer> maxCharsPerColumn = tableDescriptor.maxCharsPerColumn();
         settings.setMaxCharsPerColumn(maxCharsPerColumn.get());
       }
-      csvFile = new CsvFile(csvInputStream, gtfsFilename, settings);
+      LineEndingCheckingInputStream checkedInputStream =
+          new LineEndingCheckingInputStream(csvInputStream, noticeContainer, gtfsFilename);
+      csvFile = new CsvFile(checkedInputStream, gtfsFilename, settings);
     } catch (TextParsingException e) {
       noticeContainer.addValidationNotice(new CsvParsingFailedNotice(gtfsFilename, e));
       return tableDescriptor.createContainerForInvalidStatus(TableStatus.INVALID_HEADERS);
@@ -141,6 +146,81 @@ public final class CsvFileLoader extends TableLoader {
     ValidatorUtil.invokeSingleFileValidators(
         createSingleFileValidators(table, validatorProvider), noticeContainer);
     return table;
+  }
+
+  private static final class LineEndingCheckingInputStream extends FilterInputStream {
+    private int pendingCarriageReturns = 0;
+    private boolean invalidLineEndingFound = false;
+    private boolean finished = false;
+    private final NoticeContainer noticeContainer;
+    private final String filename;
+
+    LineEndingCheckingInputStream(
+        InputStream inputStream, NoticeContainer noticeContainer, String filename) {
+      super(inputStream);
+      this.noticeContainer = noticeContainer;
+      this.filename = filename;
+    }
+
+    private void inspect(int value) {
+      if (value == '\r') {
+        pendingCarriageReturns++;
+        return;
+      }
+
+      if (value == '\n') {
+        if (pendingCarriageReturns > 1) {
+          invalidLineEndingFound = true;
+        }
+        pendingCarriageReturns = 0;
+        return;
+      }
+
+      if (pendingCarriageReturns > 0) {
+        invalidLineEndingFound = true;
+        pendingCarriageReturns = 0;
+      }
+    }
+
+    private void finishInspection() {
+      if (finished) {
+        return;
+      }
+      finished = true;
+
+      if (pendingCarriageReturns > 0) {
+        invalidLineEndingFound = true;
+      }
+
+      if (invalidLineEndingFound) {
+        noticeContainer.addValidationNotice(new InvalidLineEndingNotice(filename));
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      int value = in.read();
+      if (value == -1) {
+        finishInspection();
+      } else {
+        inspect(value);
+      }
+      return value;
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+      int count = in.read(bytes, offset, length);
+      if (count == -1) {
+        finishInspection();
+        return -1;
+      }
+
+      for (int i = offset; i < offset + count; i++) {
+        inspect(bytes[i] & 0xff);
+      }
+      return count;
+    }
   }
 
   private NoticeContainer validateHeaders(

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/table/CsvTableLoaderTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/table/CsvTableLoaderTest.java
@@ -139,6 +139,70 @@ public class CsvTableLoaderTest {
   }
 
   @Test
+  public void malformedCrCrLfLineEndingProducesNotice() {
+    var testTableDescriptor = new GtfsTestTableDescriptor();
+    when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
+    when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
+    when(validatorProvider.createSingleFileValidators(
+            ArgumentMatchers.any(), ArgumentMatchers.any()))
+        .thenReturn(List.of());
+
+    InputStream inputStream = toInputStream("id,code\r\r\n" + "s1,value\r\r\n");
+
+    CsvFileLoader.getInstance()
+        .load(testTableDescriptor, validatorProvider, inputStream, loaderNotices);
+
+    assertThat(validationNoticeTypes(loaderNotices)).contains(InvalidLineEndingNotice.class);
+  }
+
+  @Test
+  public void loneCrLineEndingProducesNotice() {
+    var testTableDescriptor = new GtfsTestTableDescriptor();
+    when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
+
+    InputStream inputStream = toInputStream("id,code\r" + "s1,value\r");
+
+    CsvFileLoader.getInstance()
+        .load(testTableDescriptor, validatorProvider, inputStream, loaderNotices);
+
+    assertThat(validationNoticeTypes(loaderNotices)).contains(InvalidLineEndingNotice.class);
+  }
+
+  @Test
+  public void validLfLineEndingDoesNotProduceNotice() {
+    var testTableDescriptor = new GtfsTestTableDescriptor();
+    when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
+    when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
+    when(validatorProvider.createSingleFileValidators(
+            ArgumentMatchers.any(), ArgumentMatchers.any()))
+        .thenReturn(List.of());
+
+    InputStream inputStream = toInputStream("id,code\n" + "s1,value\n");
+
+    CsvFileLoader.getInstance()
+        .load(testTableDescriptor, validatorProvider, inputStream, loaderNotices);
+
+    assertThat(validationNoticeTypes(loaderNotices)).doesNotContain(InvalidLineEndingNotice.class);
+  }
+
+  @Test
+  public void validCrLfLineEndingDoesNotProduceNotice() {
+    var testTableDescriptor = new GtfsTestTableDescriptor();
+    when(validatorProvider.getTableHeaderValidator()).thenReturn(mock(TableHeaderValidator.class));
+    when(validatorProvider.getFieldValidator()).thenReturn(mock(GtfsFieldValidator.class));
+    when(validatorProvider.createSingleFileValidators(
+            ArgumentMatchers.any(), ArgumentMatchers.any()))
+        .thenReturn(List.of());
+
+    InputStream inputStream = toInputStream("id,code\r\n" + "s1,value\r\n");
+
+    CsvFileLoader.getInstance()
+        .load(testTableDescriptor, validatorProvider, inputStream, loaderNotices);
+
+    assertThat(validationNoticeTypes(loaderNotices)).doesNotContain(InvalidLineEndingNotice.class);
+  }
+
+  @Test
   public void missingRequiredField() {
     var testTableDescriptor = spy(new GtfsTestTableDescriptor());
     when(testTableDescriptor.getColumns())

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeReferenceTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/NoticeReferenceTest.java
@@ -31,6 +31,7 @@ import org.mobilitydata.gtfsvalidator.notice.InvalidGeometryNotice;
 import org.mobilitydata.gtfsvalidator.notice.InvalidInputFilesInSubfolderNotice;
 import org.mobilitydata.gtfsvalidator.notice.InvalidIntegerNotice;
 import org.mobilitydata.gtfsvalidator.notice.InvalidLanguageCodeNotice;
+import org.mobilitydata.gtfsvalidator.notice.InvalidLineEndingNotice;
 import org.mobilitydata.gtfsvalidator.notice.InvalidPhoneNumberNotice;
 import org.mobilitydata.gtfsvalidator.notice.InvalidRowLengthNotice;
 import org.mobilitydata.gtfsvalidator.notice.InvalidTimeNotice;
@@ -92,6 +93,7 @@ public class NoticeReferenceTest {
           InvalidFloatNotice.class,
           InvalidGeometryNotice.class,
           InvalidInputFilesInSubfolderNotice.class,
+          InvalidLineEndingNotice.class,
           InvalidIntegerNotice.class,
           InvalidLanguageCodeNotice.class,
           InvalidPhoneNumberNotice.class,


### PR DESCRIPTION
## Summary

Fixes #2157 by detecting GTFS text files that use line endings other than LF or CRLF.

The validator currently configures Univocity with `\n` as the line separator, which means malformed `CRCRLF` input can be parsed silently. This change adds a streaming wrapper around the CSV input so malformed carriage-return sequences are detected without altering the bytes passed to the parser.

## Implementation

- Add `InvalidLineEndingNotice` for file-level GTFS line-ending violations.
- Wrap CSV input in `CsvFileLoader` with a streaming line-ending checker.
- Preserve the original byte stream unchanged for Univocity.
- Detect lone `CR` and repeated `CR` before `LF` while allowing valid LF and CRLF.
- Keep the notice generic across GTFS text files via the existing notice-reference whitelist.

## Validation

- [x] Reproduced `CRCRLF` being silently accepted on baseline `21b27a4ac903bc2bc43d42a89bb3dbb47cc8921d`.
- [x] Verified the streaming checker preserves all input bytes.
- [x] Regression coverage for malformed `CRCRLF`.
- [x] Regression coverage for lone `CR`.
- [x] Negative controls for valid LF and CRLF.
- [x] Verified malformed line endings are still detected when header validation fails early.
- [x] Full `:core:test` passed.
- [x] Notice documentation/reference/annotation/field/name checks passed.
- [x] `:core:spotlessCheck`, `:main:spotlessCheck`, and `git diff --check` passed.

The full `:main:test` run has three Mockito initialization failures in `JsonReportSummaryGeneratorTest` and `VersionResolverTest`; all three were reproduced on an untouched worktree at the baseline commit, so they are unrelated to this change.

Closes #2157