### PR TITLE
feat: validate consecutive stop times with same time

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TooManyConsecutiveStopTimesWithSameTimeValidator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/validator/TooManyConsecutiveStopTimesWithSameTimeValidator.java
@@ -1,0 +1,110 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static org.mobilitydata.gtfsvalidator.notice.SeverityLevel.INFO;
+
+import com.google.common.collect.Multimaps;
+import java.util.List;
+import javax.inject.Inject;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidationNotice.FileRefs;
+import org.mobilitydata.gtfsvalidator.annotation.GtfsValidator;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeSchema;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+
+/**
+ * Reports trips with more than five consecutive stop times sharing the same arrival/departure time.
+ *
+ * <p>This reproduces the historical Google Python validator rule. Stop-time rows with a missing
+ * arrival or departure time may lie within a potential same-time run and contribute to the reported
+ * run length if a later fully specified row confirms the same time.
+ */
+@GtfsValidator
+public class TooManyConsecutiveStopTimesWithSameTimeValidator extends FileValidator {
+
+  private static final int MAX_CONSECUTIVE_SAME_TIME_STOP_TIMES = 5;
+
+  private final GtfsStopTimeTableContainer stopTimeTable;
+
+  @Inject
+  TooManyConsecutiveStopTimesWithSameTimeValidator(GtfsStopTimeTableContainer stopTimeTable) {
+    this.stopTimeTable = stopTimeTable;
+  }
+
+  @Override
+  public void validate(NoticeContainer noticeContainer) {
+    for (List<GtfsStopTime> stopTimes : Multimaps.asMap(stopTimeTable.byTripIdMap()).values()) {
+      validateTrip(stopTimes, noticeContainer);
+    }
+  }
+
+  private static void validateTrip(List<GtfsStopTime> stopTimes, NoticeContainer noticeContainer) {
+    GtfsTime previousDepartureTime = null;
+    int potentiallySameTimeCount = 0;
+    int fullySpecifiedSameTimeCount = 0;
+    String tripId = null;
+
+    for (GtfsStopTime stopTime : stopTimes) {
+      tripId = stopTime.tripId();
+
+      if (!stopTime.hasArrivalTime() || !stopTime.hasDepartureTime()) {
+        potentiallySameTimeCount++;
+        continue;
+      }
+
+      if (previousDepartureTime != null
+          && previousDepartureTime.equals(stopTime.arrivalTime())
+          && stopTime.arrivalTime().equals(stopTime.departureTime())) {
+        potentiallySameTimeCount++;
+        fullySpecifiedSameTimeCount = potentiallySameTimeCount;
+      } else {
+        addNoticeIfNeeded(
+            tripId, fullySpecifiedSameTimeCount, previousDepartureTime, noticeContainer);
+
+        potentiallySameTimeCount = 1;
+        fullySpecifiedSameTimeCount = 1;
+      }
+
+      previousDepartureTime = stopTime.departureTime();
+    }
+
+    addNoticeIfNeeded(tripId, fullySpecifiedSameTimeCount, previousDepartureTime, noticeContainer);
+  }
+
+  private static void addNoticeIfNeeded(
+      String tripId, int consecutiveStopTimeCount, GtfsTime time, NoticeContainer noticeContainer) {
+    if (time != null && consecutiveStopTimeCount > MAX_CONSECUTIVE_SAME_TIME_STOP_TIMES) {
+      noticeContainer.addValidationNotice(
+          new TooManyConsecutiveStopTimesWithSameTimeNotice(
+              tripId, consecutiveStopTimeCount, time));
+    }
+  }
+
+  /**
+   * More than five consecutive stop-time records have the same fully specified time.
+   *
+   * <p>This is a community rule inherited from the historical Google Python validator rather than a
+   * GTFS specification requirement.
+   */
+  @GtfsValidationNotice(severity = INFO, files = @FileRefs(GtfsStopTimeSchema.class))
+  static class TooManyConsecutiveStopTimesWithSameTimeNotice extends ValidationNotice {
+
+    /** The affected trip_id. */
+    private final String tripId;
+
+    /** Number of consecutive stop-time records in the run. */
+    private final int entityCount;
+
+    /** Shared arrival/departure time for the fully specified records in the run. */
+    private final GtfsTime time;
+
+    TooManyConsecutiveStopTimesWithSameTimeNotice(String tripId, int entityCount, GtfsTime time) {
+      this.tripId = tripId;
+      this.entityCount = entityCount;
+      this.time = time;
+    }
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TooManyConsecutiveStopTimesWithSameTimeValidatorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/validator/TooManyConsecutiveStopTimesWithSameTimeValidatorTest.java
@@ -1,0 +1,173 @@
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTime;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.type.GtfsTime;
+import org.mobilitydata.gtfsvalidator.validator.TooManyConsecutiveStopTimesWithSameTimeValidator.TooManyConsecutiveStopTimesWithSameTimeNotice;
+
+public class TooManyConsecutiveStopTimesWithSameTimeValidatorTest {
+
+  private static final String TRIP_ID = "trip";
+
+  private static GtfsStopTime createStopTime(
+      int csvRowNumber, int stopSequence, Integer arrivalSeconds, Integer departureSeconds) {
+    GtfsStopTime.Builder builder =
+        new GtfsStopTime.Builder()
+            .setCsvRowNumber(csvRowNumber)
+            .setTripId(TRIP_ID)
+            .setStopSequence(stopSequence)
+            .setStopId("stop-" + stopSequence);
+
+    if (arrivalSeconds != null) {
+      builder.setArrivalTime(GtfsTime.fromSecondsSinceMidnight(arrivalSeconds));
+    }
+    if (departureSeconds != null) {
+      builder.setDepartureTime(GtfsTime.fromSecondsSinceMidnight(departureSeconds));
+    }
+
+    return builder.build();
+  }
+
+  private static List<ValidationNotice> generateNotices(GtfsStopTime... stopTimes) {
+    NoticeContainer noticeContainer = new NoticeContainer();
+
+    new TooManyConsecutiveStopTimesWithSameTimeValidator(
+            GtfsStopTimeTableContainer.forEntities(Arrays.asList(stopTimes), noticeContainer))
+        .validate(noticeContainer);
+
+    return noticeContainer.getValidationNotices();
+  }
+
+  @Test
+  public void fiveConsecutiveSameTimesShouldNotGenerateNotice() {
+    assertThat(
+            generateNotices(
+                createStopTime(2, 1, 3600, 3600),
+                createStopTime(3, 2, 3600, 3600),
+                createStopTime(4, 3, 3600, 3600),
+                createStopTime(5, 4, 3600, 3600),
+                createStopTime(6, 5, 3600, 3600)))
+        .isEmpty();
+  }
+
+  @Test
+  public void sixConsecutiveSameTimesShouldGenerateNotice() {
+    assertThat(
+            generateNotices(
+                createStopTime(2, 1, 3600, 3600),
+                createStopTime(3, 2, 3600, 3600),
+                createStopTime(4, 3, 3600, 3600),
+                createStopTime(5, 4, 3600, 3600),
+                createStopTime(6, 5, 3600, 3600),
+                createStopTime(7, 6, 3600, 3600)))
+        .containsExactly(
+            new TooManyConsecutiveStopTimesWithSameTimeNotice(
+                TRIP_ID, 6, GtfsTime.fromSecondsSinceMidnight(3600)));
+  }
+
+  @Test
+  public void changedTimeShouldEndPreviousRun() {
+    assertThat(
+            generateNotices(
+                createStopTime(2, 1, 3600, 3600),
+                createStopTime(3, 2, 3600, 3600),
+                createStopTime(4, 3, 3600, 3600),
+                createStopTime(5, 4, 3600, 3600),
+                createStopTime(6, 5, 3600, 3600),
+                createStopTime(7, 6, 3600, 3600),
+                createStopTime(8, 7, 3660, 3660)))
+        .containsExactly(
+            new TooManyConsecutiveStopTimesWithSameTimeNotice(
+                TRIP_ID, 6, GtfsTime.fromSecondsSinceMidnight(3600)));
+  }
+
+  @Test
+  public void qualifyingRunAtEndOfTripShouldGenerateNotice() {
+    assertThat(
+            generateNotices(
+                createStopTime(2, 1, 3500, 3500),
+                createStopTime(3, 2, 3600, 3600),
+                createStopTime(4, 3, 3600, 3600),
+                createStopTime(5, 4, 3600, 3600),
+                createStopTime(6, 5, 3600, 3600),
+                createStopTime(7, 6, 3600, 3600),
+                createStopTime(8, 7, 3600, 3600)))
+        .containsExactly(
+            new TooManyConsecutiveStopTimesWithSameTimeNotice(
+                TRIP_ID, 6, GtfsTime.fromSecondsSinceMidnight(3600)));
+  }
+
+  @Test
+  public void missingTimesWithinPotentialRunShouldCountWhenLaterTimeConfirmsRun() {
+    assertThat(
+            generateNotices(
+                createStopTime(2, 1, 3600, 3600),
+                createStopTime(3, 2, 3600, 3600),
+                createStopTime(4, 3, null, null),
+                createStopTime(5, 4, null, null),
+                createStopTime(6, 5, null, null),
+                createStopTime(7, 6, 3600, 3600)))
+        .containsExactly(
+            new TooManyConsecutiveStopTimesWithSameTimeNotice(
+                TRIP_ID, 6, GtfsTime.fromSecondsSinceMidnight(3600)));
+  }
+
+  @Test
+  public void twoQualifyingRunsShouldGenerateTwoNotices() {
+    assertThat(
+            generateNotices(
+                createStopTime(2, 1, 3600, 3600),
+                createStopTime(3, 2, 3600, 3600),
+                createStopTime(4, 3, 3600, 3600),
+                createStopTime(5, 4, 3600, 3600),
+                createStopTime(6, 5, 3600, 3600),
+                createStopTime(7, 6, 3600, 3600),
+                createStopTime(8, 7, 3660, 3660),
+                createStopTime(9, 8, 3660, 3660),
+                createStopTime(10, 9, 3660, 3660),
+                createStopTime(11, 10, 3660, 3660),
+                createStopTime(12, 11, 3660, 3660),
+                createStopTime(13, 12, 3660, 3660)))
+        .containsExactly(
+            new TooManyConsecutiveStopTimesWithSameTimeNotice(
+                TRIP_ID, 6, GtfsTime.fromSecondsSinceMidnight(3600)),
+            new TooManyConsecutiveStopTimesWithSameTimeNotice(
+                TRIP_ID, 6, GtfsTime.fromSecondsSinceMidnight(3660)));
+  }
+
+  @Test
+  public void separateTripsShouldBeEvaluatedIndependently() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+
+    List<GtfsStopTime> stopTimes =
+        ImmutableList.of(
+            new GtfsStopTime.Builder()
+                .setCsvRowNumber(2)
+                .setTripId("trip-a")
+                .setStopSequence(1)
+                .setArrivalTime(GtfsTime.fromSecondsSinceMidnight(3600))
+                .setDepartureTime(GtfsTime.fromSecondsSinceMidnight(3600))
+                .build(),
+            new GtfsStopTime.Builder()
+                .setCsvRowNumber(3)
+                .setTripId("trip-b")
+                .setStopSequence(1)
+                .setArrivalTime(GtfsTime.fromSecondsSinceMidnight(3600))
+                .setDepartureTime(GtfsTime.fromSecondsSinceMidnight(3600))
+                .build());
+
+    new TooManyConsecutiveStopTimesWithSameTimeValidator(
+            GtfsStopTimeTableContainer.forEntities(stopTimes, noticeContainer))
+        .validate(noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices()).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Implements #178 by porting the historical Google Python validator check for trips with too many consecutive `stop_times.txt` rows sharing the same fully specified time.

The validator:

- runs per `trip_id` using the existing grouped stop-time table architecture;
- reports an `INFO` notice when a run contains more than five consecutive stop-time records with the same arrival/departure time;
- preserves the historical Python validator semantics for intervening rows with a missing arrival or departure time, which may contribute to a potential run that is later confirmed by a fully specified row;
- emits one notice per qualifying run with `tripId`, `entityCount`, and `time`.

## Tests

Added focused regression coverage for:

- exactly five matching stop times: no notice;
- six matching stop times: notice;
- run termination when the time changes;
- qualifying run at end of trip;
- historical missing-time behavior;
- multiple qualifying runs in one trip;
- independent evaluation of different trips.

Focused result: **7 passed**.

Full `:main:test` result locally: **682 passed, 3 failed**. The three failures are pre-existing Java 21 / Mockito environment failures (`JsonReportSummaryGeneratorTest` x2 and `VersionResolverTest`) and were reproduced independently on untouched baseline `21b27a4ac903bc2bc43d42a89bb3dbb47cc8921d`.

Closes #178