### PR TITLE
Issue/2183/3 perf: release the feed container before generating reports

### DIFF
--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunner.java
@@ -157,9 +157,17 @@ public class ValidationRunner {
             .getMemoryUsageSnapshot("ValidationRunner.run", memoryBefore);
     MemoryUsageRegister.getInstance().registerMemoryUsage(after);
 
+    // Everything the reports need from the feed container has now been extracted, so the reference
+    // is dropped before generating them. Report generation is itself allocation heavy (JSON trees,
+    // notice views, output buffers) and the container holds every loaded entity: keeping both alive
+    // makes the memory peak the sum of the two phases instead of the larger of the two. On a large
+    // feed the container alone is over a gigabyte.
+    String tableTotals = feedContainer.tableTotalsText();
+    feedContainer = null;
+
     // Output
     exportReport(feedMetadata, noticeContainer, config, versionInfo);
-    printSummary(feedMetadata, feedContainer, feedLoader, config);
+    printSummary(feedMetadata, tableTotals, feedLoader, config);
     return Status.SUCCESS;
   }
 
@@ -168,10 +176,35 @@ public class ValidationRunner {
    *
    * @param feedMetadata the {@code FeedMetadata}
    * @param feedContainer the {@code GtfsFeedContainer}
+   * @deprecated Use {@link #printSummary(FeedMetadata, String, GtfsFeedLoader,
+   *     ValidationRunnerConfig)}, which does not require the feed container to be kept in memory
+   *     while reports are generated.
    */
+  @Deprecated
   public static void printSummary(
       FeedMetadata feedMetadata,
       GtfsFeedContainer feedContainer,
+      GtfsFeedLoader loader,
+      ValidationRunnerConfig config) {
+    // The container is only read for the table totals, and the new overload returns before
+    // using them in stdout mode: a caller passing no container in that mode kept working.
+    printSummary(
+        feedMetadata,
+        feedContainer == null ? null : feedContainer.tableTotalsText(),
+        loader,
+        config);
+  }
+
+  /**
+   * Prints validation metadata.
+   *
+   * @param feedMetadata the {@code FeedMetadata}
+   * @param tableTotals the per-table entity counts, as returned by {@link
+   *     GtfsFeedContainer#tableTotalsText()}
+   */
+  public static void printSummary(
+      FeedMetadata feedMetadata,
+      String tableTotals,
       GtfsFeedLoader loader,
       ValidationRunnerConfig config) {
     // Skip summary output when using stdout mode to avoid interfering with JSON output
@@ -249,7 +282,7 @@ public class ValidationRunner {
     }
 
     logger.atInfo().log("Validation took %.3f seconds%n", feedMetadata.validationTimeSeconds);
-    logger.atInfo().log(feedContainer.tableTotalsText());
+    logger.atInfo().log(tableTotals);
   }
 
   /**

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/runner/ValidationRunnerTest.java
@@ -1,16 +1,31 @@
 package org.mobilitydata.gtfsvalidator.runner;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntityContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedLoader;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
 
 @RunWith(JUnit4.class)
 public class ValidationRunnerTest {
@@ -44,6 +59,66 @@ public class ValidationRunnerTest {
     // InvalidPathException. This should catch issues such as #1158.
     assertThrows(
         FileNotFoundException.class, () -> ValidationRunner.createGtfsInput(config, "1.1.0"));
+  }
+
+  /**
+   * The feed container is released before reports are generated, so the summary is printed from the
+   * table totals captured beforehand. Both overloads must log exactly the same thing.
+   */
+  @Test
+  public void printSummary_tableTotalsOverload_logsSameOutputAsFeedContainerOverload() {
+    GtfsFeedContainer feedContainer =
+        new GtfsFeedContainer(
+            ImmutableList.<GtfsEntityContainer<?, ?>>of(
+                GtfsStopTimeTableContainer.forEntities(ImmutableList.of(), new NoticeContainer())));
+    FeedMetadata feedMetadata = FeedMetadata.from(feedContainer, ImmutableSet.of());
+    feedMetadata.validationTimeSeconds = 1.5;
+    GtfsFeedLoader loader = new GtfsFeedLoader(ImmutableList.of());
+    ValidationRunnerConfig config = buildConfig("/tmp/nonexistent.zip");
+
+    List<String> fromTableTotals =
+        captureLoggedMessages(
+            () ->
+                ValidationRunner.printSummary(
+                    feedMetadata, feedContainer.tableTotalsText(), loader, config));
+    List<String> fromFeedContainer =
+        captureLoggedMessages(
+            () -> ValidationRunner.printSummary(feedMetadata, feedContainer, loader, config));
+
+    assertThat(fromTableTotals).contains("stop_times.txt\t0");
+    assertThat(fromFeedContainer).isEqualTo(fromTableTotals);
+  }
+
+  /** Captures the messages logged by {@link ValidationRunner} while {@code runnable} runs. */
+  private static List<String> captureLoggedMessages(Runnable runnable) {
+    List<String> messages = new ArrayList<>();
+    Handler handler =
+        new Handler() {
+          @Override
+          public void publish(LogRecord record) {
+            messages.add(record.getMessage());
+          }
+
+          @Override
+          public void flush() {}
+
+          @Override
+          public void close() {}
+        };
+    Logger logger = Logger.getLogger(ValidationRunner.class.getName());
+    Level previousLevel = logger.getLevel();
+    boolean previousUseParentHandlers = logger.getUseParentHandlers();
+    logger.setLevel(Level.INFO);
+    logger.setUseParentHandlers(false);
+    logger.addHandler(handler);
+    try {
+      runnable.run();
+    } finally {
+      logger.removeHandler(handler);
+      logger.setUseParentHandlers(previousUseParentHandlers);
+      logger.setLevel(previousLevel);
+    }
+    return messages;
   }
 
   @Test


