### PR TITLE
Issue/2183/5 perf: detect duplicate keys of stop_times and shapes without a per-row map

### DIFF
--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsShapeDuplicateKeyTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsShapeDuplicateKeyTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.table;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateKeyNotice;
+import org.mobilitydata.gtfsvalidator.testing.LoadingHelper;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
+
+/**
+ * Duplicate primary keys in shapes.txt, which is one of the two tables where they are detected by
+ * scanning the sorted groups of the shape_id index instead of a map keyed on the composite key.
+ */
+@RunWith(JUnit4.class)
+public class GtfsShapeDuplicateKeyTest {
+
+  private static final String FILENAME = "shapes.txt";
+  private static final String HEADER = "shape_id,shape_pt_lat,shape_pt_lon,shape_pt_sequence";
+
+  private LoadingHelper helper;
+  private GtfsShapeTableDescriptor tableDescriptor;
+
+  @Before
+  public void setup() {
+    tableDescriptor = new GtfsShapeTableDescriptor();
+    helper = new LoadingHelper();
+  }
+
+  @Test
+  public void distinctKeys_noNotice() throws ValidatorLoaderException {
+    helper.load(
+        tableDescriptor, HEADER, "shape1,45.0,9.0,1", "shape1,45.1,9.1,2", "shape2,45.0,9.0,1");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void duplicateKeys_reportedInFileOrderAgainstTheFirstRow()
+      throws ValidatorLoaderException {
+    helper.load(
+        tableDescriptor,
+        HEADER,
+        "shape1,45.0,9.0,1", // row 2
+        "shape2,45.0,9.0,1", // row 3
+        "shape2,45.1,9.1,1", // row 4, duplicate of row 3
+        "shape1,45.1,9.1,1", // row 5, duplicate of row 2
+        "shape1,45.2,9.2,1"); // row 6, duplicate of row 2 as well
+
+    assertThat(helper.getValidationNotices())
+        .containsExactly(
+            new DuplicateKeyNotice(FILENAME, 3, 4, "shape_id,shape_pt_sequence", "shape2,1"),
+            new DuplicateKeyNotice(FILENAME, 2, 5, "shape_id,shape_pt_sequence", "shape1,1"),
+            new DuplicateKeyNotice(FILENAME, 2, 6, "shape_id,shape_pt_sequence", "shape1,1"))
+        .inOrder();
+  }
+
+  /** The index the duplicate detection relies on is still filled and sorted. */
+  @Test
+  public void byShapeId_isSortedByShapePtSequence() throws ValidatorLoaderException {
+    GtfsShapeTableContainer container =
+        helper.load(
+            tableDescriptor, HEADER, "shape1,45.2,9.2,3", "shape1,45.0,9.0,1", "shape1,45.1,9.1,2");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+    assertThat(
+            container.byShapeId("shape1").stream()
+                .map(GtfsShape::shapePtSequence)
+                .collect(Collectors.toList()))
+        .containsExactly(1, 2, 3)
+        .inOrder();
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeDuplicateKeyTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/table/GtfsStopTimeDuplicateKeyTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.mobilitydata.gtfsvalidator.table;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.stream.Collectors;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateKeyNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.testing.LoadingHelper;
+import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
+
+/**
+ * Duplicate primary keys in stop_times.txt, which is one of the two tables where they are detected
+ * by scanning the sorted groups of the trip_id index instead of a map keyed on the composite key.
+ */
+@RunWith(JUnit4.class)
+public class GtfsStopTimeDuplicateKeyTest {
+
+  private static final String FILENAME = "stop_times.txt";
+  private static final String HEADER = "trip_id,stop_id,stop_sequence,arrival_time,departure_time";
+
+  private LoadingHelper helper;
+  private GtfsStopTimeTableDescriptor tableDescriptor;
+
+  @Before
+  public void setup() {
+    tableDescriptor = new GtfsStopTimeTableDescriptor();
+    helper = new LoadingHelper();
+  }
+
+  @Test
+  public void distinctKeys_noNotice() throws ValidatorLoaderException {
+    helper.load(
+        tableDescriptor,
+        HEADER,
+        "t1,s1,1,08:00:00,08:00:00",
+        "t1,s2,2,08:10:00,08:10:00",
+        "t2,s1,1,09:00:00,09:00:00");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+  }
+
+  @Test
+  public void duplicateKeys_reportedInFileOrderAgainstTheFirstRow()
+      throws ValidatorLoaderException {
+    helper.load(
+        tableDescriptor,
+        HEADER,
+        "t1,s1,1,08:00:00,08:00:00", // row 2
+        "t2,s1,1,09:00:00,09:00:00", // row 3
+        "t2,s2,1,09:10:00,09:10:00", // row 4, duplicate of row 3
+        "t1,s2,1,08:10:00,08:10:00", // row 5, duplicate of row 2
+        "t1,s3,1,08:20:00,08:20:00"); // row 6, duplicate of row 2 as well
+
+    assertThat(helper.getValidationNotices())
+        .containsExactly(
+            new DuplicateKeyNotice(FILENAME, 3, 4, "trip_id,stop_sequence", "t2,1"),
+            new DuplicateKeyNotice(FILENAME, 2, 5, "trip_id,stop_sequence", "t1,1"),
+            new DuplicateKeyNotice(FILENAME, 2, 6, "trip_id,stop_sequence", "t1,1"))
+        .inOrder();
+  }
+
+  /**
+   * Entities given to {@code forEntities} keep whatever order the caller used, and their row
+   * numbers may repeat, so duplicates are reported against the first entity of the list and none of
+   * them is dropped.
+   */
+  @Test
+  public void forEntities_duplicateKeys_reportedAgainstTheFirstEntityOfTheList() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    GtfsStopTimeTableContainer.forEntities(
+        ImmutableList.of(
+            new GtfsStopTime.Builder().setTripId("t1").setStopSequence(1).setStopId("s1").build(),
+            new GtfsStopTime.Builder().setTripId("t1").setStopSequence(1).setStopId("s2").build(),
+            new GtfsStopTime.Builder().setTripId("t1").setStopSequence(1).setStopId("s3").build()),
+        noticeContainer);
+
+    assertThat(noticeContainer.getValidationNotices())
+        .containsExactly(
+            new DuplicateKeyNotice(FILENAME, 0, 0, "trip_id,stop_sequence", "t1,1"),
+            new DuplicateKeyNotice(FILENAME, 0, 0, "trip_id,stop_sequence", "t1,1"));
+  }
+
+  /** The lookup used for translations keeps working, and returns the first row of a duplicate. */
+  @Test
+  public void byTranslationKey() throws ValidatorLoaderException {
+    GtfsStopTimeTableContainer container =
+        helper.load(
+            tableDescriptor,
+            HEADER,
+            "t1,s1,1,08:00:00,08:00:00",
+            "t1,s2,1,08:10:00,08:10:00",
+            "t1,s3,2,08:20:00,08:20:00");
+
+    assertThat(container.byTranslationKey("t1", "1").get().stopId()).isEqualTo("s1");
+    assertThat(container.byTranslationKey("t1", "2").get().stopId()).isEqualTo("s3");
+    assertThat(container.byTranslationKey("t1", "3").isPresent()).isFalse();
+    assertThat(container.byTranslationKey("t2", "1").isPresent()).isFalse();
+    assertThat(container.byTranslationKey("t1", "not a number").isPresent()).isFalse();
+  }
+
+  /** The index the duplicate detection relies on is still filled and sorted. */
+  @Test
+  public void byTripId_isSortedByStopSequence() throws ValidatorLoaderException {
+    GtfsStopTimeTableContainer container =
+        helper.load(
+            tableDescriptor,
+            HEADER,
+            "t1,s3,3,08:20:00,08:20:00",
+            "t1,s1,1,08:00:00,08:00:00",
+            "t1,s2,2,08:10:00,08:10:00");
+
+    assertThat(helper.getValidationNotices()).isEmpty();
+    assertThat(
+            container.byTripId("t1").stream()
+                .map(GtfsStopTime::stopId)
+                .collect(Collectors.toList()))
+        .containsExactly("s1", "s2", "s3")
+        .inOrder();
+  }
+}

--- a/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
+++ b/processor/src/main/java/org/mobilitydata/gtfsvalidator/processor/TableContainerIndexGenerator.java
@@ -83,6 +83,34 @@ class TableContainerIndexGenerator {
     }
   }
 
+  /**
+   * Returns the primary key field on whose sorted index duplicate keys can be detected, if any.
+   *
+   * <p>A table qualifies when its primary key is made of exactly two fields, one of them annotated
+   * with {@code @Index} and the other one being the sequence the index is sorted by. In that case
+   * two entities share a primary key only if they sit next to each other in a sorted group of that
+   * index, so scanning the groups detects duplicates without the map keyed on the composite key,
+   * which costs about 60 bytes per row. Those are exactly the tables where that matters:
+   * stop_times.txt and shapes.txt, which hold millions of rows on a large feed.
+   *
+   * <p>Every other table with a composite primary key keeps the map: they are small, and the
+   * map-based detection is simpler.
+   */
+  private Optional<GtfsFieldDescriptor> resolveSortedGroupIndexField() {
+    if (fileDescriptor.singleRow() || fileDescriptor.primaryKeys().size() != 2) {
+      return Optional.empty();
+    }
+    for (GtfsFieldDescriptor primaryKey : fileDescriptor.primaryKeys()) {
+      Optional<GtfsFieldDescriptor> sequenceField = resolveSequenceField(primaryKey);
+      if (fileDescriptor.indices().contains(primaryKey)
+          && sequenceField.isPresent()
+          && sequenceField.get().javaType().getKind().isPrimitive()) {
+        return Optional.of(primaryKey);
+      }
+    }
+    return Optional.empty();
+  }
+
   private Optional<GtfsFieldDescriptor> resolveSequenceField(GtfsFieldDescriptor indexField) {
     if (indexField.primaryKey().isPresent()) {
       for (GtfsFieldDescriptor field : fileDescriptor.primaryKeys()) {
@@ -156,15 +184,76 @@ class TableContainerIndexGenerator {
             .build());
   }
 
-  private static void addMapByCompositeKey(TypeSpec.Builder typeSpec, TypeName entityTypeName) {
+  private void addMapByCompositeKey(TypeSpec.Builder typeSpec, TypeName entityTypeName) {
     // Field: Map<CompositeKey, EntityType?> byCompositeKeyMap;
     TypeName keyMapType =
         ParameterizedTypeName.get(
             ClassName.get(Map.class), ClassName.get("", "CompositeKey"), entityTypeName);
+    if (resolveSortedGroupIndexField().isEmpty()) {
+      typeSpec.addField(
+          FieldSpec.builder(keyMapType, BY_COMPOSITE_KEY_MAP_FIELD_NAME, Modifier.PRIVATE)
+              .initializer("new $T<>()", ParameterizedTypeName.get(HashMap.class))
+              .build());
+      return;
+    }
+    if (!hasTranslationRecordId()) {
+      // Nothing reads the map: duplicate keys are detected on the sorted index groups and this
+      // table does not support translation lookups.
+      return;
+    }
     typeSpec.addField(
         FieldSpec.builder(keyMapType, BY_COMPOSITE_KEY_MAP_FIELD_NAME, Modifier.PRIVATE)
-            .initializer("new $T<>()", ParameterizedTypeName.get(HashMap.class))
+            .addAnnotation(Nullable.class)
+            .addJavadoc("Built on first use, see {@link #$L()}.\n", BY_COMPOSITE_KEY_MAP_FIELD_NAME)
             .build());
+    typeSpec.addMethod(generateByCompositeKeyMapMethod(keyMapType, entityTypeName));
+  }
+
+  /**
+   * Generates the accessor that builds {@code byCompositeKeyMap} on first use.
+   *
+   * <p>This is only generated for the tables where duplicate keys are detected without the map (see
+   * {@link #resolveSortedGroupIndexField()}), so that the map is paid for only by the feeds that
+   * actually translate the file.
+   */
+  private MethodSpec generateByCompositeKeyMapMethod(TypeName keyMapType, TypeName entityTypeName) {
+    return MethodSpec.methodBuilder(BY_COMPOSITE_KEY_MAP_FIELD_NAME)
+        .addModifiers(Modifier.PRIVATE, Modifier.SYNCHRONIZED)
+        .returns(keyMapType)
+        .addJavadoc(
+            "Returns the entities keyed on their composite primary key, building the map on first"
+                + " use.\n"
+                + "\n"
+                + "<p>One entry per row costs about 60 bytes, which is too much for a table with"
+                + " millions of rows, and only translation lookups need it. It is therefore built"
+                + " lazily, and synchronized because multi-file validators may run on several"
+                + " threads.\n")
+        .beginControlFlow("if ($L == null)", BY_COMPOSITE_KEY_MAP_FIELD_NAME)
+        .addStatement("$T map = new $T<>()", keyMapType, ParameterizedTypeName.get(HashMap.class))
+        .beginControlFlow("for ($T entity : entities)", entityTypeName)
+        // putIfAbsent: as when the map was filled while detecting duplicates, the first entity
+        // with a given key wins.
+        .addStatement(
+            "map.putIfAbsent(CompositeKey.builder()\n$L\n.build(), entity)",
+            compositeKeyBuilderSetters("entity"))
+        .endControlFlow()
+        .addStatement("$L = map", BY_COMPOSITE_KEY_MAP_FIELD_NAME)
+        .endControlFlow()
+        .addStatement("return $L", BY_COMPOSITE_KEY_MAP_FIELD_NAME)
+        .build();
+  }
+
+  /** Returns the {@code CompositeKey.Builder} setters filled from the given entity variable. */
+  private CodeBlock compositeKeyBuilderSetters(String entityVariable) {
+    return fileDescriptor.primaryKeys().stream()
+        .map(
+            (field) ->
+                CodeBlock.of(
+                    ".$L($L.$L())",
+                    FieldNameConverter.setterMethodName(field.name()),
+                    entityVariable,
+                    field.name()))
+        .collect(CodeBlock.joining("\n"));
   }
 
   private FieldSpec generateKeyColumnNames() {
@@ -196,6 +285,13 @@ class TableContainerIndexGenerator {
         .returns(ParameterizedTypeName.get(ImmutableList.class, String.class))
         .addStatement("return $L", KEY_COLUMN_NAMES_FIELD_NAME)
         .build();
+  }
+
+  /** Returns how to read the composite key map: the field itself, or the lazy accessor. */
+  private String byCompositeKeyMapAccessor() {
+    return resolveSortedGroupIndexField().isEmpty()
+        ? BY_COMPOSITE_KEY_MAP_FIELD_NAME
+        : BY_COMPOSITE_KEY_MAP_FIELD_NAME + "()";
   }
 
   private boolean hasTranslationRecordId() {
@@ -249,7 +345,7 @@ class TableContainerIndexGenerator {
           .beginControlFlow("try")
           .addStatement(
               "return Optional.ofNullable($L.getOrDefault(CompositeKey.builder()\n$L.\nbuild(), null))",
-              BY_COMPOSITE_KEY_MAP_FIELD_NAME,
+              byCompositeKeyMapAccessor(),
               CodeBlock.join(keyBuilderSetters, "\n"))
           .nextControlFlow("catch (NumberFormatException ex)")
           .addStatement("return Optional.empty()")
@@ -281,6 +377,7 @@ class TableContainerIndexGenerator {
 
   private MethodSpec generateSetupIndicesMethod() {
     TypeName gtfsEntityType = classNames.entityImplementationTypeName();
+    Optional<GtfsFieldDescriptor> sortedGroupIndexField = resolveSortedGroupIndexField();
     MethodSpec.Builder method =
         MethodSpec.methodBuilder("setupIndices")
             .addModifiers(Modifier.PRIVATE)
@@ -294,19 +391,12 @@ class TableContainerIndexGenerator {
               "noticeContainer.addValidationNotice(new $T(gtfsFilename(), entities.size()))",
               MoreThanOneEntityNotice.class)
           .endControlFlow();
-    } else if (fileDescriptor.hasMultiColumnPrimaryKey()) {
+    } else if (fileDescriptor.hasMultiColumnPrimaryKey() && sortedGroupIndexField.isEmpty()) {
       method
           .beginControlFlow("for ($T newEntity : entities)", gtfsEntityType)
           .addStatement(
               "CompositeKey key = CompositeKey.builder()\n$L\n.build()",
-              fileDescriptor.primaryKeys().stream()
-                  .map(
-                      (field) ->
-                          CodeBlock.of(
-                              ".$L(newEntity.$L())",
-                              FieldNameConverter.setterMethodName(field.name()),
-                              field.name()))
-                  .collect(CodeBlock.joining("\n")))
+              compositeKeyBuilderSetters("newEntity"))
           .addStatement(
               "$T oldEntity = $L.getOrDefault(key, null)",
               classNames.entityImplementationTypeName(),
@@ -373,7 +463,65 @@ class TableContainerIndexGenerator {
         }
       }
     }
+
+    sortedGroupIndexField.ifPresent(
+        (indexField) -> addSortedGroupDuplicateDetection(method, indexField));
     return method.build();
+  }
+
+  /**
+   * Emits the detection of duplicate primary keys by a scan of the sorted groups of an index.
+   *
+   * <p>Runs after the index has been filled and sorted: entities sharing a primary key are then
+   * adjacent inside a group, since the groups are keyed on one key field and sorted on the other.
+   * See {@link #resolveSortedGroupIndexField()} for why this is worth the extra code.
+   */
+  private void addSortedGroupDuplicateDetection(
+      MethodSpec.Builder method, GtfsFieldDescriptor indexField) {
+    TypeName gtfsEntityType = classNames.entityImplementationTypeName();
+    GtfsFieldDescriptor sequenceField = resolveSequenceField(indexField).get();
+    String sequence = sequenceField.name();
+    TypeName sequenceBoxedType = TypeName.get(sequenceField.javaType()).box();
+    method
+        .addComment("Entities are visited in the order they were loaded, and each one is looked up")
+        .addComment("in its own group of the index sorted above: the leftmost entity of the group")
+        .addComment("with the same sequence is the first one holding that primary key, so any")
+        .addComment("other entity is a duplicate of it. This reports exactly what the map keyed on")
+        .addComment("the composite key reported, without holding one entry per row.")
+        .beginControlFlow("for ($T entity : entities)", gtfsEntityType)
+        .addStatement(
+            "List<$T> sortedGroup = $L.get(entity.$L())",
+            gtfsEntityType,
+            byKeyMapName(indexField.name()),
+            indexField.name())
+        .addComment("Leftmost binary search: the group is sorted by " + sequence + ".")
+        .addStatement("int low = 0")
+        .addStatement("int high = sortedGroup.size()")
+        .beginControlFlow("while (low < high)")
+        .addStatement("int middle = (low + high) >>> 1")
+        .beginControlFlow(
+            "if ($T.compare(sortedGroup.get(middle).$L(), entity.$L()) < 0)",
+            sequenceBoxedType,
+            sequence,
+            sequence)
+        .addStatement("low = middle + 1")
+        .nextControlFlow("else")
+        .addStatement("high = middle")
+        .endControlFlow()
+        .endControlFlow()
+        .addStatement("$T firstEntity = sortedGroup.get(low)", gtfsEntityType)
+        .beginControlFlow("if (firstEntity == entity)")
+        .addStatement("continue")
+        .endControlFlow()
+        .addStatement(
+            "CompositeKey key = CompositeKey.builder()\n$L\n.build()",
+            compositeKeyBuilderSetters("firstEntity"))
+        .addStatement(
+            "noticeContainer.addValidationNotice(new $T(\n"
+                + "gtfsFilename(), firstEntity.csvRowNumber(), entity.csvRowNumber(),\n"
+                + "key.getDefinedKeys(firstEntity), key.getDefinedValues(firstEntity)))",
+            DuplicateKeyNotice.class)
+        .endControlFlow();
   }
 
   private TypeSpec compositeKeyClass() {

--- a/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/IdAndSequencePrimaryKeySchemaTest.java
+++ b/processor/tests/src/test/java/org/mobilitydata/gtfsvalidator/processor/tests/IdAndSequencePrimaryKeySchemaTest.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.DuplicateKeyNotice;
 import org.mobilitydata.gtfsvalidator.table.IdAndSequencePrimaryKey;
 import org.mobilitydata.gtfsvalidator.table.IdAndSequencePrimaryKeyTableContainer;
 import org.mobilitydata.gtfsvalidator.table.IdAndSequencePrimaryKeyTableDescriptor;
@@ -31,6 +32,8 @@ import org.mobilitydata.gtfsvalidator.validator.ValidatorLoaderException;
 
 @RunWith(JUnit4.class)
 public class IdAndSequencePrimaryKeySchemaTest {
+
+  private static final String FILENAME = "id_and_sequence_primary_key.txt";
 
   private IdAndSequencePrimaryKeyTableDescriptor tableDescriptor;
   private LoadingHelper helper;
@@ -70,6 +73,66 @@ public class IdAndSequencePrimaryKeySchemaTest {
 
     assertThat(helper.getValidationNotices()).hasSize(1);
     assertThat(helper.getValidationNotices().get(0).getCode()).isEqualTo("duplicate_key");
+  }
+
+  /** Every duplicate is reported against the first row with that key, not against the previous. */
+  @Test
+  public void testDuplicates_moreThanTwoRowsWithTheSameKey() throws ValidatorLoaderException {
+    helper.load(tableDescriptor, "id,sequence,fruit", "a,1,apples", "a,1,bananas", "a,1,cherries");
+
+    assertThat(helper.getValidationNotices())
+        .containsExactly(
+            new DuplicateKeyNotice(FILENAME, 2, 3, "id,sequence", "a,1"),
+            new DuplicateKeyNotice(FILENAME, 2, 4, "id,sequence", "a,1"))
+        .inOrder();
+  }
+
+  /**
+   * Duplicates are found by scanning the sorted groups of the id index, which are iterated in no
+   * useful order, so the notices have to be sorted back into the order of the rows they report.
+   */
+  @Test
+  public void testDuplicates_areReportedInFileOrder() throws ValidatorLoaderException {
+    helper.load(
+        tableDescriptor,
+        "id,sequence,fruit",
+        "a,1,apples", // row 2
+        "b,1,bananas", // row 3
+        "b,1,cherries", // row 4, duplicate of row 3
+        "a,1,dates", // row 5, duplicate of row 2
+        "b,2,elderberries", // row 6
+        "b,2,figs"); // row 7, duplicate of row 6
+
+    assertThat(helper.getValidationNotices())
+        .containsExactly(
+            new DuplicateKeyNotice(FILENAME, 3, 4, "id,sequence", "b,1"),
+            new DuplicateKeyNotice(FILENAME, 2, 5, "id,sequence", "a,1"),
+            new DuplicateKeyNotice(FILENAME, 6, 7, "id,sequence", "b,2"))
+        .inOrder();
+  }
+
+  /** Rows without an id share the default value, and duplicates among them are still reported. */
+  @Test
+  public void testDuplicates_missingId() throws ValidatorLoaderException {
+    helper.load(tableDescriptor, "id,sequence,fruit", ",1,apples", ",1,bananas");
+
+    assertThat(helper.getValidationNotices())
+        .containsExactly(new DuplicateKeyNotice(FILENAME, 2, 3, "sequence", 1));
+  }
+
+  @Test
+  public void testByTranslationKey() throws ValidatorLoaderException {
+    IdAndSequencePrimaryKeyTableContainer container =
+        helper.load(
+            tableDescriptor, "id,sequence,fruit", "a,1,apples", "a,1,bananas", "a,2,cherries");
+
+    // As when the lookup map was filled while detecting duplicates, the first row with a given
+    // key wins.
+    assertThat(container.byTranslationKey("a", "1").get().fruit()).isEqualTo("apples");
+    assertThat(container.byTranslationKey("a", "2").get().fruit()).isEqualTo("cherries");
+    assertThat(container.byTranslationKey("a", "3").isPresent()).isFalse();
+    assertThat(container.byTranslationKey("z", "1").isPresent()).isFalse();
+    assertThat(container.byTranslationKey("a", "not a number").isPresent()).isFalse();
   }
 
   private List<String> fruits(List<IdAndSequencePrimaryKey> objects) {


### PR DESCRIPTION
**Summary:**

Fifth of the six PRs #2183 is split into, in [the grouping requested here](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383). On its own, as you asked, because it changes generated code for every table container and turns `byTranslationKey` into a lazily built, synchronized fallback used from a multi-threaded loader. Based directly on `master` and independent of the other PRs in the series.

For every table with a composite primary key, the generated `setupIndices` builds a `HashMap<CompositeKey, Entity>` with one entry per row — used only to detect duplicate keys, and to serve `byTranslationKey` lookups when translations.txt refers to the table by its primary key. One entry costs about 60 bytes, so on a large feed that map alone holds hundreds of megabytes for stop_times.txt and shapes.txt, whether or not any translation ever needs it.

Both of those tables have a two-column primary key whose first column is indexed and whose second column is the sequence that index is sorted by (`trip_id` + `stop_sequence`, `shape_id` + `shape_pt_sequence`). For each entity, the generated code now binary-searches its own group of that sorted index for the leftmost entity with the same sequence: that entity is the first one holding the primary key, so any other entity with the same key is a duplicate of it. No map, no allocation. Entities are visited in load order, so `DuplicateKeyNotice`s are produced exactly as the map produced them — same pairs, same order.

The map is kept only for the translation lookups that need it, built on first use behind a synchronized accessor, so a feed that does not translate stop_times.txt or shapes.txt never pays for it. Every other table with a composite primary key keeps the map-based detection unchanged: those tables are small, and the map-based code is simpler to read.

Implementation report for the whole series: https://github.com/CarloMendola/gtfs-validator/blob/9f409204bcefff7387f05a3f70118fb03134443b/prompts/memory-optimization/MEMORY_OPTIMIZATION_REPORT.md

**Expected behavior:**

Same notices, same order, lower memory. Verified on the CTA Chicago feed (95 MB zip, 413 MB of CSV, 1439 shapes, 100 287 trips): the `notices` object of `report.json` is identical to master's and `report.html` differs only in the generation timestamp. Nothing to screenshot for that reason.

The generated code is the interesting part of this diff. `IdAndSequencePrimaryKeySchemaTest` in `processor/tests` covers the generator, and I read the generated `setupIndices` of the two optimized containers and of two control containers that must keep the previous behaviour. `GtfsStopTimeDuplicateKeyTest` and `GtfsShapeDuplicateKeyTest` are new end-to-end tests over the real containers: duplicates at the start, in the middle, at the end, several duplicates of one key, and the no-duplicate case, asserted against the notices the previous implementation emitted.

Nothing under `docs/` describes the generated indices, so no documentation change is needed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) — no visible change: the notices are identical to master's
