### PR TITLE
Issue/2183/6 allocations

### DIFF
--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/Notice.java
@@ -29,6 +29,8 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.mobilitydata.gtfsvalidator.type.GtfsColor;
@@ -73,10 +75,28 @@ public abstract class Notice {
    * @return notice code, e.g., "foreign_key_violation".
    */
   public static String getCode(Class<?> noticeClass) {
+    // Read with get before computeIfAbsent: the latter locks the bin of an already cached
+    // class unless it happens to be the first entry of that bin, and this runs once per
+    // notice.
+    String cached = CODE_CACHE.get(noticeClass);
+    return cached != null ? cached : CODE_CACHE.computeIfAbsent(noticeClass, Notice::deriveCode);
+  }
+
+  private static String deriveCode(Class<?> noticeClass) {
     return CaseFormat.UPPER_CAMEL.to(
         CaseFormat.LOWER_UNDERSCORE,
         StringUtils.removeEnd(noticeClass.getSimpleName(), NOTICE_SUFFIX));
   }
+
+  /**
+   * Notice code per notice class.
+   *
+   * <p>The code only depends on the class, and deriving it builds several intermediate strings. It
+   * is looked up on every notice added to a container and again when notices are grouped, so it is
+   * cached. A plain {@code ConcurrentHashMap} is enough: notice classes are loaded once and live
+   * for the lifetime of the process, and it behaves the same on any runtime.
+   */
+  private static final Map<Class<?>, String> CODE_CACHE = new ConcurrentHashMap<>();
 
   @Override
   public boolean equals(Object o) {

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -174,6 +174,18 @@ public class NoticeContainer {
     return validationNotices;
   }
 
+  /**
+   * Returns how many notices of the given code and severity were added to this container.
+   *
+   * <p>This counts every notice the container was given, including the ones it did not retain, and
+   * is the number the validation report exports as {@code totalNotices}. It is therefore what a
+   * report should show, rather than the size of {@link #getResolvedValidationNotices()}.
+   */
+  public int getNoticeCount(String code, SeverityLevel severityLevel) {
+    return noticesCountPerTypeAndSeverity.getOrDefault(
+        ResolvedNotice.mappingKey(code, severityLevel), 0);
+  }
+
   /** Returns a list of all validation notices in the container. */
   public List<ValidationNotice> getValidationNotices() {
     return Lists.transform(validationNotices, ResolvedNotice::getContext);

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -202,6 +202,23 @@ public class NoticeContainer {
     hasValidationWarnings |= otherContainer.hasValidationWarnings;
   }
 
+  /**
+   * Empties this container so that it can be used again.
+   *
+   * <p>This is meant for the row-by-row parsing loop, which merges one container per row into the
+   * container of the table: allocating a container per row of a file with millions of rows is a
+   * significant share of the garbage produced while loading a feed. {@link #addAll} copies the
+   * notices into the destination container, so resetting the source afterwards is safe.
+   */
+  public void reset() {
+    validationNotices.clear();
+    systemErrors.clear();
+    noticesCountPerTypeAndSeverity.clear();
+    retainedNoticesCountPerTypeAndSeverity.clear();
+    hasValidationErrors = false;
+    hasValidationWarnings = false;
+  }
+
   /** Tells if this container has any {@code ValidationNotice} that is an error. */
   public boolean hasValidationErrors() {
     return hasValidationErrors;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainer.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.notice;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MultimapBuilder;
@@ -35,8 +36,13 @@ import org.mobilitydata.gtfsvalidator.model.ValidationReport;
  * own NoticeContainer, and after execution is complete the results are merged.
  */
 public class NoticeContainer {
-  /** Limit on the amount notices of the same type and severity. */
-  private static final int MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY = 100_000;
+  /**
+   * Limit on the amount notices of the same type and severity.
+   *
+   * <p>Only {@code MAX_EXPORTS_PER_NOTICE_TYPE_AND_SEVERITY} notices per type and severity end up
+   * in a validation report, so retaining orders of magnitude more of them only costs memory.
+   */
+  @VisibleForTesting static final int MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY = 2_000;
 
   /**
    * Limit on the total amount of stored validation notices.
@@ -47,7 +53,7 @@ public class NoticeContainer {
    *
    * <p>Note that system errors are not limited since we don't expect to have a lot of them.
    */
-  private static final int MAX_TOTAL_VALIDATION_NOTICES = 10_000_000;
+  @VisibleForTesting static final int MAX_TOTAL_VALIDATION_NOTICES = 200_000;
 
   /** Limit on the amount of exported notices */
   private static final int MAX_EXPORTS_PER_NOTICE_TYPE_AND_SEVERITY = 1_000;
@@ -58,6 +64,16 @@ public class NoticeContainer {
   private final List<ResolvedNotice<ValidationNotice>> validationNotices = new ArrayList<>();
   private final List<ResolvedNotice<SystemError>> systemErrors = new ArrayList<>();
   private final Map<String, Integer> noticesCountPerTypeAndSeverity = new HashMap<>();
+
+  /**
+   * Amount of notices per type and severity actually kept in {@code validationNotices}.
+   *
+   * <p>This is deliberately separate from {@code noticesCountPerTypeAndSeverity}: the latter counts
+   * every notice ever added, including the ones dropped once a limit is reached, and is what the
+   * validation report exports as {@code totalNotices}.
+   */
+  private final Map<String, Integer> retainedNoticesCountPerTypeAndSeverity = new HashMap<>();
+
   private boolean hasValidationErrors = false;
   private boolean hasValidationWarnings = false;
 
@@ -106,12 +122,31 @@ public class NoticeContainer {
     }
 
     updateNoticeCount(resolved);
-    if (validationNotices.size() >= maxTotalValidationNotices
-        || noticesCountPerTypeAndSeverity.get(resolved.getMappingKey())
-            > maxValidationNoticesPerTypeAndSeverity) {
-      return;
+    if (canRetain(resolved)) {
+      validationNotices.add(resolved);
     }
-    validationNotices.add(resolved);
+  }
+
+  /**
+   * Tells whether the given notice fits in this container, and books the slot if it does.
+   *
+   * <p>This is the single place where the retention limits are enforced, so that notices added one
+   * by one and notices merged from another container are treated the same way.
+   */
+  private boolean canRetain(ResolvedNotice<?> notice) {
+    String mappingKey = notice.getMappingKey();
+    int retained = retainedNoticesCountPerTypeAndSeverity.getOrDefault(mappingKey, 0);
+    if (retained >= maxValidationNoticesPerTypeAndSeverity) {
+      return false;
+    }
+    // A notice type is described in the exported report only if at least one of its notices was
+    // retained, so the first notice of a type and severity is kept even once the total limit is
+    // reached: dropping it would hide the type, and its exact count, from the report entirely.
+    if (retained > 0 && validationNotices.size() >= maxTotalValidationNotices) {
+      return false;
+    }
+    retainedNoticesCountPerTypeAndSeverity.put(mappingKey, retained + 1);
+    return true;
   }
 
   public <T extends ValidationNotice> NoticeContainer addValidationNotices(Iterable<T> notices) {
@@ -142,22 +177,29 @@ public class NoticeContainer {
    * Adds all validation notices and system errors from another container.
    *
    * <p>This is useful for multithreaded validation: each thread has its own notice container which
-   * is merged into the global container when the thread finishes. Please note that the final {@code
-   * NoticeContainer} may contain more than the maximum amount of {@code ValidationNotice} allowed
-   * by {@code NoticeContainer#MAX_TOTAL_VALIDATION_NOTICES} and {@code
-   * NoticeContainer#MAX_VALIDATION_NOTICES_TYPE_AND_SEVERITY}.
+   * is merged into the global container when the thread finishes. It is also how row-by-row parsing
+   * notices reach the container of a table: {@code CsvFileLoader} merges one container per row.
+   *
+   * <p>The retention limits of this container are applied to the merged notices, so a feed where
+   * every row of a large file yields a notice cannot grow the container without bound. Notice
+   * counts are merged in full regardless of retention, so the {@code totalNotices} reported for
+   * each notice type stays exact.
    *
    * @param otherContainer a container to take the notices from
    */
   public void addAll(NoticeContainer otherContainer) {
-    validationNotices.addAll(otherContainer.validationNotices);
-    systemErrors.addAll(otherContainer.systemErrors);
-    hasValidationErrors |= otherContainer.hasValidationErrors;
-    hasValidationWarnings |= otherContainer.hasValidationWarnings;
     for (Entry<String, Integer> entry : otherContainer.noticesCountPerTypeAndSeverity.entrySet()) {
       int count = noticesCountPerTypeAndSeverity.getOrDefault(entry.getKey(), 0);
       noticesCountPerTypeAndSeverity.put(entry.getKey(), count + entry.getValue());
     }
+    for (ResolvedNotice<ValidationNotice> notice : otherContainer.validationNotices) {
+      if (canRetain(notice)) {
+        validationNotices.add(notice);
+      }
+    }
+    systemErrors.addAll(otherContainer.systemErrors);
+    hasValidationErrors |= otherContainer.hasValidationErrors;
+    hasValidationWarnings |= otherContainer.hasValidationWarnings;
   }
 
   /** Tells if this container has any {@code ValidationNotice} that is an error. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
@@ -45,7 +45,12 @@ public final class ResolvedNotice<T extends Notice> {
    * @return the key used to group notices per type and severity: code + ordinal of severity level.
    */
   public String getMappingKey() {
-    return context.getCode() + getSeverityLevel().ordinal();
+    return mappingKey(context.getCode(), getSeverityLevel());
+  }
+
+  /** Returns the key under which notices of the given code and severity level are grouped. */
+  static String mappingKey(String code, SeverityLevel severityLevel) {
+    return code + severityLevel.ordinal();
   }
 
   @Override

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/notice/ResolvedNotice.java
@@ -28,9 +28,16 @@ public final class ResolvedNotice<T extends Notice> {
 
   private final SeverityLevel severityLevel;
 
+  /**
+   * Computed once: the key is needed twice for every notice added to a container and again for
+   * every notice when they are grouped, and building it allocates.
+   */
+  private final String mappingKey;
+
   public ResolvedNotice(T context, SeverityLevel severityLevel) {
     this.context = context;
     this.severityLevel = severityLevel;
+    this.mappingKey = mappingKey(context.getCode(), severityLevel);
   }
 
   public T getContext() {
@@ -45,7 +52,7 @@ public final class ResolvedNotice<T extends Notice> {
    * @return the key used to group notices per type and severity: code + ordinal of severity level.
    */
   public String getMappingKey() {
-    return mappingKey(context.getCode(), getSeverityLevel());
+    return mappingKey;
   }
 
   /** Returns the key under which notices of the given code and severity level are grouped. */

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/CsvFile.java
@@ -49,6 +49,10 @@ public class CsvFile implements Iterable<CsvRow> {
     // Explicitly disable trimming of whitespaces because we will emit notices for them.
     settings.setIgnoreLeadingWhitespacesInQuotes(false);
     settings.setIgnoreTrailingWhitespacesInQuotes(false);
+    // Univocity reads on its own thread when several CPUs are available, which costs a thread and
+    // two buffers of the input buffer size per open file.
+    settings.setReadInputOnSeparateThread(false);
+    settings.setInputBufferSize(256 * 1024);
     return settings;
   }
 

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/parsing/RowParser.java
@@ -112,28 +112,41 @@ public class RowParser {
   @Nullable
   public String asString(int columnIndex, GtfsColumnDescriptor columnDescriptor) {
     String s = row.asString(columnIndex);
-    if (columnDescriptor.fieldLevel() == FieldLevelEnum.REQUIRED && s == null) {
+    if (s == null) {
+      noticeForMissingValue(columnDescriptor);
+      return null;
+    }
+    return validateValue(s, columnIndex, columnDescriptor, cellContext(columnIndex));
+  }
+
+  /** Adds a notice if the column requires or recommends a value and the cell has none. */
+  private void noticeForMissingValue(GtfsColumnDescriptor columnDescriptor) {
+    if (columnDescriptor.fieldLevel() == FieldLevelEnum.REQUIRED) {
       noticeContainer.addValidationNotice(
           new MissingRequiredFieldNotice(fileName, getRowNumber(), columnDescriptor.columnName()));
-    } else if (columnDescriptor.fieldLevel() == FieldLevelEnum.RECOMMENDED && s == null) {
+    } else if (columnDescriptor.fieldLevel() == FieldLevelEnum.RECOMMENDED) {
       noticeContainer.addValidationNotice(
           new MissingRecommendedFieldNotice(
               fileName, getRowNumber(), columnDescriptor.columnName()));
     }
-    if (s != null) {
-      // Validate if the string contains invalid characters
-      if (containsInvalidCharacters(s)) {
-        noticeContainer.addValidationNotice(
-            new InvalidCharacterNotice(fileName, getRowNumber(), columnDescriptor.columnName(), s));
-      }
+  }
 
-      s =
-          fieldValidator.validateField(
-              s,
-              GtfsCellContext.create(fileName, getRowNumber(), header.getColumnName(columnIndex)),
-              noticeContainer);
+  /** Applies the validation that every field value goes through, and returns the value to store. */
+  private String validateValue(
+      String s,
+      int columnIndex,
+      GtfsColumnDescriptor columnDescriptor,
+      GtfsCellContext cellContext) {
+    // Validate if the string contains invalid characters
+    if (containsInvalidCharacters(s)) {
+      noticeContainer.addValidationNotice(
+          new InvalidCharacterNotice(fileName, getRowNumber(), columnDescriptor.columnName(), s));
     }
-    return s;
+    return fieldValidator.validateField(s, cellContext, noticeContainer);
+  }
+
+  private GtfsCellContext cellContext(int columnIndex) {
+    return GtfsCellContext.create(fileName, getRowNumber(), header.getColumnName(columnIndex));
   }
 
   private boolean containsInvalidCharacters(String string) {
@@ -147,17 +160,17 @@ public class RowParser {
 
   @Nullable
   public String asId(int columnIndex, GtfsColumnDescriptor columnDescriptor) {
-    return asValidatedString(columnIndex, columnDescriptor, fieldValidator::validateId);
+    return asValidatedString(columnIndex, columnDescriptor, FieldValidation.ID);
   }
 
   @Nullable
   public String asUrl(int columnIndex, GtfsColumnDescriptor columnDescriptor) {
-    return asValidatedString(columnIndex, columnDescriptor, fieldValidator::validateUrl);
+    return asValidatedString(columnIndex, columnDescriptor, FieldValidation.URL);
   }
 
   @Nullable
   public String asEmail(int columnIndex, GtfsColumnDescriptor columnDescriptor) {
-    return asValidatedString(columnIndex, columnDescriptor, fieldValidator::validateEmail);
+    return asValidatedString(columnIndex, columnDescriptor, FieldValidation.EMAIL);
   }
 
   /**
@@ -173,7 +186,7 @@ public class RowParser {
    */
   @Nullable
   public String asPhoneNumber(int columnIndex, GtfsColumnDescriptor columnDescriptor) {
-    return asValidatedString(columnIndex, columnDescriptor, fieldValidator::validatePhoneNumber);
+    return asValidatedString(columnIndex, columnDescriptor, FieldValidation.PHONE_NUMBER);
   }
 
   @Nullable
@@ -426,22 +439,22 @@ public class RowParser {
    *
    * @param columnIndex index of the column to parse
    * @param columnDescriptor GTFS column descriptor
-   * @param validatingFunction the predicate to validate a given string
+   * @param validation the type-specific validation to apply to the value
    * @return the cell value at the given column or null if the value is missing
    */
   @Nullable
   private String asValidatedString(
-      int columnIndex,
-      GtfsColumnDescriptor columnDescriptor,
-      FieldValidatingFunction validatingFunction) {
-    String s = asString(columnIndex, columnDescriptor);
+      int columnIndex, GtfsColumnDescriptor columnDescriptor, FieldValidation validation) {
+    String s = row.asString(columnIndex);
     if (s == null) {
+      noticeForMissingValue(columnDescriptor);
       return null;
     }
-    validatingFunction.apply(
-        s,
-        GtfsCellContext.create(fileName, getRowNumber(), header.getColumnName(columnIndex)),
-        noticeContainer);
+    // Both validations describe the same cell, so the context is built once instead of once each.
+    // This runs for every non-empty id, URL, e-mail address and phone number of the feed.
+    GtfsCellContext cellContext = cellContext(columnIndex);
+    s = validateValue(s, columnIndex, columnDescriptor, cellContext);
+    validation.validate(fieldValidator, s, cellContext, noticeContainer);
     return s;
   }
 
@@ -456,10 +469,60 @@ public class RowParser {
     T apply(String filename, int csvRowNumber, String fieldName, String fieldValue);
   }
 
-  /** Validates the given field and adds appropriate notices to the container. */
-  @FunctionalInterface
-  private interface FieldValidatingFunction {
+  /**
+   * The type-specific validation applied to a field on top of the validation every field goes
+   * through.
+   *
+   * <p>This is an enum rather than a function passed by the caller because it is selected for a
+   * large share of the cells of a feed: a method reference on the field validator would allocate a
+   * capturing lambda on every call.
+   */
+  private enum FieldValidation {
+    ID {
+      @Override
+      void validate(
+          GtfsFieldValidator fieldValidator,
+          String fieldValue,
+          GtfsCellContext cellContext,
+          NoticeContainer noticeContainer) {
+        fieldValidator.validateId(fieldValue, cellContext, noticeContainer);
+      }
+    },
+    URL {
+      @Override
+      void validate(
+          GtfsFieldValidator fieldValidator,
+          String fieldValue,
+          GtfsCellContext cellContext,
+          NoticeContainer noticeContainer) {
+        fieldValidator.validateUrl(fieldValue, cellContext, noticeContainer);
+      }
+    },
+    EMAIL {
+      @Override
+      void validate(
+          GtfsFieldValidator fieldValidator,
+          String fieldValue,
+          GtfsCellContext cellContext,
+          NoticeContainer noticeContainer) {
+        fieldValidator.validateEmail(fieldValue, cellContext, noticeContainer);
+      }
+    },
+    PHONE_NUMBER {
+      @Override
+      void validate(
+          GtfsFieldValidator fieldValidator,
+          String fieldValue,
+          GtfsCellContext cellContext,
+          NoticeContainer noticeContainer) {
+        fieldValidator.validatePhoneNumber(fieldValue, cellContext, noticeContainer);
+      }
+    };
 
-    void apply(String fieldValue, GtfsCellContext cellContext, NoticeContainer noticeContainer);
+    abstract void validate(
+        GtfsFieldValidator fieldValidator,
+        String fieldValue,
+        GtfsCellContext cellContext,
+        NoticeContainer noticeContainer);
   }
 }

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/table/CsvFileLoader.java
@@ -95,12 +95,15 @@ public final class CsvFileLoader extends TableLoader {
     final List<SingleEntityValidator<GtfsEntity>> singleEntityValidators =
         createSingleEntityValidators(tableDescriptor.getEntityClass(), header, validatorProvider);
 
+    // One container reused for every row instead of one per row: on a file with millions of rows
+    // that is a few million containers, each with its own lists and map, of pure garbage.
+    final NoticeContainer rowNotices = new NoticeContainer();
     try {
       for (CsvRow row : csvFile) {
         if (row.getRowNumber() % 200000 == 0) {
           logger.atInfo().log("Reading %s, row %d", gtfsFilename, row.getRowNumber());
         }
-        NoticeContainer rowNotices = new NoticeContainer();
+        rowNotices.reset();
         rowParser.setRow(row, rowNotices);
         if (!rowParser.checkRowNumber()) {
           hasUnparsableRows = true;

--- a/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtil.java
+++ b/core/src/main/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtil.java
@@ -37,8 +37,16 @@ public final class ValidatorUtil {
    */
   public static <T extends GtfsEntity> void invokeSingleEntityValidators(
       T entity, List<SingleEntityValidator<T>> validators, NoticeContainer noticeContainer) {
-    for (SingleEntityValidator<T> validator : validators) {
-      safeValidate(c -> validator.validate(entity, c), validator.getClass(), noticeContainer);
+    // This runs once per entity per validator, millions of times on a large feed, so the validators
+    // are invoked directly rather than through safeValidate: a lambda capturing the entity would be
+    // allocated on every call.
+    for (int i = 0, size = validators.size(); i < size; ++i) {
+      SingleEntityValidator<T> validator = validators.get(i);
+      try {
+        validator.validate(entity, noticeContainer);
+      } catch (RuntimeException exception) {
+        logRuntimeException(exception, validator.getClass(), noticeContainer);
+      }
     }
   }
 
@@ -73,11 +81,17 @@ public final class ValidatorUtil {
     try {
       validate.accept(noticeContainer);
     } catch (RuntimeException e) {
-      logger.atSevere().withCause(e).log(
-          "Runtime exception in validator %s", validatorClass.getCanonicalName());
-      noticeContainer.addSystemError(
-          new RuntimeExceptionInValidatorError(validatorClass.getCanonicalName(), e));
+      logRuntimeException(e, validatorClass, noticeContainer);
     }
+  }
+
+  /** Logs an exception raised by a validator and stores it as a system error. */
+  private static void logRuntimeException(
+      RuntimeException exception, Class<?> validatorClass, NoticeContainer noticeContainer) {
+    logger.atSevere().withCause(exception).log(
+        "Runtime exception in validator %s", validatorClass.getCanonicalName());
+    noticeContainer.addSystemError(
+        new RuntimeExceptionInValidatorError(validatorClass.getCanonicalName(), exception));
   }
 
   private ValidatorUtil() {}

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -250,6 +250,44 @@ public class NoticeContainerTest {
     assertThat(container.hasValidationWarnings()).isTrue();
   }
 
+  @Test
+  public void reset_emptiesTheContainerButNotTheOneItWasMergedInto() {
+    NoticeContainer container = new NoticeContainer();
+    NoticeContainer rowNotices = new NoticeContainer();
+    ValidationNotice notice = new MissingRequiredFileNotice("stops.txt");
+    rowNotices.addValidationNotice(notice);
+    rowNotices.addSystemError(
+        new RuntimeExceptionInValidatorError("Validator1", new IllegalStateException("boom")));
+    container.addAll(rowNotices);
+
+    rowNotices.reset();
+
+    assertThat(rowNotices.getValidationNotices()).isEmpty();
+    assertThat(rowNotices.getSystemErrors()).isEmpty();
+    assertThat(rowNotices.hasValidationErrors()).isFalse();
+    assertThat(rowNotices.hasValidationWarnings()).isFalse();
+    assertThat(rowNotices.getNoticeCount("missing_required_file", SeverityLevel.ERROR))
+        .isEqualTo(0);
+    // The notices merged earlier survive in the destination container.
+    assertThat(container.getValidationNotices()).containsExactly(notice);
+    assertThat(container.getNoticeCount("missing_required_file", SeverityLevel.ERROR)).isEqualTo(1);
+  }
+
+  /** After a reset the container must be as good as new, limits included. */
+  @Test
+  public void reset_restoresTheRetentionCapacity() {
+    NoticeContainer container = new NoticeContainer(10, 1, 10);
+    container.addValidationNotice(new StringFieldNotice("first"));
+    container.addValidationNotice(new StringFieldNotice("dropped"));
+    assertThat(container.getValidationNotices()).hasSize(1);
+
+    container.reset();
+    ValidationNotice afterReset = new StringFieldNotice("after reset");
+    container.addValidationNotice(afterReset);
+
+    assertThat(container.getValidationNotices()).containsExactly(afterReset);
+  }
+
   /**
    * A notice type is described in the exported report only if one of its notices was retained, so
    * reaching the total limit must not make a whole type disappear from the report.

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -182,6 +182,19 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void getNoticeCount_countsDroppedNoticesToo() {
+    NoticeContainer container = new NoticeContainer(1_000, 2, 2);
+    for (int i = 0; i < 10; i++) {
+      container.addValidationNotice(new StringFieldNotice("value"));
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(2);
+    assertThat(container.getNoticeCount("string_field", SeverityLevel.ERROR)).isEqualTo(10);
+    assertThat(container.getNoticeCount("string_field", SeverityLevel.WARNING)).isEqualTo(0);
+    assertThat(container.getNoticeCount("unknown_file", SeverityLevel.INFO)).isEqualTo(0);
+  }
+
+  @Test
   public void exportNotices_shouldReflectTheTotalNumberOfNoticesAndContexts() {
     NoticeContainer container = new NoticeContainer(26, 8, 3);
     for (int i = 0; i < 55; i++) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeContainerTest.java
@@ -195,6 +195,87 @@ public class NoticeContainerTest {
   }
 
   @Test
+  public void addAll_shouldRespectMaxPerNoticeTypeAndSeverity() {
+    NoticeContainer container = new NoticeContainer(1_000, 5, 5);
+    for (int i = 0; i < 20; i++) {
+      // Reproduces how CsvFileLoader merges one container per parsed row.
+      NoticeContainer rowNotices = new NoticeContainer();
+      rowNotices.addValidationNotice(new DoubleFieldNotice(i));
+      container.addAll(rowNotices);
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(5);
+  }
+
+  @Test
+  public void addAll_shouldRespectMaxTotalValidationNotices() {
+    NoticeContainer container = new NoticeContainer(7, 1_000, 1_000);
+    for (int i = 0; i < 20; i++) {
+      NoticeContainer otherContainer = new NoticeContainer();
+      otherContainer.addValidationNotice(new DoubleFieldNotice(i));
+      otherContainer.addValidationNotice(new StringFieldNotice(Integer.toString(i)));
+      container.addAll(otherContainer);
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(7);
+  }
+
+  @Test
+  public void exportNoticesAfterAddAll_shouldReportExactTotalCountBeyondRetentionLimit() {
+    NoticeContainer container = new NoticeContainer(1_000, 2, 2);
+    for (int i = 0; i < 100; i++) {
+      NoticeContainer rowNotices = new NoticeContainer();
+      rowNotices.addValidationNotice(new StringFieldNotice("value"));
+      container.addAll(rowNotices);
+    }
+
+    assertThat(container.getValidationNotices()).hasSize(2);
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
+        .isEqualTo(
+            "{\"notices\":[{\"code\":\"string_field\",\"severity\":\"ERROR\","
+                + "\"totalNotices\":100,\"sampleNotices\":[{\"someField\":\"value\"},{"
+                + "\"someField\":\"value\"}]}]}");
+  }
+
+  @Test
+  public void addAll_shouldKeepValidationErrorAndWarningFlagsWhenNoticesAreDropped() {
+    NoticeContainer container = new NoticeContainer(0, 0, 0);
+    NoticeContainer otherContainer = new NoticeContainer();
+    otherContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+    otherContainer.addValidationNotice(new MissingRecommendedFileNotice("feed_info.txt"));
+    container.addAll(otherContainer);
+
+    assertThat(container.getValidationNotices()).isEmpty();
+    assertThat(container.hasValidationErrors()).isTrue();
+    assertThat(container.hasValidationWarnings()).isTrue();
+  }
+
+  /**
+   * A notice type is described in the exported report only if one of its notices was retained, so
+   * reaching the total limit must not make a whole type disappear from the report.
+   */
+  @Test
+  public void addAll_totalLimitReached_stillRetainsTheFirstNoticeOfEachType() {
+    NoticeContainer container = new NoticeContainer(4, 2, 10);
+    NoticeContainer otherContainer = new NoticeContainer();
+    for (int i = 0; i < 3; i++) {
+      otherContainer.addValidationNotice(new MissingRequiredFileNotice("stops.txt"));
+      otherContainer.addValidationNotice(new UnknownFileNotice("unknown.txt"));
+    }
+    otherContainer.addValidationNotice(new DoubleFieldNotice(2.0));
+    container.addAll(otherContainer);
+
+    assertThat(new Gson().toJson(container.exportValidationNotices()))
+        .isEqualTo(
+            "{\"notices\":[{\"code\":\"double_field\",\"severity\":\"ERROR\",\"totalNotices\":1,"
+                + "\"sampleNotices\":[{\"doubleField\":2.0}]},{\"code\":\"missing_required_file\","
+                + "\"severity\":\"ERROR\",\"totalNotices\":3,\"sampleNotices\":[{\"filename\":"
+                + "\"stops.txt\"},{\"filename\":\"stops.txt\"}]},{\"code\":\"unknown_file\","
+                + "\"severity\":\"INFO\",\"totalNotices\":3,\"sampleNotices\":[{\"filename\":"
+                + "\"unknown.txt\"},{\"filename\":\"unknown.txt\"}]}]}");
+  }
+
+  @Test
   public void exportNotices_shouldReflectTheTotalNumberOfNoticesAndContexts() {
     NoticeContainer container = new NoticeContainer(26, 8, 3);
     for (int i = 0; i < 55; i++) {

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/notice/NoticeTest.java
@@ -40,6 +40,21 @@ public class NoticeTest {
   }
 
   @Test
+  public void getCode_isCachedPerNoticeClass() {
+    assertThat(Notice.getCode(StringFieldNotice.class))
+        .isSameInstanceAs(Notice.getCode(StringFieldNotice.class));
+    assertThat(Notice.getCode(OtherStringFieldNotice.class)).isEqualTo("other_string_field");
+  }
+
+  @Test
+  public void getMappingKey_isCodeAndSeverityOrdinal() {
+    assertThat(
+            new ResolvedNotice<>(new StringFieldNotice("value1"), SeverityLevel.WARNING)
+                .getMappingKey())
+        .isEqualTo("string_field" + SeverityLevel.WARNING.ordinal());
+  }
+
+  @Test
   public void toJsonTree() {
     JsonObject expected = new JsonObject();
     expected.addProperty("someField", "someValue");

--- a/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtilTest.java
+++ b/core/src/test/java/org/mobilitydata/gtfsvalidator/validator/ValidatorUtilTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.validator;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.notice.RuntimeExceptionInValidatorError;
+import org.mobilitydata.gtfsvalidator.notice.SystemError;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntity;
+
+@RunWith(JUnit4.class)
+public class ValidatorUtilTest {
+
+  @Test
+  public void invokeSingleEntityValidators_invokesEveryValidatorWithTheEntity() {
+    List<String> invocations = new ArrayList<>();
+    GtfsEntity entity = () -> 7;
+    NoticeContainer noticeContainer = new NoticeContainer();
+
+    ValidatorUtil.invokeSingleEntityValidators(
+        entity,
+        ImmutableList.of(
+            recordingValidator("first", invocations), recordingValidator("second", invocations)),
+        noticeContainer);
+
+    assertThat(invocations).containsExactly("first:7", "second:7").inOrder();
+    assertThat(noticeContainer.getSystemErrors()).isEmpty();
+  }
+
+  /** A validator that throws must not stop the others, and must be reported as a system error. */
+  @Test
+  public void invokeSingleEntityValidators_validatorThrows_reportsSystemErrorAndContinues() {
+    List<String> invocations = new ArrayList<>();
+    GtfsEntity entity = () -> 7;
+    NoticeContainer noticeContainer = new NoticeContainer();
+
+    ValidatorUtil.invokeSingleEntityValidators(
+        entity,
+        ImmutableList.of(throwingValidator(), recordingValidator("after", invocations)),
+        noticeContainer);
+
+    assertThat(invocations).containsExactly("after:7");
+    assertThat(noticeContainer.getSystemErrors()).hasSize(1);
+    SystemError error = noticeContainer.getSystemErrors().get(0);
+    assertThat(error).isInstanceOf(RuntimeExceptionInValidatorError.class);
+    assertThat(error.toJsonTree().getAsJsonObject().get("message").getAsString())
+        .isEqualTo("broken validator");
+  }
+
+  private static SingleEntityValidator<GtfsEntity> recordingValidator(
+      String name, List<String> invocations) {
+    return new SingleEntityValidator<>() {
+      @Override
+      public void validate(GtfsEntity entity, NoticeContainer noticeContainer) {
+        invocations.add(name + ":" + entity.csvRowNumber());
+      }
+    };
+  }
+
+  private static SingleEntityValidator<GtfsEntity> throwingValidator() {
+    return new SingleEntityValidator<>() {
+      @Override
+      public void validate(GtfsEntity entity, NoticeContainer noticeContainer) {
+        throw new IllegalStateException("broken validator");
+      }
+    };
+  }
+}

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGenerator.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGenerator.java
@@ -73,6 +73,12 @@ public class HtmlReportGenerator {
     }
   }
 
+  /**
+   * Returns, per notice code, the fields that are set on at least one of its notices.
+   *
+   * <p>The lists in {@code noticesByCode} hold the notices the report actually lists, so the
+   * columns are derived from exactly the rows that are rendered.
+   */
   private Map<String, List<String>> getUniqueFieldsForCodes(
       Map<String, List<NoticeView>> noticesByCode) {
     return noticesByCode.entrySet().stream()

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
@@ -16,6 +16,7 @@
 
 package org.mobilitydata.gtfsvalidator.reportsummary.model;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.*;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
@@ -25,6 +26,17 @@ import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 /** ReportSummary is the class containing the summary methods for the HTML report. */
 public class ReportSummary {
+
+  /**
+   * Maximum number of notices per code for which a {@link NoticeView} is created.
+   *
+   * <p>A {@code NoticeView} holds the complete JSON tree of its notice, so building one per notice
+   * costs a few hundred bytes per notice, allocated at the very end of validation when the heap is
+   * already at its peak. The report only lists this many affected records per notice code, so the
+   * remaining views were built and discarded without ever being read.
+   */
+  @VisibleForTesting static final int MAX_NOTICES_PER_CODE = 50;
+
   private final Map<SeverityLevel, Long> severityCounts;
   private final Map<SeverityLevel, Map<String, List<NoticeView>>> noticesMap;
   private final Map<SeverityLevel, Map<String, Integer>> noticeCountPerSeverityAndCode;
@@ -39,15 +51,18 @@ public class ReportSummary {
     this.noticeCountPerSeverityAndCode = new EnumMap<>(SeverityLevel.class);
 
     for (ResolvedNotice<ValidationNotice> notice : container.getResolvedValidationNotices()) {
-      noticesMap
-          .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
-          .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>())
-          .add(new NoticeView(notice));
+      List<NoticeView> notices =
+          noticesMap
+              .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
+              .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>());
+      if (notices.size() < MAX_NOTICES_PER_CODE) {
+        notices.add(new NoticeView(notice));
+      }
     }
 
     // The counts come from the container rather than from the notices above, which are only the
-    // ones the container retained. The report must show how many notices the feed actually
-    // produced, the same number the JSON report exports as totalNotices.
+    // ones the container retained and this summary materialized. The report must show how many
+    // notices the feed actually produced, the same number the JSON report exports.
     int total = 0;
     for (Map.Entry<SeverityLevel, Map<String, List<NoticeView>>> bySeverity :
         noticesMap.entrySet()) {
@@ -68,9 +83,11 @@ public class ReportSummary {
 
   /**
    * Returns the notices grouped by SeverityLevel and notice code. The notices are returned as a map
-   * of maps. The SeverityLevel map is implemented with a LinkedHashMap to preserve the original
-   * order of severity levels. The notice code map is implemented with a TreeMap to sort the notices
-   * alphabetically.
+   * of maps. The SeverityLevel map is sorted from the most to the least severe level. The notice
+   * code map is implemented with a TreeMap to sort the notices alphabetically.
+   *
+   * <p>Each list holds at most {@link #MAX_NOTICES_PER_CODE} notices, which is what the report
+   * lists. Use {@link #getNoticeCountForCode} for the total number of notices of a code.
    *
    * @return the notices as a map of maps.
    */
@@ -88,6 +105,15 @@ public class ReportSummary {
     return noticeCountPerSeverityAndCode
         .getOrDefault(severityLevel, Map.of())
         .getOrDefault(code, 0);
+  }
+
+  /**
+   * Returns the maximum number of notices per code listed in the report.
+   *
+   * @return the maximum number of notices listed per code.
+   */
+  public int getMaxNoticesPerCode() {
+    return MAX_NOTICES_PER_CODE;
   }
 
   /**

--- a/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
+++ b/main/src/main/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummary.java
@@ -17,34 +17,53 @@
 package org.mobilitydata.gtfsvalidator.reportsummary.model;
 
 import java.util.*;
-import java.util.stream.Collectors;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.notice.ResolvedNotice;
 import org.mobilitydata.gtfsvalidator.notice.SeverityLevel;
+import org.mobilitydata.gtfsvalidator.notice.ValidationNotice;
 import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 /** ReportSummary is the class containing the summary methods for the HTML report. */
 public class ReportSummary {
-  private final NoticeContainer container;
   private final Map<SeverityLevel, Long> severityCounts;
   private final Map<SeverityLevel, Map<String, List<NoticeView>>> noticesMap;
+  private final Map<SeverityLevel, Map<String, Integer>> noticeCountPerSeverityAndCode;
+  private final int noticeCount;
   private final VersionInfo versionInfo;
 
   public ReportSummary(NoticeContainer container, VersionInfo versionInfo) {
-    this.container = container;
-    this.severityCounts =
-        container.getResolvedValidationNotices().stream()
-            .collect(
-                Collectors.groupingBy(ResolvedNotice::getSeverityLevel, Collectors.counting()));
-    this.noticesMap =
-        container.getResolvedValidationNotices().stream()
-            .map(NoticeView::new)
-            .collect(
-                Collectors.groupingBy(
-                    NoticeView::getSeverityLevel,
-                    () -> new TreeMap<>(Comparator.reverseOrder()),
-                    Collectors.groupingBy(NoticeView::getCode, TreeMap::new, Collectors.toList())));
     this.versionInfo = versionInfo;
+    this.severityCounts = new EnumMap<>(SeverityLevel.class);
+    // Severity levels are listed from the most to the least severe, notice codes alphabetically.
+    this.noticesMap = new TreeMap<>(Comparator.reverseOrder());
+    this.noticeCountPerSeverityAndCode = new EnumMap<>(SeverityLevel.class);
+
+    for (ResolvedNotice<ValidationNotice> notice : container.getResolvedValidationNotices()) {
+      noticesMap
+          .computeIfAbsent(notice.getSeverityLevel(), level -> new TreeMap<>())
+          .computeIfAbsent(notice.getContext().getCode(), code -> new ArrayList<>())
+          .add(new NoticeView(notice));
+    }
+
+    // The counts come from the container rather than from the notices above, which are only the
+    // ones the container retained. The report must show how many notices the feed actually
+    // produced, the same number the JSON report exports as totalNotices.
+    int total = 0;
+    for (Map.Entry<SeverityLevel, Map<String, List<NoticeView>>> bySeverity :
+        noticesMap.entrySet()) {
+      SeverityLevel severityLevel = bySeverity.getKey();
+      Map<String, Integer> countPerCode = new TreeMap<>();
+      long severityCount = 0;
+      for (String code : bySeverity.getValue().keySet()) {
+        int count = container.getNoticeCount(code, severityLevel);
+        countPerCode.put(code, count);
+        severityCount += count;
+      }
+      noticeCountPerSeverityAndCode.put(severityLevel, countPerCode);
+      severityCounts.put(severityLevel, severityCount);
+      total += severityCount;
+    }
+    this.noticeCount = total;
   }
 
   /**
@@ -60,12 +79,24 @@ public class ReportSummary {
   }
 
   /**
+   * Returns the total count of notices of the given severity level and code, including the ones the
+   * container did not retain and which are therefore absent from {@link #getNoticesMap()}.
+   *
+   * @return the total count of notices for that severity level and code.
+   */
+  public int getNoticeCountForCode(SeverityLevel severityLevel, String code) {
+    return noticeCountPerSeverityAndCode
+        .getOrDefault(severityLevel, Map.of())
+        .getOrDefault(code, 0);
+  }
+
+  /**
    * Returns the total count of notices in the validation report.
    *
    * @return the total count of notices.
    */
   public int getNoticeCount() {
-    return container.getValidationNotices().size();
+    return noticeCount;
   }
 
   /**

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -351,7 +351,7 @@
                             <p> You can see more about this notice <a
                                     th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key} + '-rule'}">here</a>.
                             </p>
-                             <p th:if="${totalForCode > 50}">Only the first 50 of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
+                             <p th:if="${totalForCode > summary.maxNoticesPerCode}">Only the first <span th:text="${summary.maxNoticesPerCode}"></span> of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
                             <table>
                                 <thead>
                                     <tr>
@@ -366,7 +366,7 @@
                                     </tr>
                                 </thead>
                                 <tbody>
-                                    <tr th:each="notice, iterStat : ${noticesByCode.value}" th:if="${iterStat.index < 50}">
+                                    <tr th:each="notice : ${noticesByCode.value}">
                                         <th:block th:each="field: ${uniqueFieldsByCode[noticesByCode.key]}">
                                             <td th:text="${notice.getFields().contains(field) ? notice.getValueForField(field) : 'N/A'}" />
                                         </th:block>

--- a/main/src/main/resources/report.html
+++ b/main/src/main/resources/report.html
@@ -335,12 +335,13 @@
         </thead>
         <tbody>
         <span th:each="noticesBySeverityLevel: ${summary.noticesMap}">
-            <span th:each="noticesByCode: ${noticesBySeverityLevel.value}">
+            <span th:each="noticesByCode: ${noticesBySeverityLevel.value}"
+                  th:with="totalForCode=${summary.getNoticeCountForCode(noticesBySeverityLevel.key, noticesByCode.key)}">
                 <tr class="notice">
                     <td th:text="${noticesByCode.key}" />
                     <td th:class="${noticesBySeverityLevel.key.toString().toLowerCase()}"
                         th:text="${noticesBySeverityLevel.key}" />
-                    <td th:text="${noticesByCode.value.size}" />
+                    <td th:text="${totalForCode}" />
                 </tr>
                 <tr class="description">
                     <td colspan="4">
@@ -350,7 +351,7 @@
                             <p> You can see more about this notice <a
                                     th:href="@{'https://gtfs-validator.mobilitydata.org/rules.html#' + ${noticesByCode.key} + '-rule'}">here</a>.
                             </p>
-                             <p th:if="${noticesByCode.value.size > 50}">Only the first 50 of <span th:text="${noticesByCode.value.size}"></span> affected records are displayed below.</p>
+                             <p th:if="${totalForCode > 50}">Only the first 50 of <span th:text="${totalForCode}"></span> affected records are displayed below.</p>
                             <table>
                                 <thead>
                                     <tr>

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2026 MobilityData
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.mobilitydata.gtfsvalidator.reportsummary;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mobilitydata.gtfsvalidator.input.CountryCode;
+import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
+import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
+import org.mobilitydata.gtfsvalidator.table.GtfsEntityContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
+import org.mobilitydata.gtfsvalidator.table.GtfsStopTimeTableContainer;
+import org.mobilitydata.gtfsvalidator.util.VersionInfo;
+
+@RunWith(JUnit4.class)
+public class HtmlReportGeneratorTest {
+
+  @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  /**
+   * The page must report how many notices the feed produced, not how many the container kept: the
+   * container drops notices of a type past its retention limit, and the JSON report generated from
+   * the same run reports the exact number.
+   */
+  @Test
+  public void generateReport_countsAreExactWhenTheContainerDroppedNotices() throws IOException {
+    NoticeContainer noticeContainer = new NoticeContainer(1_000, 100, 100);
+    for (int i = 1; i <= 300; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(noticeContainer.getValidationNotices()).hasSize(100);
+    assertThat(report).contains("300 notices reported ( 300 errors, 0 warnings, 0 infos)");
+    assertThat(report).contains("missing_required_field ERROR 300");
+    assertThat(report).contains("Only the first 50 of 300 affected records are displayed below.");
+  }
+
+  /** Strips the markup so that assertions read like the rendered page. */
+  private static String visibleText(String html) {
+    return html.replaceAll("<[^>]*>", " ").replaceAll("\\s+", " ");
+  }
+
+  private String generateReport(NoticeContainer noticeContainer) throws IOException {
+    GtfsFeedContainer feedContainer =
+        new GtfsFeedContainer(
+            ImmutableList.<GtfsEntityContainer<?, ?>>of(
+                GtfsStopTimeTableContainer.forEntities(ImmutableList.of(), new NoticeContainer())));
+    Path reportPath = temporaryFolder.newFile("report.html").toPath();
+    ValidationRunnerConfig config =
+        ValidationRunnerConfig.builder()
+            .setGtfsSource(Path.of("feed.zip").toUri())
+            .setOutputDirectory(reportPath.getParent())
+            .setCountryCode(CountryCode.forStringOrUnknown(""))
+            .build();
+
+    new HtmlReportGenerator()
+        .generateReport(
+            FeedMetadata.from(feedContainer, ImmutableSet.of("stop_times.txt")),
+            noticeContainer,
+            config,
+            VersionInfo.empty(),
+            reportPath,
+            "2026-01-01T00:00:00+00:00",
+            false);
+
+    return Files.readString(reportPath);
+  }
+}

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/HtmlReportGeneratorTest.java
@@ -32,6 +32,7 @@ import org.mobilitydata.gtfsvalidator.input.CountryCode;
 import org.mobilitydata.gtfsvalidator.notice.MissingRequiredFieldNotice;
 import org.mobilitydata.gtfsvalidator.notice.NoticeContainer;
 import org.mobilitydata.gtfsvalidator.reportsummary.model.FeedMetadata;
+import org.mobilitydata.gtfsvalidator.reportsummary.model.ReportSummary;
 import org.mobilitydata.gtfsvalidator.runner.ValidationRunnerConfig;
 import org.mobilitydata.gtfsvalidator.table.GtfsEntityContainer;
 import org.mobilitydata.gtfsvalidator.table.GtfsFeedContainer;
@@ -40,6 +41,10 @@ import org.mobilitydata.gtfsvalidator.util.VersionInfo;
 
 @RunWith(JUnit4.class)
 public class HtmlReportGeneratorTest {
+
+  /** Number of notices per code the report lists, mirrors {@code ReportSummary}. */
+  private static final int MAX_NOTICES_PER_CODE =
+      new ReportSummary(new NoticeContainer(), VersionInfo.empty()).getMaxNoticesPerCode();
 
   @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
@@ -62,6 +67,50 @@ public class HtmlReportGeneratorTest {
     assertThat(report).contains("300 notices reported ( 300 errors, 0 warnings, 0 infos)");
     assertThat(report).contains("missing_required_field ERROR 300");
     assertThat(report).contains("Only the first 50 of 300 affected records are displayed below.");
+  }
+
+  /**
+   * A notice code with more occurrences than the report lists must still report its exact total,
+   * while only the listed occurrences appear in the table.
+   */
+  @Test
+  public void generateReport_listsAtMostMaxNoticesPerCodeButReportsExactTotal() throws IOException {
+    int noticeCount = 120;
+    NoticeContainer noticeContainer = new NoticeContainer();
+    for (int i = 1; i <= noticeCount; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(report).contains("missing_required_field ERROR 120");
+    assertThat(report)
+        .contains(
+            "Only the first "
+                + MAX_NOTICES_PER_CODE
+                + " of 120 affected records are displayed below.");
+    assertThat(report).contains("field_001");
+    assertThat(report).contains(String.format("field_%03d", MAX_NOTICES_PER_CODE));
+    assertThat(report).doesNotContain(String.format("field_%03d", MAX_NOTICES_PER_CODE + 1));
+    assertThat(report).doesNotContain("field_120");
+  }
+
+  @Test
+  public void generateReport_fewerNoticesThanTheLimit_listsThemAll() throws IOException {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    for (int i = 1; i <= 3; i++) {
+      noticeContainer.addValidationNotice(
+          new MissingRequiredFieldNotice("test.txt", i, String.format("field_%03d", i)));
+    }
+
+    String report = visibleText(generateReport(noticeContainer));
+
+    assertThat(report).doesNotContain("affected records are displayed below");
+    assertThat(report).contains("missing_required_field ERROR 3");
+    assertThat(report).contains("field_001");
+    assertThat(report).contains("field_002");
+    assertThat(report).contains("field_003");
   }
 
   /** Strips the markup so that assertions read like the rendered page. */

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
@@ -139,6 +139,30 @@ public class ReportSummaryTest {
   }
 
   @Test
+  public void noticesMapTest_isTruncatedButCountsAreNot() {
+    NoticeContainer noticeContainer = new NoticeContainer();
+    int noticeCount = 3 * ReportSummary.MAX_NOTICES_PER_CODE;
+    for (int i = 1; i <= noticeCount; i++) {
+      noticeContainer.addValidationNotice(new MissingRequiredFieldNotice("test.txt", i, "field"));
+    }
+    ReportSummary reportSummary = new ReportSummary(noticeContainer, VersionInfo.empty());
+
+    assertEquals(
+        ReportSummary.MAX_NOTICES_PER_CODE,
+        reportSummary
+            .getNoticesMap()
+            .get(SeverityLevel.ERROR)
+            .get(MISSING_REQUIRED_FIELD_NOTICE_CODE)
+            .size());
+    assertEquals(
+        noticeCount,
+        reportSummary.getNoticeCountForCode(
+            SeverityLevel.ERROR, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+    assertEquals(noticeCount, reportSummary.getNoticeCount());
+    assertEquals(noticeCount, reportSummary.getErrorCount());
+  }
+
+  @Test
   public void testVersionPresent() {
     VersionInfo versionInfo = VersionInfo.create(Optional.of("1.2.3"), Optional.of("1.2.4"));
     ReportSummary reportSummary = new ReportSummary(new NoticeContainer(), versionInfo);

--- a/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
+++ b/main/src/test/java/org/mobilitydata/gtfsvalidator/reportsummary/model/ReportSummaryTest.java
@@ -100,6 +100,44 @@ public class ReportSummaryTest {
         1);
   }
 
+  /**
+   * The counts must describe the feed, not what the container kept: a container that dropped
+   * notices past its retention limit still knows how many it was given, and the JSON report exports
+   * that number.
+   */
+  @Test
+  public void countsTest_areExactWhenTheContainerDroppedNotices() {
+    NoticeContainer noticeContainer = new NoticeContainer(1_000, 10, 10);
+    for (int i = 1; i <= 300; i++) {
+      noticeContainer.addValidationNotice(new MissingRequiredFieldNotice("test.txt", i, "field"));
+    }
+    for (int i = 1; i <= 40; i++) {
+      noticeContainer.addValidationNotice(new UnknownColumnNotice("test.txt", "unknown", i));
+    }
+    ReportSummary reportSummary = new ReportSummary(noticeContainer, VersionInfo.empty());
+
+    assertEquals(20, noticeContainer.getValidationNotices().size());
+    assertEquals(340, reportSummary.getNoticeCount());
+    assertEquals(300, reportSummary.getErrorCount());
+    assertEquals(40, reportSummary.getInfoCount());
+    assertEquals(0, reportSummary.getWarningCount());
+    assertEquals(
+        300,
+        reportSummary.getNoticeCountForCode(
+            SeverityLevel.ERROR, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+    assertEquals(
+        40, reportSummary.getNoticeCountForCode(SeverityLevel.INFO, UNKNOWN_COLUMN_NOTICE_CODE));
+  }
+
+  @Test
+  public void noticeCountForCodeTest_unknownCode() {
+    assertEquals(0, generateReportSummary().getNoticeCountForCode(SeverityLevel.ERROR, "unknown"));
+    assertEquals(
+        0,
+        generateReportSummary()
+            .getNoticeCountForCode(SeverityLevel.INFO, MISSING_REQUIRED_FIELD_NOTICE_CODE));
+  }
+
   @Test
   public void testVersionPresent() {
     VersionInfo versionInfo = VersionInfo.create(Optional.of("1.2.3"), Optional.of("1.2.4"));


### PR DESCRIPTION
**Summary:**

Last of the six PRs #2183 is split into, in [the grouping requested here](https://github.com/MobilityData/gtfs-validator/issues/2183#issuecomment-5514792383). The Phase 2 work: five changes that do not reduce what is retained, they reduce what is allocated per row and per cell while a feed is loaded. With the earlier PRs in, this is where the remaining GC time was. Nothing here changes any output.

**Stacked on PR 4** (and through it PR 1), which it needs to compile: the first three commits of this diff belong to those PRs and disappear from it as they merge. **The five commits to review here are the last five.**

**1. Invoke single-entity validators without a lambda per entity.** `invokeSingleEntityValidators` wrapped every call in a lambda capturing the entity, one object per entity per validator. `stop_times.txt` has four single-entity validators, so on a large feed that is tens of millions of short-lived objects — enough to promote live data to the old generation early. The validators are invoked directly now, with the same try/catch `safeValidate` applies; `safeValidate` keeps working for its other callers, which run once per file rather than once per row.

**2. Reuse one notice container for the row-by-row parsing loop.** `CsvFileLoader` allocated a `NoticeContainer` per parsed row — each with two lists and two maps — for the 0 to 3 notices a row typically produces. The loop now reuses one container, emptied at the start of each row by the new `NoticeContainer.reset()`. `addAll` copies the notices into the destination, so emptying the source afterwards loses nothing; `reset` also clears the retained-notice bookkeeping so the container is as good as new.

**3. Build one cell context per validated cell instead of two.** Parsing an id, a URL, an e-mail address or a phone number went through `asString`, which built a `GtfsCellContext` for the validation every field goes through and then built a second, identical one for the type-specific validation — plus a capturing lambda to select that validation. The context is now built once and passed to both, and the type-specific validation is selected by an enum constant. The context stays immutable, so nothing changes for validators that hold on to it.

**4. Compute notice codes and grouping keys once.** `Notice.getCode` derived the code from the class name on every call, building several intermediate strings, and `ResolvedNotice.getMappingKey` concatenated code and severity every time it was asked — twice per notice added to a container, once more per notice when they are grouped for export. The code is memoized per notice class in a `ConcurrentHashMap` (same reasoning as the doc-comment cache in PR 2: no `ClassValue`, nothing runtime-specific, and the same `get`-before-`computeIfAbsent` read path so a cached lookup never locks a bin), and the key is computed once in the `ResolvedNotice` constructor. The four bytes per resolved notice this adds are bounded by the retention limits from PR 4. This lookup runs once per notice created, so it is the one place where the cache implementation is on a hot path: measured in the built jar over the 53 notice classes of `core`, 2.5 ns per lookup with `ClassValue` against 3.1 ns with this one, under a millisecond over the 1.2 million notices of the reference feed.

**5. Read CSV files on the parsing thread.** Univocity reads the input on a thread of its own when several CPUs are available, which costs a thread and two buffers of the input-buffer size per open file. The validator loads one table at a time by default, so that buys little, and the buffers were larger than they need to be. Measured on a synthetic feed of 800 000 stop times: slightly faster (9.7 s against 10.0 s at `-Xmx512m`) and noticeably more consistent between runs, with the minimum heap unchanged. This is the one change of the five whose benefit is smallest — happy to drop it if you would rather not touch the parser settings.

Implementation report for the whole series: https://github.com/CarloMendola/gtfs-validator/blob/9f409204bcefff7387f05a3f70118fb03134443b/prompts/memory-optimization/MEMORY_OPTIMIZATION_REPORT.md

**Expected behavior:**

Identical output, fewer allocations. Measured on a synthetic feed of 800 000 stop times, the four allocation changes together take garbage collections during validation from 76 to 50 and their total pause from ~300 ms to ~220 ms at `-Xmx512m`. On the CTA Chicago feed (95 MB zip, 413 MB of CSV), with all six PRs in, the smallest `-Xmx` in which validation completes goes from 1616 MB to 278 MB and the GC pause total at `-Xmx8g` from 6.98 s to 1.79 s, with the `notices` object of `report.json` identical to master's. Nothing to screenshot for that reason.

Tests:

- `ValidatorUtilTest` — new file: `invokeSingleEntityValidators_invokesEveryValidatorWithTheEntity` and `invokeSingleEntityValidators_validatorThrows_reportsSystemErrorAndContinues`, so the try/catch behaviour of the direct invocation is pinned.
- `NoticeContainerTest.reset_emptiesTheContainerButNotTheOneItWasMergedInto` and `reset_restoresTheRetentionCapacity` — `reset` empties the source, leaves the destination alone and restores the retention capacity.
- `NoticeTest.getCode_isCachedPerNoticeClass` and `getMappingKey_isCodeAndSeverityOrdinal` — the cache returns the same instance and the key is unchanged.
- The existing `RowParser` tests cover the shared cell context; they pass unchanged, which is the point.

Nothing under `docs/` describes these internals, so no documentation change is needed.

Please make sure these boxes are checked before submitting your pull request - thanks!

- [x] Run the unit tests with `gradle test` to make sure you didn't break anything
- [x] Add or update any needed [documentation](https://github.com/MobilityData/gtfs-validator/tree/master/docs) to the repo 
- [x] Format the title like "feat: [new feature short description]". Title must follow the Conventional Commit Specification(https://www.conventionalcommits.org/en/v1.0.0/).
- [x] Linked all relevant issues
- [ ] Include screenshot(s) showing how this pull request works and fixes the issue(s) — no visible change: the output is identical to master's