### PR DESCRIPTION
**Summary:**

Third of the six PRs #2183 is split into, in [the grouping requested here](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383). Based directly on `master` and independent of the other PRs in the series.

`ValidationRunner.run` holds a strong reference to the `GtfsFeedContainer` across the whole reporting phase, because `printSummary` needs it *after* `exportReport`. Report generation is the second most allocation-heavy phase of a run (JSON trees, notice views, output buffers), so the peak memory of the process is `live(feed) + peak(reports)` instead of the larger of the two. On a large feed the container alone is over a gigabyte, and it is dead weight by then: every entity has already been validated.

The only thing the summary needs from the container is `tableTotalsText()`. It is now captured before the reporting phase and the local reference is dropped, so the entities become collectable while the reports are built:

```java
String tableTotals = feedContainer.tableTotalsText();
feedContainer = null;

exportReport(feedMetadata, noticeContainer, config, versionInfo);
printSummary(feedMetadata, tableTotals, feedLoader, config);
```

`printSummary` gets an overload taking the totals as a `String`. As you noted, the old signature has exactly one in-repo caller — this one — so the previous signature is kept only for external users: it is deprecated and delegates. It also keeps tolerating a `null` container the way the old body did, since in stdout mode the method returns before the totals are used.

On the reference feed this is the single largest contributor to the drop in peak memory.

Implementation report for the whole series: https://github.com/CarloMendola/gtfs-validator/blob/9f409204bcefff7387f05a3f70118fb03134443b/prompts/memory-optimization/MEMORY_OPTIMIZATION_REPORT.md

**Expected behavior:**

Identical output, lower peak memory. Nothing about the reports or the printed summary changes; the only difference is when the loaded feed becomes garbage. Verified on the CTA Chicago feed (95 MB zip, 413 MB of CSV): the `notices` object of `report.json` is identical to master's and `report.html` differs only in the generation timestamp. Nothing to screenshot for that reason.

`ValidationRunnerTest.printSummary_tableTotalsOverload_logsSameOutputAsFeedContainerOverload` captures what `ValidationRunner` logs through both overloads and asserts they are identical, so the deprecated delegate cannot drift from the new path.

Nothing under `docs/` documents this method or the reporting sequence, so no documentation change is needed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) — no visible change: the output is identical to master's
