### PR TITLE
refactor: simplify GTFS entity container parameterization

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
@@ -40,7 +40,7 @@ public final class CsvFileLoader extends TableLoader {
   private final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   @Override
-  public GtfsEntityContainer<?, ?> load(
+  public GtfsEntityContainer<?> load(
       GtfsFileDescriptor fileDescriptor,
       ValidatorProvider validatorProvider,
       InputStream csvInputStream,

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsEntityContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsEntityContainer.java
@@ -8,15 +8,13 @@ import java.util.Optional;
  * entities
  *
  * @param <T> The entity for this container (e.g. GtfsCalendarDate or GtfsGeoJsonFeature )
- * @param <D> The descriptor for the file for the container (e.g. GtfsCalendarDateTableDescriptor or
- *     GtfsGeoJsonFileDescriptor)
  */
-public abstract class GtfsEntityContainer<T extends GtfsEntity, D extends GtfsFileDescriptor> {
+public abstract class GtfsEntityContainer<T extends GtfsEntity> {
 
-  private final D descriptor;
+  private final GtfsFileDescriptor descriptor;
   private final TableStatus tableStatus;
 
-  public GtfsEntityContainer(D descriptor, TableStatus tableStatus) {
+  public GtfsEntityContainer(GtfsFileDescriptor descriptor, TableStatus tableStatus) {
     this.tableStatus = tableStatus;
     this.descriptor = descriptor;
   }
@@ -25,7 +23,7 @@ public abstract class GtfsEntityContainer<T extends GtfsEntity, D extends GtfsFi
     return tableStatus;
   }
 
-  public D getDescriptor() {
+  public GtfsFileDescriptor getDescriptor() {
     return descriptor;
   }
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedContainer.java
@@ -25,12 +25,12 @@ import java.util.*;
  * <p>The tables are kept as {@link GtfsEntityContainer} instances.
  */
 public class GtfsFeedContainer {
-  private final Map<String, GtfsEntityContainer<?, ?>> tables = new HashMap<>();
-  private final Map<Class<? extends GtfsEntityContainer>, GtfsEntityContainer<?, ?>> tablesByClass =
+  private final Map<String, GtfsEntityContainer<?>> tables = new HashMap<>();
+  private final Map<Class<? extends GtfsEntityContainer>, GtfsEntityContainer<?>> tablesByClass =
       new HashMap<>();
 
-  public GtfsFeedContainer(List<GtfsEntityContainer<?, ?>> tableContainerList) {
-    for (GtfsEntityContainer<?, ?> table : tableContainerList) {
+  public GtfsFeedContainer(List<GtfsEntityContainer<?>> tableContainerList) {
+    for (GtfsEntityContainer<?> table : tableContainerList) {
       tables.put(table.gtfsFilename(), table);
       tablesByClass.put(table.getClass(), table);
     }
@@ -48,12 +48,12 @@ public class GtfsFeedContainer {
    * @param filename file name, including ".txt" extension
    * @return GTFS table or empty if the table is not supported by schema
    */
-  public <T extends GtfsEntityContainer<?, ?>> Optional<T> getTableForFilename(String filename) {
+  public <T extends GtfsEntityContainer<?>> Optional<T> getTableForFilename(String filename) {
     return (Optional<T>)
         Optional.ofNullable(tables.getOrDefault(Ascii.toLowerCase(filename), null));
   }
 
-  public <T extends GtfsEntityContainer<?, ?>> T getTable(Class<T> clazz) {
+  public <T extends GtfsEntityContainer<?>> T getTable(Class<T> clazz) {
     return (T) tablesByClass.get(clazz);
   }
 
@@ -65,7 +65,7 @@ public class GtfsFeedContainer {
    * @return true if all files were successfully parsed, false otherwise
    */
   public boolean isParsedSuccessfully() {
-    for (GtfsEntityContainer<?, ?> table : tables.values()) {
+    for (GtfsEntityContainer<?> table : tables.values()) {
       if (!table.isParsedSuccessfully()) {
         return false;
       }
@@ -73,13 +73,13 @@ public class GtfsFeedContainer {
     return true;
   }
 
-  public Collection<GtfsEntityContainer<?, ?>> getTables() {
+  public Collection<GtfsEntityContainer<?>> getTables() {
     return tables.values();
   }
 
   public String tableTotalsText() {
     List<String> totalList = new ArrayList<>();
-    for (GtfsEntityContainer<?, ?> table : tables.values()) {
+    for (GtfsEntityContainer<?> table : tables.values()) {
       if (table.getTableStatus() == TableStatus.MISSING_FILE
           && !table.getDescriptor().isRequired()) {
         continue;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsFeedLoader.java
@@ -132,7 +132,7 @@ public class GtfsFeedLoader {
         loaderCallables.add(
             () -> {
               NoticeContainer loaderNotices = new NoticeContainer();
-              GtfsEntityContainer<?, ?> tableContainer;
+              GtfsEntityContainer<?> tableContainer;
               // The descriptor knows what loader to use to load the file
               TableLoader tableLoader = tableDescriptor.getTableLoader();
               tableLoader.setSkippedValidators(skippedValidators);
@@ -159,7 +159,7 @@ public class GtfsFeedLoader {
             });
       }
     }
-    ArrayList<GtfsEntityContainer<?, ?>> tableContainers = new ArrayList<>();
+    ArrayList<GtfsEntityContainer<?>> tableContainers = new ArrayList<>();
     tableContainers.ensureCapacity(tableDescriptors.size());
     for (GtfsFileDescriptor<?> tableDescriptor : remainingDescriptors.values()) {
       TableLoader tableLoader = tableDescriptor.getTableLoader();
@@ -193,7 +193,7 @@ public class GtfsFeedLoader {
       NoticeContainer noticeContainer,
       ExecutorService exec,
       List<Callable<TableAndNoticeContainers>> loaderCallables,
-      ArrayList<GtfsEntityContainer<?, ?>> tableContainers)
+      ArrayList<GtfsEntityContainer<?>> tableContainers)
       throws InterruptedException {
     for (Future<TableAndNoticeContainers> futureContainer : exec.invokeAll(loaderCallables)) {
       try {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsTableContainer.java
@@ -31,7 +31,7 @@ import org.mobilitydata.gtfsvalidator.parsing.CsvHeader;
  * @param <D> subclass of {@code GtfsTableDescriptor}
  */
 public abstract class GtfsTableContainer<T extends GtfsEntity, D extends GtfsTableDescriptor>
-    extends GtfsEntityContainer<T, D> {
+    extends GtfsEntityContainer<T> {
 
   private final CsvHeader header;
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/TableLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/TableLoader.java
@@ -47,7 +47,7 @@ public abstract class TableLoader {
 
   protected <T extends GtfsEntity, D extends GtfsTableDescriptor>
       List<FileValidator> createSingleFileValidators(
-          GtfsEntityContainer<T, D> table, ValidatorProvider validatorProvider) {
+          GtfsEntityContainer<T> table, ValidatorProvider validatorProvider) {
 
     return validatorProvider.createSingleFileValidators(table, skippedValidators);
   }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/DefaultValidatorProvider.java
@@ -41,7 +41,7 @@ public class DefaultValidatorProvider implements ValidatorProvider {
   private final ListMultimap<Class<? extends GtfsEntity>, Class<? extends SingleEntityValidator<?>>>
       singleEntityValidators;
   private final ListMultimap<
-          Class<? extends GtfsEntityContainer<?, ?>>, Class<? extends FileValidator>>
+          Class<? extends GtfsEntityContainer<?>>, Class<? extends FileValidator>>
       singleFileValidators;
   private final List<Class<? extends FileValidator>> multiFileValidators;
 
@@ -116,7 +116,7 @@ public class DefaultValidatorProvider implements ValidatorProvider {
   @SuppressWarnings("unchecked")
   public <T extends GtfsEntity, D extends GtfsTableDescriptor>
       List<FileValidator> createSingleFileValidators(
-          GtfsEntityContainer<T, D> table,
+          GtfsEntityContainer<T> table,
           Multimap<GtfsFeedLoader.SkippedValidatorReason, Class<?>> skippedValidators) {
     List<FileValidator> validators = new ArrayList<>();
     for (Class<? extends FileValidator> validatorClass :

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorLoader.java
@@ -44,7 +44,7 @@ public class ValidatorLoader {
   private final ListMultimap<Class<? extends GtfsEntity>, Class<? extends SingleEntityValidator<?>>>
       singleEntityValidators = ArrayListMultimap.create();
   private final ListMultimap<
-          Class<? extends GtfsEntityContainer<?, ?>>, Class<? extends FileValidator>>
+          Class<? extends GtfsEntityContainer<?>>, Class<? extends FileValidator>>
       singleFileValidators = ArrayListMultimap.create();
   private final List<Class<? extends FileValidator>> multiFileValidators = new ArrayList<>();
 
@@ -76,7 +76,7 @@ public class ValidatorLoader {
   }
 
   /** Loaded single-file validator classes keyed by table container class. */
-  public ListMultimap<Class<? extends GtfsEntityContainer<?, ?>>, Class<? extends FileValidator>>
+  public ListMultimap<Class<? extends GtfsEntityContainer<?>>, Class<? extends FileValidator>>
       getSingleFileValidators() {
     return singleFileValidators;
   }
@@ -114,14 +114,14 @@ public class ValidatorLoader {
     // Indicates that the full GtfsFeedContainer needs to be injected.
     boolean injectFeedContainer = false;
     // Find out which GTFS tables need to be injected.
-    List<Class<? extends GtfsEntityContainer<?, ?>>> injectedTables = new ArrayList<>();
+    List<Class<? extends GtfsEntityContainer<?>>> injectedTables = new ArrayList<>();
     for (Class<?> parameterType : constructor.getParameterTypes()) {
       if (GtfsFeedContainer.class.isAssignableFrom(parameterType)) {
         injectFeedContainer = true;
         continue;
       }
       if (GtfsEntityContainer.class.isAssignableFrom(parameterType)) {
-        injectedTables.add((Class<? extends GtfsEntityContainer<?, ?>>) parameterType);
+        injectedTables.add((Class<? extends GtfsEntityContainer<?>>) parameterType);
       }
     }
 
@@ -202,7 +202,7 @@ public class ValidatorLoader {
   public static <T extends FileValidator>
       ValidatorWithDependencyStatus<T> createSingleFileValidator(
           Class<? extends FileValidator> clazz,
-          GtfsEntityContainer<?, ?> table,
+          GtfsEntityContainer<?> table,
           ValidationContext validationContext)
           throws ReflectiveOperationException, ValidatorLoaderException {
     return (ValidatorWithDependencyStatus<T>)
@@ -223,7 +223,7 @@ public class ValidatorLoader {
    */
   private static class DependencyResolver {
     private final ValidationContext context;
-    @Nullable private final GtfsEntityContainer<?, ?> tableContainer;
+    @Nullable private final GtfsEntityContainer<?> tableContainer;
     @Nullable private final GtfsFeedContainer feedContainer;
 
     /** This will be set to true if a resolved dependency was not parsed successfully. */
@@ -231,7 +231,7 @@ public class ValidatorLoader {
 
     public DependencyResolver(
         ValidationContext context,
-        @Nullable GtfsEntityContainer<?, ?> tableContainer,
+        @Nullable GtfsEntityContainer<?> tableContainer,
         @Nullable GtfsFeedContainer feedContainer) {
       this.context = context;
       this.tableContainer = tableContainer;
@@ -259,8 +259,8 @@ public class ValidatorLoader {
         return tableContainer;
       }
       if (feedContainer != null && GtfsEntityContainer.class.isAssignableFrom(parameterClass)) {
-        GtfsEntityContainer<?, ?> container =
-            feedContainer.getTable((Class<? extends GtfsEntityContainer<?, ?>>) parameterClass);
+        GtfsEntityContainer<?> container =
+            feedContainer.getTable((Class<? extends GtfsEntityContainer<?>>) parameterClass);
         if (container != null && !container.isParsedSuccessfully()) {
           dependenciesHaveErrors = true;
         }
@@ -306,8 +306,7 @@ public class ValidatorLoader {
     if (!singleFileValidators.isEmpty()) {
       builder.append("Single-file validators\n");
       for (Map.Entry<
-              Class<? extends GtfsEntityContainer<?, ?>>,
-              Collection<Class<? extends FileValidator>>>
+              Class<? extends GtfsEntityContainer<?>>, Collection<Class<? extends FileValidator>>>
           entry : singleFileValidators.asMap().entrySet()) {
         builder.append("\t").append(entry.getKey().getSimpleName()).append(": ");
         for (Class<? extends FileValidator> validatorClass : entry.getValue()) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorProvider.java
@@ -63,7 +63,7 @@ public interface ValidatorProvider {
    */
   <T extends GtfsEntity, D extends GtfsTableDescriptor>
       List<FileValidator> createSingleFileValidators(
-          GtfsEntityContainer<T, D> table,
+          GtfsEntityContainer<T> table,
           Multimap<SkippedValidatorReason, Class<?>> skippedValidators);
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/FeedMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/FeedMetadata.java
@@ -160,7 +160,7 @@ public class FeedMetadata {
   }
 
   private <E extends GtfsEntity> int loadUniqueCount(
-      GtfsEntityContainer<?, ?> table, Class<E> clazz, Function<E, String> idExtractor) {
+      GtfsEntityContainer<?> table, Class<E> clazz, Function<E, String> idExtractor) {
     // Iterate through entities and count unique IDs
     Set<String> uniqueIds = new HashSet<>();
     for (GtfsEntity entity : table.getEntities()) {
@@ -696,8 +696,7 @@ public class FeedMetadata {
                 List.of((Function<GtfsRoute, Boolean>) GtfsRoute::hasRouteTextColor)));
   }
 
-  private void loadAgencyData(
-      GtfsEntityContainer<GtfsAgency, GtfsAgencyTableDescriptor> agencyTable) {
+  private void loadAgencyData(GtfsEntityContainer<GtfsAgency> agencyTable) {
     for (GtfsAgency agency : agencyTable.getEntities()) {
       agencies.add(
           new AgencyMetadata(

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/TableMetadata.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/TableMetadata.java
@@ -15,7 +15,7 @@ public class TableMetadata {
     this.entityCount = entityCount;
   }
 
-  public static TableMetadata from(GtfsEntityContainer<?, ?> table) {
+  public static TableMetadata from(GtfsEntityContainer<?> table) {
     return new TableMetadata(table.gtfsFilename(), table.getTableStatus(), table.entityCount());
   }
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsGeoJsonFeaturesContainer.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/table/GtfsGeoJsonFeaturesContainer.java
@@ -27,8 +27,7 @@ import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
  * Container for GeoJSON features. Contrarily to the csv containers, this class is not auto
  * generated since we have only one such class.
  */
-public class GtfsGeoJsonFeaturesContainer
-    extends GtfsEntityContainer<GtfsGeoJsonFeature, GtfsGeoJsonFileDescriptor> {
+public class GtfsGeoJsonFeaturesContainer extends GtfsEntityContainer<GtfsGeoJsonFeature> {
 
   private final Map<String, GtfsGeoJsonFeature> byLocationIdMap = new HashMap<>();
 

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TranslationFieldAndReferenceValidator.java
@@ -121,7 +121,7 @@ public class TranslationFieldAndReferenceValidator extends FileValidator {
                 translation, GtfsTranslation.RECORD_SUB_ID_FIELD_NAME, translation.recordSubId()));
       }
     }
-    Optional<GtfsEntityContainer<GtfsTranslation, GtfsTranslationTableDescriptor>> parentTable =
+    Optional<GtfsEntityContainer<GtfsTranslation>> parentTable =
         feedContainer.getTableForFilename(translation.tableName() + ".txt");
     if (parentTable.isEmpty() || parentTable.get().isMissingFile()) {
       noticeContainer.addValidationNotice(new TranslationUnknownTableNameNotice(translation));


### PR DESCRIPTION
## Summary

Simplifies `GtfsEntityContainer` by removing the unnecessary descriptor type parameter.

`GtfsEntityContainer<T, D>` stored the descriptor as `D`, but callers only rely on the base `GtfsFileDescriptor` API. This change reduces it to `GtfsEntityContainer<T>` while preserving the descriptor-specific generic on `GtfsTableContainer<T, D>`, where it is still useful.

Fixes #1865.

## Changes

- remove `D extends GtfsFileDescriptor` from `GtfsEntityContainer`;
- store and expose the descriptor as `GtfsFileDescriptor`;
- update affected container, loader, validator-provider, report-summary, GeoJSON, and translation references;
- preserve `GtfsTableContainer<T, D>` and its table-descriptor typing.

## Validation

- `:core:compileJava` — pass
- `:main:compileJava` — pass
- `:core:test` — pass
- targeted `FeedMetadataTest` — pass
- targeted `TranslationFieldAndReferenceValidatorTest` — pass
- `:core:spotlessCheck :main:spotlessCheck` — pass
- `git diff --check` — pass
- no remaining two-argument `GtfsEntityContainer<..., ...>` references

Full `:main:test` completed 678 tests with 3 failures. The failures are the existing Mockito initialization failures in:
- `JsonReportSummaryGeneratorTest.withFeedMetadataWithConfigTest`
- `JsonReportSummaryGeneratorTest.withFeedMetadataNoConfigTest`
- `VersionResolverTest`

These failures reproduce on the untouched baseline and are unrelated to this refactor.