### PR TITLE
Issue/2183/2 no observable change

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/input/GtfsInput.java
@@ -78,9 +78,12 @@ public abstract class GtfsInput implements Closeable {
    * @throws IOException
    */
   public static boolean hasSubfolderWithGtfsFile(Path path) throws IOException {
-    ZipInputStream zipInputStream =
-        new ZipInputStream(new BufferedInputStream(new FileInputStream(path.toFile())));
-    return containsGtfsFileInSubfolder(zipInputStream);
+    // The stream owns a file descriptor and an Inflater holding a native zlib stream, so it has to
+    // be closed: a long-running process validating many feeds would otherwise leak both.
+    try (ZipInputStream zipInputStream =
+        new ZipInputStream(new BufferedInputStream(new FileInputStream(path.toFile())))) {
+      return containsGtfsFileInSubfolder(zipInputStream);
+    }
   }
 
   /**
@@ -172,9 +175,11 @@ public abstract class GtfsInput implements Closeable {
       HttpGetUtil.loadFromUrl(sourceUrl, outputStream, validatorVersion, httpHeaders);
       File zipFile = new File(sourceUrl.toString());
       String fileName = zipFile.getName().replace(".zip", "");
-      if (containsGtfsFileInSubfolder(
-          new ZipInputStream(new ByteArrayInputStream(outputStream.toByteArray())))) {
-        noticeContainer.addValidationNotice(new InvalidInputFilesInSubfolderNotice());
+      try (ZipInputStream zipInputStream =
+          new ZipInputStream(new ByteArrayInputStream(outputStream.toByteArray()))) {
+        if (containsGtfsFileInSubfolder(zipInputStream)) {
+          noticeContainer.addValidationNotice(new InvalidInputFilesInSubfolderNotice());
+        }
       }
       return new GtfsZipFileInput(
           new ZipFile(new SeekableInMemoryByteChannel(outputStream.toByteArray())), fileName);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGenerator.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGenerator.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.lang.reflect.Field;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsJson;
 import org.mobilitydata.gtfsvalidator.annotation.GtfsTable;
@@ -51,6 +52,19 @@ public class NoticeSchemaGenerator {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
   private static Gson GSON = new GsonBuilder().create();
+
+  /**
+   * Documentation comments per notice class.
+   *
+   * <p>Loading them means opening a resource and parsing JSON, and the HTML report needs the
+   * comments of a notice class once per rendered notice. The result only depends on the class, so
+   * it is cached. A plain {@code ConcurrentHashMap} is enough: notice classes are loaded once and
+   * live for the lifetime of the process, and it behaves the same on any runtime.
+   *
+   * <p>The cached instances are shared by all callers and must be treated as read-only, even though
+   * {@link NoticeDocComments} is mutable.
+   */
+  private static final Map<Class<?>, NoticeDocComments> COMMENTS_CACHE = new ConcurrentHashMap<>();
 
   /**
    * Convenient function to find all notices in given packages and describe their fields.
@@ -127,6 +141,16 @@ public class NoticeSchemaGenerator {
   }
 
   public static NoticeDocComments loadComments(Class<?> noticeClass) {
+    // Read with get before computeIfAbsent: the latter locks the bin of an already cached
+    // class unless it happens to be the first entry of that bin, and this is called once per
+    // notice rendered in the report.
+    NoticeDocComments cached = COMMENTS_CACHE.get(noticeClass);
+    return cached != null
+        ? cached
+        : COMMENTS_CACHE.computeIfAbsent(noticeClass, NoticeSchemaGenerator::loadCommentsUncached);
+  }
+
+  private static NoticeDocComments loadCommentsUncached(Class<?> noticeClass) {
     String resourceName = NoticeDocComments.getResourceNameForClass(noticeClass);
     InputStream is = noticeClass.getResourceAsStream(resourceName);
     if (is == null) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/input/GtfsInputTest.java
@@ -25,6 +25,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -75,6 +77,37 @@ public class GtfsInputTest {
     try (GtfsInput gtfsInput = GtfsInput.createFromPath(zipFile.toPath(), noticeContainer)) {
       assertThat(gtfsInput.getFilenames()).containsExactly("stops.txt");
     }
+  }
+
+  @Test
+  public void hasSubfolderWithGtfsFile_detectsGtfsFileInSubfolder() throws IOException {
+    assertTrue(GtfsInput.hasSubfolderWithGtfsFile(writeZip("subfolder.zip", "sub/stops.txt")));
+    assertFalse(GtfsInput.hasSubfolderWithGtfsFile(writeZip("flat.zip", "stops.txt")));
+    assertFalse(GtfsInput.hasSubfolderWithGtfsFile(writeZip("other.zip", "sub/readme.md")));
+  }
+
+  /**
+   * The archive is only read to look for a subfolder, and the stream that reads it must be closed.
+   * Deleting a file that is still open fails on Windows, which is where this assertion bites.
+   */
+  @Test
+  public void hasSubfolderWithGtfsFile_releasesTheArchive() throws IOException {
+    Path zipFile = writeZip("archived.zip", "sub/stops.txt");
+
+    GtfsInput.hasSubfolderWithGtfsFile(zipFile);
+
+    assertTrue(Files.deleteIfExists(zipFile));
+  }
+
+  private Path writeZip(String zipName, String... entryNames) throws IOException {
+    File zipFile = tmpDir.newFile(zipName);
+    try (ZipOutputStream out = new ZipOutputStream(new FileOutputStream(zipFile))) {
+      for (String entryName : entryNames) {
+        out.putNextEntry(new ZipEntry(entryName));
+        out.closeEntry();
+      }
+    }
+    return zipFile.toPath();
   }
 
   @Test

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/schema/NoticeSchemaGeneratorTest.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.junit.Test;
 import org.mobilitydata.gtfsvalidator.notice.DuplicateKeyNotice;
 import org.mobilitydata.gtfsvalidator.notice.ForeignKeyViolationNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeDocComments;
 import org.mobilitydata.gtfsvalidator.notice.schema.ReferencesSchema.UrlReference;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.DocumentedNotice;
 import org.mobilitydata.gtfsvalidator.notice.testnotices.S2LatLngNotice;
@@ -119,6 +120,22 @@ public class NoticeSchemaGeneratorTest {
     String actualJson = new GsonBuilder().setPrettyPrinting().create().toJson(schema);
     String expectedJson = retrieveResource("generateJsonSchemaForNotice_s2LatLngNotice.json");
     assertThat(actualJson).isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void loadComments_isCachedPerNoticeClass() {
+    NoticeDocComments comments = NoticeSchemaGenerator.loadComments(DocumentedNotice.class);
+
+    assertThat(NoticeSchemaGenerator.loadComments(DocumentedNotice.class))
+        .isSameInstanceAs(comments);
+    assertThat(comments.getFieldComment("value")).isEqualTo("A field comment");
+  }
+
+  @Test
+  public void loadComments_noticeWithoutComments_returnsEmptyComments() {
+    NoticeDocComments comments = NoticeSchemaGenerator.loadComments(String.class);
+
+    assertThat(comments.getFieldComment("value")).isNull();
   }
 
   private static String retrieveResource(String name) throws IOException {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -21,7 +21,9 @@ import static org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader.SkippedValidat
 import com.google.common.flogger.FluentLogger;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
 import java.io.IOException;
+import java.io.Writer;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -328,9 +330,13 @@ public class ValidationRunner {
     }
 
     if (config.stdoutOutput()) {
-      // Output JSON to stdout
+      // Output JSON to stdout. The report is serialized straight to the stream: on a feed with
+      // many notices, holding it as a String and then as its byte array costs several times its
+      // size, at the point where the heap is already at its peak.
       try {
-        System.out.println(gson.toJson(jsonReport));
+        gson.toJson(jsonReport, System.out);
+        System.out.println();
+        System.out.flush();
       } catch (Exception ex) {
         logger.atSevere().withCause(ex).log("Error creating JSON report");
       }
@@ -351,10 +357,10 @@ public class ValidationRunner {
     boolean is_different_date = !now.toLocalDate().equals(config.dateForValidation());
 
     HtmlReportGenerator htmlGenerator = new HtmlReportGenerator();
-    try {
-      Files.write(
-          outputDir.resolve(config.validationReportFileName()),
-          gson.toJson(jsonReport).getBytes(StandardCharsets.UTF_8));
+    try (Writer writer =
+        Files.newBufferedWriter(
+            outputDir.resolve(config.validationReportFileName()), StandardCharsets.UTF_8)) {
+      gson.toJson(jsonReport, writer);
     } catch (Exception ex) {
       logger.atSevere().withCause(ex).log("Error creating JSON report");
     }
@@ -368,10 +374,14 @@ public class ValidationRunner {
           outputDir.resolve(config.htmlReportFileName()),
           date,
           is_different_date);
-      Files.write(
-          outputDir.resolve(config.systemErrorsReportFileName()),
-          gson.toJson(noticeContainer.exportSystemErrors()).getBytes(StandardCharsets.UTF_8));
-    } catch (IOException e) {
+      try (Writer writer =
+          Files.newBufferedWriter(
+              outputDir.resolve(config.systemErrorsReportFileName()), StandardCharsets.UTF_8)) {
+        gson.toJson(noticeContainer.exportSystemErrors(), writer);
+      }
+      // Gson reports a failing writer as a JsonIOException, so it is caught here alongside the
+      // IOException the file operations themselves throw.
+    } catch (IOException | JsonIOException e) {
       logger.atSevere().withCause(e).log("Cannot store report files");
     }
   }

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
@@ -1,19 +1,36 @@
 package org.mobilitydata.gtfsvalidator.runner;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.gson.Gson;
+import com.google.gson.JsonParser;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.RuntimeExceptionInValidatorError;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 @RunWith(JUnit4.class)
 public class ValidationRunnerTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   private static ValidationRunnerConfig buildConfig(String gtfsDirectory) {
     ValidationRunnerConfig.Builder config = ValidationRunnerConfig.builder();
@@ -44,6 +61,46 @@ public class ValidationRunnerTest {
     // InvalidPathException. This should catch issues such as #1158.
     assertThrows(
         FileNotFoundException.class, () -> ValidationRunner.createGtfsInput(config, "1.1.0"));
+  }
+
+  /**
+   * The reports are serialized straight to their file instead of through an intermediate string, so
+   * this covers the encoding of the produced files.
+   */
+  @Test
+  public void exportReport_writesUtf8EncodedJsonReports() throws IOException {
+    // A non-ASCII name, so that the encoding of the written files is covered.
+    String filename = "stazioné.txt";
+    Path outputDirectory = temporaryFolder.newFolder().toPath();
+    ValidationRunnerConfig config =
+        ValidationRunnerConfig.builder()
+            .setGtfsSource(Path.of("feed.zip").toUri())
+            .setOutputDirectory(outputDirectory)
+            .setCountryCode(CountryCode.forStringOrUnknown(""))
+            .build();
+    NoticeContainer noticeContainer = new NoticeContainer();
+    noticeContainer.addValidationNotice(new MissingRequiredFieldNotice(filename, 1, "field"));
+    noticeContainer.addSystemError(
+        new RuntimeExceptionInValidatorError(
+            "FaultyValidator", new IllegalStateException(filename)));
+
+    ValidationRunner.exportReport(
+        FeedMetadata.from(
+            new GtfsFeedContainer(ImmutableList.of()), ImmutableSet.of("stop_times.txt")),
+        noticeContainer,
+        config,
+        VersionInfo.empty());
+
+    String validationReport =
+        Files.readString(
+            outputDirectory.resolve(config.validationReportFileName()), StandardCharsets.UTF_8);
+    assertThat(JsonParser.parseString(validationReport).isJsonObject()).isTrue();
+    assertThat(validationReport).contains(filename);
+    assertThat(
+            Files.readString(
+                outputDirectory.resolve(config.systemErrorsReportFileName()),
+                StandardCharsets.UTF_8))
+        .isEqualTo(new Gson().toJson(noticeContainer.exportSystemErrors()));
   }
 
   @Test


### PR DESCRIPTION
**Summary:**

Second of the six PRs #2183 is split into, in [the grouping requested here](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383). Based directly on `master` and independent of the other PRs in the series. Three changes grouped because none of them changes anything observable: same reports, same bytes, same notices — they only stop holding things the run does not need.

**1. Close the `ZipInputStream` used to look for a subfolder.** `GtfsInput.hasSubfolderWithGtfsFile` and `createFromUrlInMemory` opened a `ZipInputStream` over the archive and never closed it. Each holds a file descriptor and an `Inflater`, which owns a zlib stream in native memory released only when the cleaner eventually runs. Harmless for one CLI invocation; a long-running service validating one feed after another leaks descriptors and resident memory. Both are now in try-with-resources.

**2. Cache the notice documentation comments per notice class.** `NoticeSchemaGenerator.loadComments` opens a classpath resource and parses JSON on every call, and `NoticeView` calls it once **per notice**. Generating the HTML report for a feed with many notices repeated the same resource read and JSON parse thousands of times and retained one identical `NoticeDocComments` instance — each with its own map — per notice. It is simultaneously the largest CPU cost of report generation and a per-notice memory cost. The result depends only on the notice class, so it is memoized in a `ConcurrentHashMap<Class<?>, NoticeDocComments>`, [as you preferred](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383) over `ClassValue`.

The lookup reads with `get` and falls back to `computeIfAbsent` only on a miss, which is deliberate: `computeIfAbsent` locks the bin of an already cached key unless that key happens to be the first entry of its bin. Measured over the 53 notice classes of `core`, per lookup: `ClassValue` 2.5 ns, plain `computeIfAbsent` 6.1 ns, `get` first 3.9 ns single-threaded (0.65 / 2.34 / 1.05 ns per operation with four threads).

One thing worth a reviewer's eye: `NoticeDocComments` is mutable and the cached instance is now shared. No caller in the repository mutates it (`NoticeView` and `generateSchemaForNotice` only read), and the cache javadoc says the instances must be treated as read-only. If you would rather have a hard guarantee, making the type immutable would be a good follow-up.

**3. Serialize the JSON reports straight to their destination.** `gson.toJson(report)` built the whole report as a `String` and `getBytes` copied it into a byte array, so writing a report held two or three copies of it at the moment the heap is already at its peak; on a feed with many notices the report is tens of megabytes. The reports are now serialized directly into a `Writer` on the output file, and the stdout variant writes to `System.out` (a `PrintStream` is an `Appendable`, so its encoding and the trailing newline are unchanged). Since Gson signals a failing writer with the unchecked `JsonIOException`, the system-errors write now catches that alongside `IOException`, which is what the previous `Files.write` form did in effect.

Implementation report for the whole series: https://github.com/CarloMendola/gtfs-validator/blob/9f409204bcefff7387f05a3f70118fb03134443b/prompts/memory-optimization/MEMORY_OPTIMIZATION_REPORT.md

**Expected behavior:**

No user-visible change. The produced bytes are identical — Gson uses the same serialization path for both APIs — so `report.json`, `system_errors.json` and `report.html` are what master writes for the same feed. Verified on the CTA Chicago feed (95 MB zip, 413 MB of CSV): the `notices` object of `report.json` is identical to master's, and `report.html` differs only in the generation timestamp. Nothing to screenshot for that reason.

Tests:

- `GtfsInputTest` — subfolder detection with and without a nested GTFS file, now over a closed stream.
- `NoticeSchemaGeneratorTest.loadComments_isCachedPerNoticeClass` — the same instance comes back.
- `NoticeSchemaGeneratorTest.loadComments_noticeWithoutComments_returnsEmptyComments` — the missing-resource path still works through the cache.
- `ValidationRunnerTest.exportReport_writesUtf8EncodedJsonReports` — writes both JSON reports with a non-ASCII filename in the notices and asserts the file contents, covering the encoding of the new writer path.

Nothing under `docs/` describes any of these internals, so no documentation change is needed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) — no visible change: the reports are identical to master's
