### PR TITLE
Issue/2183/4 notice retention

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -174,6 +174,18 @@ public class NoticeContainer {
     return validationNotices;
   }
 
+  /**
+   * Returns how many notices of the given code and severity were added to this container.
+   *
+   * <p>This counts every notice the container was given, including the ones it did not retain, and
+   * is the number the validation report exports as {@code totalNotices}. It is therefore what a
+   * report should show, rather than the size of {@link #getResolvedValidationNotices()}.
+   */
+  public int getNoticeCount(String code, SeverityLevel severityLevel) {
+    return noticesCountPerTypeAndSeverity.getOrDefault(
+        ResolvedNotice.mappingKey(code, severityLevel), 0);
+  }
+
   /** Returns a list of all validation notices in the container. */
   public List<ValidationNotice> getValidationNotices() {
     return Lists.transform(validationNotices, ResolvedNotice::getContext);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MultimapBuilder;
@@ -35,8 +36,13 @@ import org.mobilitydata.gtfsvalidator.model.ValidationReport;
  * own NoticeContainer, and after execution is complete the results are merged.
  */
 public class NoticeContainer {
-  /** Limit on the amount notices of the same type and severity. */
-  private static final int MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY = 100_000;
+  /**
+   * Limit on the amount notices of the same type and severity.
+   *
+   * <p>Only {@code MAX_EXPORTS_PER_NOTICE_TYPE_AND_SEVERITY} notices per type and severity end up
+   * in a validation report, so retaining orders of magnitude more of them only costs memory.
+   */
+  @VisibleForTesting static final int MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY = 2_000;
 
   /**
    * Limit on the total amount of stored validation notices.
@@ -47,7 +53,7 @@ public class NoticeContainer {
    *
    * <p>Note that system errors are not limited since we don't expect to have a lot of them.
    */
-  private static final int MAX_TOTAL_VALIDATION_NOTICES = 10_000_000;
+  @VisibleForTesting static final int MAX_TOTAL_VALIDATION_NOTICES = 200_000;
 
   /** Limit on the amount of exported notices */
   private static final int MAX_EXPORTS_PER_NOTICE_TYPE_AND_SEVERITY = 1_000;
@@ -58,6 +64,16 @@ public class NoticeContainer {
   private final List<ResolvedNotice<ValidationNotice>> validationNotices = new ArrayList<>();
   private final List<ResolvedNotice<SystemError>> systemErrors = new ArrayList<>();
   private final Map<String, Integer> noticesCountPerTypeAndSeverity = new HashMap<>();
+
+  /**
+   * Amount of notices per type and severity actually kept in {@code validationNotices}.
+   *
+   * <p>This is deliberately separate from {@code noticesCountPerTypeAndSeverity}: the latter counts
+   * every notice ever added, including the ones dropped once a limit is reached, and is what the
+   * validation report exports as {@code totalNotices}.
+   */
+  private final Map<String, Integer> retainedNoticesCountPerTypeAndSeverity = new HashMap<>();
+
   private boolean hasValidationErrors = false;
   private boolean hasValidationWarnings = false;
 
@@ -106,12 +122,31 @@ public class NoticeContainer {
     }
 
     updateNoticeCount(resolved);
-    if (validationNotices.size() >= maxTotalValidationNotices
-        || noticesCountPerTypeAndSeverity.get(resolved.getMappingKey())
-            > maxValidationNoticesPerTypeAndSeverity) {
-      return;
+    if (canRetain(resolved)) {
+      validationNotices.add(resolved);
     }
-    validationNotices.add(resolved);
+  }
+
+  /**
+   * Tells whether the given notice fits in this container, and books the slot if it does.
+   *
+   * <p>This is the single place where the retention limits are enforced, so that notices added one
+   * by one and notices merged from another container are treated the same way.
+   */
+  private boolean canRetain(ResolvedNotice<?> notice) {
+    String mappingKey = notice.getMappingKey();
+    int retained = retainedNoticesCountPerTypeAndSeverity.getOrDefault(mappingKey, 0);
+    if (retained >= maxValidationNoticesPerTypeAndSeverity) {
+      return false;
+    }
+    // A notice type is described in the exported report only if at least one of its notices was
+    // retained, so the first notice of a type and severity is kept even once the total limit is
+    // reached: dropping it would hide the type, and its exact count, from the report entirely.
+    if (retained > 0 && validationNotices.size() >= maxTotalValidationNotices) {
+      return false;
+    }
+    retainedNoticesCountPerTypeAndSeverity.put(mappingKey, retained + 1);
+    return true;
   }
 
   public <T extends ValidationNotice> NoticeContainer addValidationNotices(Iterable<T> notices) {
@@ -142,22 +177,29 @@ public class NoticeContainer {
    * Adds all validation notices and system errors from another container.
    *
    * <p>This is useful for multithreaded validation: each thread has its own notice container which
-   * is merged into the global container when the thread finishes. Please note that the final {@code
-   * NoticeContainer} may contain more than the maximum amount of {@code ValidationNotice} allowed
-   * by {@code NoticeContainer#MAX_TOTAL_VALIDATION_NOTICES} and {@code
-   * NoticeContainer#MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY}.
+   * is merged into the global container when the thread finishes. It is also how row-by-row parsing
+   * notices reach the container of a table: {@code CsvFileLoader} merges one container per row.
+   *
+   * <p>The retention limits of this container are applied to the merged notices, so a feed where
+   * every row of a large file yields a notice cannot grow the container without bound. Notice
+   * counts are merged in full regardless of retention, so the {@code totalNotices} reported for
+   * each notice type stays exact.
    *
    * @param otherContainer a container to take the notices from
    */
   public void addAll(NoticeContainer otherContainer) {
-    validationNotices.addAll(otherContainer.validationNotices);
-    systemErrors.addAll(otherContainer.systemErrors);
-    hasValidationErrors |= otherContainer.hasValidationErrors;
-    hasValidationWarnings |= otherContainer.hasValidationWarnings;
     for (Entry<String, Integer> entry : otherContainer.noticesCountPerTypeAndSeverity.entrySet()) {
       int count = noticesCountPerTypeAndSeverity.getOrDefault(entry.getKey(), 0);
       noticesCountPerTypeAndSeverity.put(entry.getKey(), count + entry.getValue());
     }
+    for (ResolvedNotice<ValidationNotice> notice : otherContainer.validationNotices) {
+      if (canRetain(notice)) {
+        validationNotices.add(notice);
+      }
+    }
+    systemErrors.addAll(otherContainer.systemErrors);
+    hasValidationErrors |= otherContainer.hasValidationErrors;
+    hasValidationWarnings |= otherContainer.hasValidationWarnings;
   }
 
   /** Tells if this container has any {@code ValidationNotice} that is an error. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
@@ -45,7 +45,12 @@ public final class ResolvedNotice<T extends Notice> {
    * @return the key used to group notices per type and severity: code + ordinal of severity level.
    */
   public String getMappingKey() {
-    return context.getCode() + getSeverityLevel().ordinal();
+    return mappingKey(context.getCode(), getSeverityLevel());
+  }
+
+  /** Returns the key under which notices of the given code and severity level are grouped. */
+  static String mappingKey(String code, SeverityLevel severityLevel) {
+    return code + severityLevel.ordinal();
   }
 
   @Override

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -182,6 +182,19 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void getNoticeCount_countsDroppedNoticesToo() {
+    NoticeContainer container = new NoticeContainer(1_000, 2, 2);
+    for (int i = 0; i < 10; i++) {
+      container.addValidationNotice(new StringFieldNotice("value"));
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(2);
+    assertThat(container.getNoticeCount("string_field", SeverityLevel.ERROR)).isEqualTo(10);
+    assertThat(container.getNoticeCount("string_field", SeverityLevel.WARNING)).isEqualTo(0);
+    assertThat(container.getNoticeCount("unknown_file", SeverityLevel.INFO)).isEqualTo(0);
+  }
+
+  @Test
   public void exportNotices_shouldReflectTheTotalNumberOfNoticesAndContexts() {
     NoticeContainer container = new NoticeContainer(26, 8, 3);
     for (int i = 0; i < 55; i++) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -195,6 +195,87 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void addAll_shouldRespectMaxPerNoticeTypeAndSeverity() {
+    NoticeContainer container = new NoticeContainer(1_000, 5, 5);
+    for (int i = 0; i < 20; i++) {
+      // Reproduces how CsvFileLoader merges one container per parsed row.
+      NoticeContainer rowNotices = new NoticeContainer();
+      rowNotices.addValidationNotice(new DoubleFieldNotice(i));
+      container.addAll(rowNotices);
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(5);
+  }
+
+  @Test
+  public void addAll_shouldRespectMaxTotalValidationNotices() {
+    NoticeContainer container = new NoticeContainer(7, 1_000, 1_000);
+    for (int i = 0; i < 20; i++) {
+      NoticeContainer otherContainer = new NoticeContainer();
+      otherContainer.addValidationNotice(new DoubleFieldNotice(i));
+      otherContainer.addValidationNotice(new StringFieldNotice(Integer.toString(i)));
+      container.addAll(otherContainer);
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(7);
+  }
+
+  @Test
+  public void exportNoticesAfterAddAll_shouldReportExactTotalCountBeyondRetentionLimit() {
+    NoticeContainer container = new NoticeContainer(1_000, 2, 2);
+    for (int i = 0; i < 100; i++) {
+      NoticeContainer rowNotices = new NoticeContainer();
+      rowNotices.addValidationNotice(new StringFieldNotice("value"));
+      container.addAll(rowNotices);
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(2);
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
+        .isEqualTo(
+            "{\"notices\":[{\"code\":\"string_field\",\"severity\":\"ERROR\","
+                + "\"totalNotices\":100,\"sampleNotices\":[{\"someField\":\"value\"},{"
+                + "\"someField\":\"value\"}]}]}");
+  }
+
+  @Test
+  public void addAll_shouldKeepValidationErrorAndWarningFlagsWhenNoticesAreDropped() {
+    NoticeContainer container = new NoticeContainer(0, 0, 0);
+    NoticeContainer otherContainer = new NoticeContainer();
+    otherContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+    otherContainer.addValidationNotice(new MissingRecommendedFileNotice("feed_info.txt"));
+    container.addAll(otherContainer);
+
+    assertThat(container.getValidationNotices()).isEmpty();
+    assertThat(container.hasValidationErrors()).isTrue();
+    assertThat(container.hasValidationWarnings()).isTrue();
+  }
+
+  /**
+   * A notice type is described in the exported report only if one of its notices was retained, so
+   * reaching the total limit must not make a whole type disappear from the report.
+   */
+  @Test
+  public void addAll_totalLimitReached_stillRetainsTheFirstNoticeOfEachType() {
+    NoticeContainer container = new NoticeContainer(4, 2, 10);
+    NoticeContainer otherContainer = new NoticeContainer();
+    for (int i = 0; i < 3; i++) {
+      otherContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+      otherContainer.addValidationNotice(new UnknownFileNotice("unknown.txt"));
+    }
+    otherContainer.addValidationNotice(new DoubleFieldNotice(2.0));
+    container.addAll(otherContainer);
+
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
+        .isEqualTo(
+            "{\"notices\":[{\"code\":\"double_field\",\"severity\":\"ERROR\",\"totalNotices\":1,"
+                + "\"sampleNotices\":[{\"doubleField\":2.0}]},{\"code\":\"missing_required_file\","
+                + "\"severity\":\"ERROR\",\"totalNotices\":3,\"sampleNotices\":[{\"filename\":"
+                + "\"stops.txt\"},{\"filename\":\"stops.txt\"}]},{\"code\":\"unknown_file\","
+                + "\"severity\":\"INFO\",\"totalNotices\":3,\"sampleNotices\":[{\"filename\":"
+                + "\"unknown.txt\"},{\"filename\":\"unknown.txt\"}]}]}");
+  }
+
+  @Test
   public void exportNotices_shouldReflectTheTotalNumberOfNoticesAndContexts() {
     NoticeContainer container = new NoticeContainer(26, 8, 3);
     for (int i = 0; i < 55; i++) {

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGenerator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGenerator.java
@@ -73,6 +73,12 @@ public class HtmlReportGenerator {
     }
   }
 
+  /**
+   * Returns, per notice code, the fields that are set on at least one of its notices.
+   *
+   * <p>The lists in {@code noticesByCode} hold the notices the report actually lists, so the
+   * columns are derived from exactly the rows that are rendered.
+   */
   private Map<String, List<String>> getUniqueFieldsForCodes(
       Map<String, List<NoticeView>> noticesByCode) {
     return noticesByCode.entrySet().stream()

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.reportsummary.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.*;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
@@ -25,6 +26,17 @@ import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 /** ReportSummary is the class containing the summary methods for the HTML report. */
 public class ReportSummary {
+
+  /**
+   * Maximum number of notices per code for which a {@link NoticeView} is created.
+   *
+   * <p>A {@code NoticeView} holds the complete JSON tree of its notice, so building one per notice
+   * costs a few hundred bytes per notice, allocated at the very end of validation when the heap is
+   * already at its peak. The report only lists this many affected records per notice code, so the
+   * remaining views were built and discarded without ever being read.
+   */
+  @VisibleForTesting static final int MAX_NOTICES_PER_CODE = 50;
+
   private final Map<SeverityLevel, Long> severityCounts;
   private final Map<SeverityLevel, Map<String, List<NoticeView>>> noticesMap;
   private final Map<SeverityLevel, Map<String, Integer>> noticeCountPerSeverityAndCode;
@@ -39,15 +51,18 @@ public class ReportSummary {
     this.noticeCountPerSeverityAndCode = new EnumMap<>(SeverityLevel.class);
 
     for (ResolvedNotice<ValidationNotice> notice : container.getResolvedValidationNotices()) {
-      noticesMap
-          .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
-          .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>())
-          .add(new NoticeView(notice));
+      List<NoticeView> notices =
+          noticesMap
+              .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
+              .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>());
+      if (notices.size() < MAX_NOTICES_PER_CODE) {
+        notices.add(new NoticeView(notice));
+      }
     }
 
     // The counts come from the container rather than from the notices above, which are only the
-    // ones the container retained. The report must show how many notices the feed actually
-    // produced, the same number the JSON report exports as totalNotices.
+    // ones the container retained and this summary materialized. The report must show how many
+    // notices the feed actually produced, the same number the JSON report exports.
     int total = 0;
     for (Map.Entry<SeverityLevel, Map<String, List<NoticeView>>> bySeverity :
         noticesMap.entrySet()) {
@@ -68,9 +83,11 @@ public class ReportSummary {
 
   /**
    * Returns the notices grouped by SeverityLevel and notice code. The notices are returned as a map
-   * of maps. The SeverityLevel map is implemented with a LinkedHashMap to preserve the original
-   * order of severity levels. The notice code map is implemented with a TreeMap to sort the notices
-   * alphabetically.
+   * of maps. The SeverityLevel map is sorted from the most to the least severe level. The notice
+   * code map is implemented with a TreeMap to sort the notices alphabetically.
+   *
+   * <p>Each list holds at most {@link #MAX_NOTICES_PER_CODE} notices, which is what the report
+   * lists. Use {@link #getNoticeCountForCode} for the total number of notices of a code.
    *
    * @return the notices as a map of maps.
    */
@@ -88,6 +105,15 @@ public class ReportSummary {
     return noticeCountPerSeverityAndCode
         .getOrDefault(severityLevel, Map.of())
         .getOrDefault(code, 0);
+  }
+
+  /**
+   * Returns the maximum number of notices per code listed in the report.
+   *
+   * @return the maximum number of notices listed per code.
+   */
+  public int getMaxNoticesPerCode() {
+    return MAX_NOTICES_PER_CODE;
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
@@ -17,34 +17,53 @@
 package org.mobilitydata.gtfsvalidator.reportsummary.model;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 /** ReportSummary is the class containing the summary methods for the HTML report. */
 public class ReportSummary {
-  private final NoticeContainer container;
   private final Map<SeverityLevel, Long> severityCounts;
   private final Map<SeverityLevel, Map<String, List<NoticeView>>> noticesMap;
+  private final Map<SeverityLevel, Map<String, Integer>> noticeCountPerSeverityAndCode;
+  private final int noticeCount;
   private final VersionInfo versionInfo;
 
   public ReportSummary(NoticeContainer container, VersionInfo versionInfo) {
-    this.container = container;
-    this.severityCounts =
-        container.getResolvedValidationNotices().stream()
-            .collect(
-                Collectors.groupingBy(ResolvedNotice::getSeverityLevel, Collectors.counting()));
-    this.noticesMap =
-        container.getResolvedValidationNotices().stream()
-            .map(NoticeView::new)
-            .collect(
-                Collectors.groupingBy(
-                    NoticeView::getSeverityLevel,
-                    () -> new TreeMap<>(Comparator.reverseOrder()),
-                    Collectors.groupingBy(NoticeView::getCode, TreeMap::new, Collectors.toList())));
     this.versionInfo = versionInfo;
+    this.severityCounts = new EnumMap<>(SeverityLevel.class);
+    // Severity levels are listed from the most to the least severe, notice codes alphabetically.
+    this.noticesMap = new TreeMap<>(Comparator.reverseOrder());
+    this.noticeCountPerSeverityAndCode = new EnumMap<>(SeverityLevel.class);
+
+    for (ResolvedNotice<ValidationNotice> notice : container.getResolvedValidationNotices()) {
+      noticesMap
+          .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
+          .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>())
+          .add(new NoticeView(notice));
+    }
+
+    // The counts come from the container rather than from the notices above, which are only the
+    // ones the container retained. The report must show how many notices the feed actually
+    // produced, the same number the JSON report exports as totalNotices.
+    int total = 0;
+    for (Map.Entry<SeverityLevel, Map<String, List<NoticeView>>> bySeverity :
+        noticesMap.entrySet()) {
+      SeverityLevel severityLevel = bySeverity.getKey();
+      Map<String, Integer> countPerCode = new TreeMap<>();
+      long severityCount = 0;
+      for (String code : bySeverity.getValue().keySet()) {
+        int count = container.getNoticeCount(code, severityLevel);
+        countPerCode.put(code, count);
+        severityCount += count;
+      }
+      noticeCountPerSeverityAndCode.put(severityLevel, countPerCode);
+      severityCounts.put(severityLevel, severityCount);
+      total += severityCount;
+    }
+    this.noticeCount = total;
   }
 
   /**
@@ -60,12 +79,24 @@ public class ReportSummary {
   }
 
   /**
+   * Returns the total count of notices of the given severity level and code, including the ones the
+   * container did not retain and which are therefore absent from {@link #getNoticesMap()}.
+   *
+   * @return the total count of notices for that severity level and code.
+   */
+  public int getNoticeCountForCode(SeverityLevel severityLevel, String code) {
+    return noticeCountPerSeverityAndCode
+        .getOrDefault(severityLevel, Map.of())
+        .getOrDefault(code, 0);
+  }
+
+  /**
    * Returns the total count of notices in the validation report.
    *
    * @return the total count of notices.
    */
   public int getNoticeCount() {
-    return container.getValidationNotices().size();
+    return noticeCount;
   }
 
   /**

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -351,7 +351,7 @@
                             <p> You can see more about this notice <a
                                     th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key} + '-rule'}">here</a>.
                             </p>
-                             <p th:if="${totalForCode > 50}">Only the first 50 of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
+                             <p th:if="${totalForCode > summary.maxNoticesPerCode}">Only the first <span th:text="${summary.maxNoticesPerCode}"></span> of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
                             <table>
                                 <thead>
                                     <tr>
@@ -366,7 +366,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr th:each="notice, iterStat : ${noticesByCode.value}" th:if="${iterStat.index < 50}">
+                                    <tr th:each="notice : ${noticesByCode.value}">
                                         <th:block th:each="field: ${uniqueFieldsByCode[noticesByCode.key]}">
                                             <td th:text="${notice.getFields().contains(field) ? notice.getValueForField(field) : 'N/A'}" />
                                         </th:block>

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -335,12 +335,13 @@
         </thead>
         <tbody>
         <span th:each="noticesBySeverityLevel: ${summary.noticesMap}">
-            <span th:each="noticesByCode: ${noticesBySeverityLevel.value}">
+            <span th:each="noticesByCode: ${noticesBySeverityLevel.value}"
+                  th:with="totalForCode=${summary.getNoticeCountForCode(noticesBySeverityLevel.key, noticesByCode.key)}">
                 <tr class="notice">
                     <td th:text="${noticesByCode.key}" />
                     <td th:class="${noticesBySeverityLevel.key.toString().toLowerCase()}"
                         th:text="${noticesBySeverityLevel.key}" />
-                    <td th:text="${noticesByCode.value.size}" />
+                    <td th:text="${totalForCode}" />
                 </tr>
                 <tr class="description">
                     <td colspan="4">
@@ -350,7 +351,7 @@
                             <p> You can see more about this notice <a
                                     th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key} + '-rule'}">here</a>.
                             </p>
-                             <p th:if="${noticesByCode.value.size > 50}">Only the first 50 of <span th:text="${noticesByCode.value.size}"></span> affected records are displayed below.</p>
+                             <p th:if="${totalForCode > 50}">Only the first 50 of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
                             <table>
                                 <thead>
                                     <tr>

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.reportsummary;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntityContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.util.VersionInfo;
+
+@RunWith(JUnit4.class)
+public class HtmlReportGeneratorTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * The page must report how many notices the feed produced, not how many the container kept: the
+   * container drops notices of a type past its retention limit, and the JSON report generated from
+   * the same run reports the exact number.
+   */
+  @Test
+  public void generateReport_countsAreExactWhenTheContainerDroppedNotices() throws IOException {
+    NoticeContainer noticeContainer = new NoticeContainer(1_000, 100, 100);
+    for (int i = 1; i <= 300; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(noticeContainer.getValidationNotices()).hasSize(100);
+    assertThat(report).contains("300 notices reported ( 300 errors, 0 warnings, 0 infos)");
+    assertThat(report).contains("missing_required_field ERROR 300");
+    assertThat(report).contains("Only the first 50 of 300 affected records are displayed below.");
+  }
+
+  /** Strips the markup so that assertions read like the rendered page. */
+  private static String visibleText(String html) {
+    return html.replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ");
+  }
+
+  private String generateReport(NoticeContainer noticeContainer) throws IOException {
+    GtfsFeedContainer feedContainer =
+        new GtfsFeedContainer(
+            ImmutableList.<GtfsEntityContainer<?, ?>>of(
+                GtfsStopTimeTableContainer.forEntities(ImmutableList.of(), new NoticeContainer())));
+    Path reportPath = temporaryFolder.newFile("report.html").toPath();
+    ValidationRunnerConfig config =
+        ValidationRunnerConfig.builder()
+            .setGtfsSource(Path.of("feed.zip").toUri())
+            .setOutputDirectory(reportPath.getParent())
+            .setCountryCode(CountryCode.forStringOrUnknown(""))
+            .build();
+
+    new HtmlReportGenerator()
+        .generateReport(
+            FeedMetadata.from(feedContainer, ImmutableSet.of("stop_times.txt")),
+            noticeContainer,
+            config,
+            VersionInfo.empty(),
+            reportPath,
+            "2026-01-01T00:00:00+00:00",
+            false);
+
+    return Files.readString(reportPath);
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
@@ -32,6 +32,7 @@ import org.mobilitydata.gtfsvalidator.input.CountryCode;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.ReportSummary;
 import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
 import org.mobilitydata.gtfsvalidator.table.GtfsEntityContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
@@ -40,6 +41,10 @@ import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 @RunWith(JUnit4.class)
 public class HtmlReportGeneratorTest {
+
+  /** Number of notices per code the report lists, mirrors {@code ReportSummary}. */
+  private static final int MAX_NOTICES_PER_CODE =
+      new ReportSummary(new NoticeContainer(), VersionInfo.empty()).getMaxNoticesPerCode();
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -62,6 +67,50 @@ public class HtmlReportGeneratorTest {
     assertThat(report).contains("300 notices reported ( 300 errors, 0 warnings, 0 infos)");
     assertThat(report).contains("missing_required_field ERROR 300");
     assertThat(report).contains("Only the first 50 of 300 affected records are displayed below.");
+  }
+
+  /**
+   * A notice code with more occurrences than the report lists must still report its exact total,
+   * while only the listed occurrences appear in the table.
+   */
+  @Test
+  public void generateReport_listsAtMostMaxNoticesPerCodeButReportsExactTotal() throws IOException {
+    int noticeCount = 120;
+    NoticeContainer noticeContainer = new NoticeContainer();
+    for (int i = 1; i <= noticeCount; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(report).contains("missing_required_field ERROR 120");
+    assertThat(report)
+        .contains(
+            "Only the first "
+                + MAX_NOTICES_PER_CODE
+                + " of 120 affected records are displayed below.");
+    assertThat(report).contains("field_001");
+    assertThat(report).contains(String.format("field_%03d", MAX_NOTICES_PER_CODE));
+    assertThat(report).doesNotContain(String.format("field_%03d", MAX_NOTICES_PER_CODE + 1));
+    assertThat(report).doesNotContain("field_120");
+  }
+
+  @Test
+  public void generateReport_fewerNoticesThanTheLimit_listsThemAll() throws IOException {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    for (int i = 1; i <= 3; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(report).doesNotContain("affected records are displayed below");
+    assertThat(report).contains("missing_required_field ERROR 3");
+    assertThat(report).contains("field_001");
+    assertThat(report).contains("field_002");
+    assertThat(report).contains("field_003");
   }
 
   /** Strips the markup so that assertions read like the rendered page. */

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
@@ -139,6 +139,30 @@ public class ReportSummaryTest {
   }
 
   @Test
+  public void noticesMapTest_isTruncatedButCountsAreNot() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    int noticeCount = 3 * ReportSummary.MAX_NOTICES_PER_CODE;
+    for (int i = 1; i <= noticeCount; i++) {
+      noticeContainer.addValidationNotice(new MissingRequiredFieldNotice("test.txt", i, "field"));
+    }
+    ReportSummary reportSummary = new ReportSummary(noticeContainer, VersionInfo.empty());
+
+    assertEquals(
+        ReportSummary.MAX_NOTICES_PER_CODE,
+        reportSummary
+            .getNoticesMap()
+            .get(SeverityLevel.ERROR)
+            .get(MISSING_REQUIRED_FIELD_NOTICE_CODE)
+            .size());
+    assertEquals(
+        noticeCount,
+        reportSummary.getNoticeCountForCode(
+            SeverityLevel.ERROR, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+    assertEquals(noticeCount, reportSummary.getNoticeCount());
+    assertEquals(noticeCount, reportSummary.getErrorCount());
+  }
+
+  @Test
   public void testVersionPresent() {
     VersionInfo versionInfo = VersionInfo.create(Optional.of("1.2.3"), Optional.of("1.2.4"));
     ReportSummary reportSummary = new ReportSummary(new NoticeContainer(), versionInfo);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
@@ -100,6 +100,44 @@ public class ReportSummaryTest {
         1);
   }
 
+  /**
+   * The counts must describe the feed, not what the container kept: a container that dropped
+   * notices past its retention limit still knows how many it was given, and the JSON report exports
+   * that number.
+   */
+  @Test
+  public void countsTest_areExactWhenTheContainerDroppedNotices() {
+    NoticeContainer noticeContainer = new NoticeContainer(1_000, 10, 10);
+    for (int i = 1; i <= 300; i++) {
+      noticeContainer.addValidationNotice(new MissingRequiredFieldNotice("test.txt", i, "field"));
+    }
+    for (int i = 1; i <= 40; i++) {
+      noticeContainer.addValidationNotice(new UnknownColumnNotice("test.txt", "unknown", i));
+    }
+    ReportSummary reportSummary = new ReportSummary(noticeContainer, VersionInfo.empty());
+
+    assertEquals(20, noticeContainer.getValidationNotices().size());
+    assertEquals(340, reportSummary.getNoticeCount());
+    assertEquals(300, reportSummary.getErrorCount());
+    assertEquals(40, reportSummary.getInfoCount());
+    assertEquals(0, reportSummary.getWarningCount());
+    assertEquals(
+        300,
+        reportSummary.getNoticeCountForCode(
+            SeverityLevel.ERROR, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+    assertEquals(
+        40, reportSummary.getNoticeCountForCode(SeverityLevel.INFO, UNKNOWN_COLUMN_NOTICE_CODE));
+  }
+
+  @Test
+  public void noticeCountForCodeTest_unknownCode() {
+    assertEquals(0, generateReportSummary().getNoticeCountForCode(SeverityLevel.ERROR, "unknown"));
+    assertEquals(
+        0,
+        generateReportSummary()
+            .getNoticeCountForCode(SeverityLevel.INFO, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+  }
+
   @Test
   public void testVersionPresent() {
     VersionInfo versionInfo = VersionInfo.create(Optional.of("1.2.3"), Optional.of("1.2.4"));


### PR DESCRIPTION
**Summary:**

Fourth of the six PRs #2183 is split into, in [the grouping requested here](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383). This is the group with the deliberate behaviour change, and the one you said you would want to discuss most.

**Stacked on PR 1**, which it needs to compile: the first commit of this diff is PR 1's and disappears from it once PR 1 merges. **The two commits to review here are the last two.**

**1. `NoticeContainer.addAll` bypassed the retention limits.** `addAll` copied every notice of the source container into the destination with `validationNotices.addAll(...)`, applying no limits. That is not an edge case: `CsvFileLoader` creates one `NoticeContainer` **per parsed row** and merges it, so each source container holds a handful of notices and the per-container limits never trigger. A feed where every row of stop_times.txt produces a warning — trailing whitespace or a non-ASCII character in an id, both common — retains one notice per row and grows the heap without bound. The `addAll` javadoc documented this explicitly ("the final `NoticeContainer` may contain more than the maximum amount…"), so the behaviour was known; this PR makes the limits actually hold, and updates that javadoc.

The limits now live in one place, `canRetain`, used by both `addValidationNoticeWithSeverity` and `addAll`. Two properties are preserved on purpose:

- **Counts are merged in full**, regardless of retention, so `totalNotices` in `report.json` — and the counts the HTML report shows after PR 1 — stay exact. A second map tracks how many notices of each type and severity were actually retained.
- **The first notice of a type and severity is retained even once the total limit is reached.** A notice type is described in the exported report only if one of its notices was retained, so dropping them all would hide the type, and its exact count, from the report entirely — and since the total limit is reached in merge order, which types disappeared would depend on file order.

The defaults are lowered accordingly:

| | before | after |
|---|---:|---:|
| `MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY` | 100 000 | 2 000 |
| `MAX_TOTAL_VALIDATION_NOTICES` | 10 000 000 | 200 000 |
| `MAX_EXPORTS_PER_NOTICE_TYPE_AND_SEVERITY` | 1 000 | 1 000 (unchanged) |

At most 1 000 notices per type and severity are ever exported and the HTML report lists 50, so retaining 100 000 of them was pure overhead. 2 000 keeps a margin over both.

**2. Build only the notice views the report lists.** `ReportSummary` created a `NoticeView` for every retained notice, each holding the complete JSON tree of its notice, while the report lists at most 50 records per code. On a feed with many notices that is hundreds of megabytes built and thrown away, allocated at the very end of validation when the heap is already at its peak. Views are now built only up to the limit, defined once as `ReportSummary.MAX_NOTICES_PER_CODE` and read by the template through `summary.maxNoticesPerCode` instead of being duplicated as the literal `50` in two places in `report.html`.

**The consequence for `HtmlReportGenerator.getUniqueFieldsForCodes`, as you asked.** That method derives the column set of a notice table from the views of the code. With the views capped, the columns come from exactly the rows that get rendered: a field only ever set on a record past the 50th no longer gets a column — a column that, before this change, existed and was `N/A` on every rendered row. I think that is the better behaviour and the javadoc now states it, but it is a rendering difference on feeds with heterogeneous notices of one code, so it should be a conscious decision rather than a side effect. If you would rather keep the column set derived from all retained notices, that is a small change to that method and it does not affect the memory win — say the word.

Implementation report for the whole series: https://github.com/CarloMendola/gtfs-validator/blob/9f409204bcefff7387f05a3f70118fb03134443b/prompts/memory-optimization/MEMORY_OPTIMIZATION_REPORT.md

**Expected behavior:**

**The observable change:** on a pathological feed, a caller that iterates `getValidationNotices()` gets a smaller sample than before. `totalNotices` is unaffected, the exported `sampleNotices` are unaffected (1 000 ≤ 2 000), and the HTML report is unaffected (50 listed). Callers needing different bounds can use the three-argument constructor, which is unchanged.

On a normal feed nothing changes. Verified on the CTA Chicago feed (95 MB zip, 413 MB of CSV, 168 443 notices): the `notices` object of `report.json` is identical to master's, because every notice type there is well below the new limits — the truncation only appears on feeds producing hundreds of thousands of notices of a single type.

The rendered page is unchanged: same rows, same cells, same text (344 `<tr>`, 1 689 `<td>` on both). The file does get much smaller — 6 587 188 B on master against 272 071 B on that feed — but that is whitespace, not content: for every notice skipped by the old `th:if="${iterStat.index < 50}"`, Thymeleaf still emitted the indentation of the iteration, 168 255 blank lines of it. Capping the list means there are no skipped iterations left.

Tests:

- `addAll_shouldRespectMaxPerNoticeTypeAndSeverity`, `addAll_shouldRespectMaxTotalValidationNotices` — the row-by-row merge pattern of `CsvFileLoader`, reproduced.
- `exportNoticesAfterAddAll_shouldReportExactTotalCountBeyondRetentionLimit` — `totalNotices` is still exact when notices were dropped, asserted on the exported JSON.
- `addAll_shouldKeepValidationErrorAndWarningFlagsWhenNoticesAreDropped` — the error/warning flags are not lost with the notices.
- `addAll_totalLimitReached_stillRetainsTheFirstNoticeOfEachType` — every type still appears in the exported report, with its exact count.
- `ReportSummaryTest.noticesMapTest_isTruncatedButCountsAreNot` — the map is capped, the counts are not.
- `HtmlReportGeneratorTest.generateReport_listsAtMostMaxNoticesPerCodeButReportsExactTotal` and `generateReport_fewerNoticesThanTheLimit_listsThemAll` — what the page shows, on both sides of the limit.

Nothing under `docs/` describes the retention limits, so no documentation change is needed; the `addAll` javadoc that did describe them is updated.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) — the rendered page is unchanged on any feed below the limits; the two tests above assert what the page shows above them
