### PR TITLE
Issue/2183/1 fix: report the exact notice counts in the HTML report

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -174,6 +174,18 @@ public class NoticeContainer {
     return validationNotices;
   }
 
+  /**
+   * Returns how many notices of the given code and severity were added to this container.
+   *
+   * <p>This counts every notice the container was given, including the ones it did not retain, and
+   * is the number the validation report exports as {@code totalNotices}. It is therefore what a
+   * report should show, rather than the size of {@link #getResolvedValidationNotices()}.
+   */
+  public int getNoticeCount(String code, SeverityLevel severityLevel) {
+    return noticesCountPerTypeAndSeverity.getOrDefault(
+        ResolvedNotice.mappingKey(code, severityLevel), 0);
+  }
+
   /** Returns a list of all validation notices in the container. */
   public List<ValidationNotice> getValidationNotices() {
     return Lists.transform(validationNotices, ResolvedNotice::getContext);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
@@ -45,7 +45,12 @@ public final class ResolvedNotice<T extends Notice> {
    * @return the key used to group notices per type and severity: code + ordinal of severity level.
    */
   public String getMappingKey() {
-    return context.getCode() + getSeverityLevel().ordinal();
+    return mappingKey(context.getCode(), getSeverityLevel());
+  }
+
+  /** Returns the key under which notices of the given code and severity level are grouped. */
+  static String mappingKey(String code, SeverityLevel severityLevel) {
+    return code + severityLevel.ordinal();
   }
 
   @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -182,6 +182,19 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void getNoticeCount_countsDroppedNoticesToo() {
+    NoticeContainer container = new NoticeContainer(1_000, 2, 2);
+    for (int i = 0; i < 10; i++) {
+      container.addValidationNotice(new StringFieldNotice("value"));
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(2);
+    assertThat(container.getNoticeCount("string_field", SeverityLevel.ERROR)).isEqualTo(10);
+    assertThat(container.getNoticeCount("string_field", SeverityLevel.WARNING)).isEqualTo(0);
+    assertThat(container.getNoticeCount("unknown_file", SeverityLevel.INFO)).isEqualTo(0);
+  }
+
+  @Test
   public void exportNotices_shouldReflectTheTotalNumberOfNoticesAndContexts() {
     NoticeContainer container = new NoticeContainer(26, 8, 3);
     for (int i = 0; i < 55; i++) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
@@ -17,34 +17,53 @@
 package org.mobilitydata.gtfsvalidator.reportsummary.model;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 /** ReportSummary is the class containing the summary methods for the HTML report. */
 public class ReportSummary {
-  private final NoticeContainer container;
   private final Map<SeverityLevel, Long> severityCounts;
   private final Map<SeverityLevel, Map<String, List<NoticeView>>> noticesMap;
+  private final Map<SeverityLevel, Map<String, Integer>> noticeCountPerSeverityAndCode;
+  private final int noticeCount;
   private final VersionInfo versionInfo;
 
   public ReportSummary(NoticeContainer container, VersionInfo versionInfo) {
-    this.container = container;
-    this.severityCounts =
-        container.getResolvedValidationNotices().stream()
-            .collect(
-                Collectors.groupingBy(ResolvedNotice::getSeverityLevel, Collectors.counting()));
-    this.noticesMap =
-        container.getResolvedValidationNotices().stream()
-            .map(NoticeView::new)
-            .collect(
-                Collectors.groupingBy(
-                    NoticeView::getSeverityLevel,
-                    () -> new TreeMap<>(Comparator.reverseOrder()),
-                    Collectors.groupingBy(NoticeView::getCode, TreeMap::new, Collectors.toList())));
     this.versionInfo = versionInfo;
+    this.severityCounts = new EnumMap<>(SeverityLevel.class);
+    // Severity levels are listed from the most to the least severe, notice codes alphabetically.
+    this.noticesMap = new TreeMap<>(Comparator.reverseOrder());
+    this.noticeCountPerSeverityAndCode = new EnumMap<>(SeverityLevel.class);
+
+    for (ResolvedNotice<ValidationNotice> notice : container.getResolvedValidationNotices()) {
+      noticesMap
+          .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
+          .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>())
+          .add(new NoticeView(notice));
+    }
+
+    // The counts come from the container rather than from the notices above, which are only the
+    // ones the container retained. The report must show how many notices the feed actually
+    // produced, the same number the JSON report exports as totalNotices.
+    int total = 0;
+    for (Map.Entry<SeverityLevel, Map<String, List<NoticeView>>> bySeverity :
+        noticesMap.entrySet()) {
+      SeverityLevel severityLevel = bySeverity.getKey();
+      Map<String, Integer> countPerCode = new TreeMap<>();
+      long severityCount = 0;
+      for (String code : bySeverity.getValue().keySet()) {
+        int count = container.getNoticeCount(code, severityLevel);
+        countPerCode.put(code, count);
+        severityCount += count;
+      }
+      noticeCountPerSeverityAndCode.put(severityLevel, countPerCode);
+      severityCounts.put(severityLevel, severityCount);
+      total += severityCount;
+    }
+    this.noticeCount = total;
   }
 
   /**
@@ -60,12 +79,24 @@ public class ReportSummary {
   }
 
   /**
+   * Returns the total count of notices of the given severity level and code, including the ones the
+   * container did not retain and which are therefore absent from {@link #getNoticesMap()}.
+   *
+   * @return the total count of notices for that severity level and code.
+   */
+  public int getNoticeCountForCode(SeverityLevel severityLevel, String code) {
+    return noticeCountPerSeverityAndCode
+        .getOrDefault(severityLevel, Map.of())
+        .getOrDefault(code, 0);
+  }
+
+  /**
    * Returns the total count of notices in the validation report.
    *
    * @return the total count of notices.
    */
   public int getNoticeCount() {
-    return container.getValidationNotices().size();
+    return noticeCount;
   }
 
   /**

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -335,12 +335,13 @@
         </thead>
         <tbody>
         <span th:each="noticesBySeverityLevel: ${summary.noticesMap}">
-            <span th:each="noticesByCode: ${noticesBySeverityLevel.value}">
+            <span th:each="noticesByCode: ${noticesBySeverityLevel.value}"
+                  th:with="totalForCode=${summary.getNoticeCountForCode(noticesBySeverityLevel.key, noticesByCode.key)}">
                 <tr class="notice">
                     <td th:text="${noticesByCode.key}" />
                     <td th:class="${noticesBySeverityLevel.key.toString().toLowerCase()}"
                         th:text="${noticesBySeverityLevel.key}" />
-                    <td th:text="${noticesByCode.value.size}" />
+                    <td th:text="${totalForCode}" />
                 </tr>
                 <tr class="description">
                     <td colspan="4">
@@ -350,7 +351,7 @@
                             <p> You can see more about this notice <a
                                     th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key} + '-rule'}">here</a>.
                             </p>
-                             <p th:if="${noticesByCode.value.size > 50}">Only the first 50 of <span th:text="${noticesByCode.value.size}"></span> affected records are displayed below.</p>
+                             <p th:if="${totalForCode > 50}">Only the first 50 of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
                             <table>
                                 <thead>
                                     <tr>

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.reportsummary;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntityContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.util.VersionInfo;
+
+@RunWith(JUnit4.class)
+public class HtmlReportGeneratorTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * The page must report how many notices the feed produced, not how many the container kept: the
+   * container drops notices of a type past its retention limit, and the JSON report generated from
+   * the same run reports the exact number.
+   */
+  @Test
+  public void generateReport_countsAreExactWhenTheContainerDroppedNotices() throws IOException {
+    NoticeContainer noticeContainer = new NoticeContainer(1_000, 100, 100);
+    for (int i = 1; i <= 300; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(noticeContainer.getValidationNotices()).hasSize(100);
+    assertThat(report).contains("300 notices reported ( 300 errors, 0 warnings, 0 infos)");
+    assertThat(report).contains("missing_required_field ERROR 300");
+    assertThat(report).contains("Only the first 50 of 300 affected records are displayed below.");
+  }
+
+  /** Strips the markup so that assertions read like the rendered page. */
+  private static String visibleText(String html) {
+    return html.replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ");
+  }
+
+  private String generateReport(NoticeContainer noticeContainer) throws IOException {
+    GtfsFeedContainer feedContainer =
+        new GtfsFeedContainer(
+            ImmutableList.<GtfsEntityContainer<?, ?>>of(
+                GtfsStopTimeTableContainer.forEntities(ImmutableList.of(), new NoticeContainer())));
+    Path reportPath = temporaryFolder.newFile("report.html").toPath();
+    ValidationRunnerConfig config =
+        ValidationRunnerConfig.builder()
+            .setGtfsSource(Path.of("feed.zip").toUri())
+            .setOutputDirectory(reportPath.getParent())
+            .setCountryCode(CountryCode.forStringOrUnknown(""))
+            .build();
+
+    new HtmlReportGenerator()
+        .generateReport(
+            FeedMetadata.from(feedContainer, ImmutableSet.of("stop_times.txt")),
+            noticeContainer,
+            config,
+            VersionInfo.empty(),
+            reportPath,
+            "2026-01-01T00:00:00+00:00",
+            false);
+
+    return Files.readString(reportPath);
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
@@ -100,6 +100,44 @@ public class ReportSummaryTest {
         1);
   }
 
+  /**
+   * The counts must describe the feed, not what the container kept: a container that dropped
+   * notices past its retention limit still knows how many it was given, and the JSON report exports
+   * that number.
+   */
+  @Test
+  public void countsTest_areExactWhenTheContainerDroppedNotices() {
+    NoticeContainer noticeContainer = new NoticeContainer(1_000, 10, 10);
+    for (int i = 1; i <= 300; i++) {
+      noticeContainer.addValidationNotice(new MissingRequiredFieldNotice("test.txt", i, "field"));
+    }
+    for (int i = 1; i <= 40; i++) {
+      noticeContainer.addValidationNotice(new UnknownColumnNotice("test.txt", "unknown", i));
+    }
+    ReportSummary reportSummary = new ReportSummary(noticeContainer, VersionInfo.empty());
+
+    assertEquals(20, noticeContainer.getValidationNotices().size());
+    assertEquals(340, reportSummary.getNoticeCount());
+    assertEquals(300, reportSummary.getErrorCount());
+    assertEquals(40, reportSummary.getInfoCount());
+    assertEquals(0, reportSummary.getWarningCount());
+    assertEquals(
+        300,
+        reportSummary.getNoticeCountForCode(
+            SeverityLevel.ERROR, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+    assertEquals(
+        40, reportSummary.getNoticeCountForCode(SeverityLevel.INFO, UNKNOWN_COLUMN_NOTICE_CODE));
+  }
+
+  @Test
+  public void noticeCountForCodeTest_unknownCode() {
+    assertEquals(0, generateReportSummary().getNoticeCountForCode(SeverityLevel.ERROR, "unknown"));
+    assertEquals(
+        0,
+        generateReportSummary()
+            .getNoticeCountForCode(SeverityLevel.INFO, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+  }
+
   @Test
   public void testVersionPresent() {
     VersionInfo versionInfo = VersionInfo.create(Optional.of("1.2.3"), Optional.of("1.2.4"));


### PR DESCRIPTION
**Summary:**

First of the six PRs #2183 is split into, in [the grouping requested here](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383). It goes first because it changes the numbers the HTML report shows, so the report comparisons of every later PR start from correct counts.

`ReportSummary` derives every number it shows — the total in the heading, the per-severity totals and the per-code total in the table — from `container.getResolvedValidationNotices()`, the list of notices the container **retained**. `NoticeContainer` stops retaining notices of a type once `MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY` (100 000) is reached, while `noticesCountPerTypeAndSeverity` keeps counting all of them and is what `report.json` exports as `totalNotices`. So whenever a notice type crosses that limit, `report.html` and `report.json` disagree for the same run.

This is reachable on master today, without any of the other changes in #2183 — see the screenshots below. It becomes much easier to hit once PR 4 of the series lowers the retention limits, which is why it is fixed first.

The change:

- `ResolvedNotice.mappingKey(code, severityLevel)` — the key `code + severity.ordinal()` was spelled out inline in `getMappingKey()`; it is now a static helper, so a caller holding a code and a severity can build the same key.
- `NoticeContainer.getNoticeCount(code, severityLevel)` — new accessor over `noticesCountPerTypeAndSeverity`: how many notices of that code and severity the container was **given**, retained or not. Its javadoc states explicitly that this, not the size of `getResolvedValidationNotices()`, is what a report should show.
- `ReportSummary` — `severityCounts`, the per-code counts and `getNoticeCount()` now come from the container. The new `getNoticeCountForCode(severityLevel, code)` exposes the per-code total to the template. The `container` field is gone: nothing needs it after construction.
- `report.html` — the two spots that used `noticesByCode.value.size` now call `summary.getNoticeCountForCode(...)`, bound once per code with `th:with`.

Implementation report for the whole series: https://github.com/CarloMendola/gtfs-validator/blob/9f409204bcefff7387f05a3f70118fb03134443b/prompts/memory-optimization/MEMORY_OPTIMIZATION_REPORT.md

**Expected behavior:**

The counts in `report.html` match `report.json` for the same run. Nothing else changes: `report.json` is untouched (it was already exact), the same notices are retained, the same records are listed in the page, and the 50-record cap in the template stays as it is. On a feed that produces fewer notices per type than the retention limit — every normal feed — the rendered report is identical to master's.

Below, the same feed validated twice. The validation itself is identical in both runs — the same
notices are produced, the same ones are retained, `report.json` is the same file — so the only thing
that changes is the number **printed in `report.html`**, which stops under-reporting:

| number printed in `report.html` | on `master` | with this PR | true count, as `report.json` already reports it in both runs |
|---|---:|---:|---:|
| total in the heading | 1 008 001 | 1 213 921 | 1 213 921 |
| `fast_travel_between_consecutive_stops` | 100 000 | 205 920 | 205 920 |
| `stop_too_far_from_shape` | 100 000 | 200 000 | 200 000 |
| `leading_or_trailing_whitespaces` | 800 000 | 800 000 | 800 000 |

The two truncated rows are notice types added straight to the container, so the per-type limit of
100 000 caps the retained list that `ReportSummary` was counting. `leading_or_trailing_whitespaces`
reaches the container through `addAll`, which does not apply the limit on `master`, so its 800 000
were all retained and the page happened to be right about that one.

Before, on `master`:

<img width="900" height="520" alt="before-master" src="https://github.com/user-attachments/assets/1a190506-e3e4-4dc1-9dd5-8145f42a42ba" />

After, with this PR:

<img width="900" height="520" alt="after-pr1" src="https://github.com/user-attachments/assets/d22c7e1d-e878-4be9-ad80-f2d7d9d0d6e6" />


Covered by tests rather than by hand:

- `NoticeContainerTest.getNoticeCount_countsDroppedNoticesToo` — counts survive dropped notices.
- `ReportSummaryTest.countsTest_areExactWhenTheContainerDroppedNotices` — 300 + 40 notices into a container that retains 10 of each: the summary reports 340, 300 and 40, not 20.
- `ReportSummaryTest.noticeCountForCodeTest_unknownCode` — unknown code and wrong severity give 0.
- `HtmlReportGeneratorTest.generateReport_countsAreExactWhenTheContainerDroppedNotices` — renders a real report and asserts on the visible text of the page. This is the first test `HtmlReportGenerator` has ever had.

Nothing under `docs/` describes the report counts or the retention limits, so no documentation change is needed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [x] Include screenshot(s) showing how this pull request works and fixes the issue(s)
